### PR TITLE
Fix so rTerm is undefined when deleting terminal

### DIFF
--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -46,10 +46,10 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
 
 export function deleteTerminal(term: Terminal) {
     if (isDeepStrictEqual(term, rTerm)) {
+        rTerm = undefined;
         if (config().get<boolean>('sessionWatcher')) {
             removeSessionFiles();
         }
-        rTerm = undefined;
     }
 }
 


### PR DESCRIPTION
Fixes #402 

**What problem did you solve?**

If session watcher is on but `R: Always Use Active Terminal` is off, closing an R terminal created by vscode-R does not undefine `rTerm`. This means that future commands that should create a new R terminal instead do nothing.

**How can I check this pull request?**

1. Enable setting `R: Session Watcher`
1. Disable setting `R: Always Use Active Terminal`
1. Create file `temp.R` with content `x <- 1`
1. Command `R: Run Selection/Line`
1. Observe `R Interactive` terminal is created and line is sent to terminal
1. Close `R Interactive` by clicking on the terminal trashcan icon. Terminal should now be `1: cmd` (if on Windows)
1. Command `R: Run Selection/Line`

**With PR**

Terminal `R Interactive` is created and line is sent to terminal.

**Before PR**

Nothing happens.

**Notes**

I came up with this after putting a breakpoint on the original `rTerm = undefined` line and discovering that it was never reached.