### PR TITLE
Rmarkdown preview fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -527,36 +527,31 @@
         "command": "r.goToNextChunk"
       },
       {
-        "command": "r.markdown.previewSide",
+        "command": "r.markdown.showPreviewToSide",
         "title": "Open Preview to the Side",
         "icon": "$(open-preview)",
         "category": "R"
       },
       {
-        "command": "r.markdown.preview",
+        "command": "r.markdown.showPreview",
         "title": "Open Preview",
         "icon": "$(open-preview)",
         "category": "R"
       },
       {
-        "command": "r.markdown.explorerPreview",
-        "title": "Open Preview",
-        "category": "R"
-      },
-      {
-        "command": "r.markdown.refresh",
+        "command": "r.markdown.preview.refresh",
         "title": "Refresh Preview",
         "icon": "$(refresh)",
         "category": "R"
       },
       {
-        "command": "r.markdown.openExternal",
+        "command": "r.markdown.preview.openExternal",
         "title": "Open in External Browser",
         "icon": "$(link-external)",
         "category": "R"
       },
       {
-        "command": "r.markdown.showSource",
+        "command": "r.markdown.preview.showSource",
         "title": "Show Source",
         "icon": "$(go-to-file)",
         "category": "R"
@@ -834,13 +829,13 @@
         "when": "editorTextFocus && editorLangId == 'r'"
       },
       {
-        "command": "r.markdown.previewSide",
+        "command": "r.markdown.showPreviewToSide",
         "key": "Ctrl+k v",
         "mac": "cmd+k v",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
-        "command": "r.markdown.preview",
+        "command": "r.markdown.showPreview",
         "key": "Ctrl+shift+v",
         "mac": "cmd+shift+v",
         "when": "editorTextFocus && editorLangId == 'rmd'"
@@ -860,17 +855,17 @@
       ],
       "editor/title": [
         {
-          "command": "r.markdown.refresh",
+          "command": "r.markdown.preview.refresh",
           "when": "resourceScheme =~ /webview/ && r.preview.active",
           "group": "navigation@3"
         },
         {
-          "command": "r.markdown.openExternal",
+          "command": "r.markdown.preview.openExternal",
           "when": "resourceScheme =~ /webview/ && r.preview.active",
           "group": "navigation@1"
         },
         {
-          "command": "r.markdown.showSource",
+          "command": "r.markdown.preview.showSource",
           "when": "resourceScheme =~ /webview/ && r.preview.active",
           "group": "navigation@2"
         },
@@ -970,8 +965,8 @@
           "command": "r.plot.openUrl"
         },
         {
-          "command": "r.markdown.previewSide",
-          "alt": "r.markdown.preview",
+          "command": "r.markdown.showPreviewToSide",
+          "alt": "r.markdown.showPreview",
           "when": "editorLangId == rmd",
           "group": "navigation"
         }
@@ -1111,15 +1106,9 @@
       ],
       "explorer/context": [
         {
-          "command": "r.markdown.explorerPreview",
+          "command": "r.markdown.showPreview",
           "when": "resourceLangId == rmd",
           "group": "navigation"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "r.markdown.explorerPreview",
-          "when": "false"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -527,6 +527,23 @@
         "command": "r.goToNextChunk"
       },
       {
+        "command": "r.markdown.previewSide",
+        "title": "Open preview to the side",
+        "icon": "$(open-preview)",
+        "category": "R"
+      },
+      {
+        "command": "r.markdown.preview",
+        "title": "Open preview",
+        "icon": "$(open-preview)",
+        "category": "R"
+      },
+      {
+        "command": "r.markdown.explorerPreview",
+        "title": "Open preview",
+        "category": "R"
+      },
+      {
         "title": "Launch RStudio Addin",
         "category": "R",
         "command": "r.launchAddinPicker"
@@ -797,6 +814,18 @@
         "key": "Ctrl+alt+e",
         "mac": "cmd+alt+e",
         "when": "editorTextFocus && editorLangId == 'r'"
+      },
+      {
+        "command": "r.markdown.previewSide",
+        "key": "Ctrl+k v",
+        "mac": "cmd+k v",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.markdown.preview",
+        "key": "Ctrl+shift+v",
+        "mac": "cmd+shift+v",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
       }
     ],
     "menus": {
@@ -906,6 +935,12 @@
           "group": "httpgd",
           "when": "resourceScheme =~ /webview/ && r.plot.active",
           "command": "r.plot.openUrl"
+        },
+        {
+          "command": "r.markdown.previewSide",
+          "alt": "r.markdown.preview",
+          "when": "editorLangId == rmd",
+          "group": "navigation"
         }
       ],
       "editor/context": [
@@ -1040,6 +1075,19 @@
           "group": "navigation@3",
           "when": "view == rLiveShare && r.liveShare:aborted"
         }
+      ],
+      "explorer/context": [
+        {
+          "command": "r.markdown.explorerPreview",
+          "when": "resourceLangId == rmd",
+          "group": "navigation"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "r.markdown.explorerPreview",
+          "when": "false"
+        }
       ]
     },
     "configuration": {
@@ -1107,6 +1155,19 @@
           "type": "string",
           "default": "rgba(128, 128, 128, 0.1)",
           "description": "RMarkdown chunk background color in RGBA or RGB value. Defaults to rgba(128, 128, 128, 0.1). Leave it empty to disable it (use default editor background color). Reload VS Code after changing settings.\n\nLearn how to set colors: https://www.w3schools.com/css/css_colors_rgb.asp.\n\nExamples for syntax rgba(<red>, <green>, <blue>, <alpha>):\nrgba(128, 128, 128, 0.1)\nrgba(128, 128, 128, 0.3)\nrgba(255, 165, 0, 0.1)\n\n"
+        },
+        "r.rmarkdown.previewEngine": {
+          "type": "string",
+          "enum": [
+            "rmarkdown::run",
+            "xaringan::infinite_moon_reader"
+          ],
+          "enumDescriptions": [
+            "Use rmarkdown::run() to preview documents",
+            "Use xaringan::infinite_moon_reader() to preview documents"
+          ],
+          "description": "What package command to use for previewing R Markdown documents.",
+          "default": "rmarkdown::run"
         },
         "r.helpPanel.enableSyntaxHighlighting": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -855,11 +855,6 @@
       ],
       "editor/title": [
         {
-          "command": "r.markdown.preview.refresh",
-          "when": "resourceScheme =~ /webview/ && r.preview.active",
-          "group": "navigation@3"
-        },
-        {
           "command": "r.markdown.preview.openExternal",
           "when": "resourceScheme =~ /webview/ && r.preview.active",
           "group": "navigation@1"
@@ -868,6 +863,11 @@
           "command": "r.markdown.preview.showSource",
           "when": "resourceScheme =~ /webview/ && r.preview.active",
           "group": "navigation@2"
+        },
+        {
+          "command": "r.markdown.preview.refresh",
+          "when": "resourceScheme =~ /webview/ && r.preview.active",
+          "group": "1_rMarkdown"
         },
         {
           "command": "r.browser.refresh",

--- a/package.json
+++ b/package.json
@@ -546,6 +546,19 @@
       {
         "command": "r.markdown.refresh",
         "title": "Refresh preview",
+        "icon": "$(refresh)",
+        "category": "R"
+      },
+      {
+        "command": "r.markdown.openExternal",
+        "title": "Open in external browser",
+        "icon": "$(link-external)",
+        "category": "R"
+      },
+      {
+        "command": "r.markdown.showSource",
+        "title": "Show source",
+        "icon": "$(go-to-file)",
         "category": "R"
       },
       {
@@ -846,6 +859,21 @@
         }
       ],
       "editor/title": [
+        {
+          "command": "r.markdown.refresh",
+          "when": "resourceScheme =~ /webview/ && r.preview.active",
+          "group": "navigation@3"
+        },
+        {
+          "command": "r.markdown.openExternal",
+          "when": "resourceScheme =~ /webview/ && r.preview.active",
+          "group": "navigation@1"
+        },
+        {
+          "command": "r.markdown.showSource",
+          "when": "resourceScheme =~ /webview/ && r.preview.active",
+          "group": "navigation@2"
+        },
         {
           "command": "r.browser.refresh",
           "when": "resourceScheme =~ /webview/ && r.browser.active",

--- a/package.json
+++ b/package.json
@@ -544,6 +544,11 @@
         "category": "R"
       },
       {
+        "command": "r.markdown.refresh",
+        "title": "Refresh preview",
+        "category": "R"
+      },
+      {
         "title": "Launch RStudio Addin",
         "category": "R",
         "command": "r.launchAddinPicker"

--- a/package.json
+++ b/package.json
@@ -530,47 +530,47 @@
         "command": "r.markdown.showPreviewToSide",
         "title": "Open Preview to the Side",
         "icon": "$(open-preview)",
-        "category": "R"
+        "category": "R Markdown"
       },
       {
         "command": "r.markdown.showPreview",
         "title": "Open Preview",
         "icon": "$(open-preview)",
-        "category": "R"
+        "category": "R Markdown"
       },
       {
         "command": "r.markdown.preview.refresh",
         "title": "Refresh Preview",
         "icon": "$(refresh)",
-        "category": "R"
+        "category": "R Markdown"
       },
       {
         "command": "r.markdown.preview.openExternal",
         "title": "Open in External Browser",
         "icon": "$(link-external)",
-        "category": "R"
+        "category": "R Markdown"
       },
       {
         "command": "r.markdown.preview.showSource",
         "title": "Show Source",
         "icon": "$(go-to-file)",
-        "category": "R"
+        "category": "R Markdown"
       },
       {
         "title": "Toggle Style",
-        "category": "R",
+        "category": "R Markdown",
         "command": "r.markdown.preview.toggleStyle",
         "icon": "$(symbol-color)"
       },
       {
         "title": "Enable Auto Refresh",
-        "category": "R",
+        "category": "R Markdown",
         "command": "r.markdown.preview.enableAutoRefresh",
         "icon": "$(sync)"
       },
       {
         "title": "Disable Auto Refresh",
-        "category": "R",
+        "category": "R Markdown",
         "command": "r.markdown.preview.disableAutoRefresh",
         "icon": "$(sync-ignored)"
       },

--- a/package.json
+++ b/package.json
@@ -565,12 +565,14 @@
       {
         "title": "Enable Auto Refresh",
         "category": "R",
-        "command": "r.markdown.preview.enableAutoRefresh"
+        "command": "r.markdown.preview.enableAutoRefresh",
+        "icon": "$(sync)"
       },
       {
         "title": "Disable Auto Refresh",
         "category": "R",
-        "command": "r.markdown.preview.disableAutoRefresh"
+        "command": "r.markdown.preview.disableAutoRefresh",
+        "icon": "$(sync-ignored)"
       },
       {
         "title": "Launch RStudio Addin",
@@ -888,17 +890,17 @@
         {
           "command": "r.markdown.preview.refresh",
           "when": "resourceScheme =~ /webview/ && r.preview.active",
-          "group": "1_rMarkdown"
+          "group": "navigation@4"
         },
         {
           "command": "r.markdown.preview.enableAutoRefresh",
           "when": "resourceScheme =~ /webview/ && r.preview.active && !r.preview.autoRefresh",
-          "group": "1_rMarkdown"
+          "group": "navigation@5"
         },
         {
           "command": "r.markdown.preview.disableAutoRefresh",
           "when": "resourceScheme =~ /webview/ && r.preview.active && r.preview.autoRefresh",
-          "group": "1_rMarkdown"
+          "group": "navigation@5"
         },
         {
           "command": "r.browser.refresh",

--- a/package.json
+++ b/package.json
@@ -563,6 +563,16 @@
         "icon": "$(symbol-color)"
       },
       {
+        "title": "Enable Auto Refresh",
+        "category": "R",
+        "command": "r.markdown.preview.enableAutoRefresh"
+      },
+      {
+        "title": "Disable Auto Refresh",
+        "category": "R",
+        "command": "r.markdown.preview.disableAutoRefresh"
+      },
+      {
         "title": "Launch RStudio Addin",
         "category": "R",
         "command": "r.launchAddinPicker"
@@ -881,6 +891,16 @@
           "group": "1_rMarkdown"
         },
         {
+          "command": "r.markdown.preview.enableAutoRefresh",
+          "when": "resourceScheme =~ /webview/ && r.preview.active && !r.preview.autoRefresh",
+          "group": "1_rMarkdown"
+        },
+        {
+          "command": "r.markdown.preview.disableAutoRefresh",
+          "when": "resourceScheme =~ /webview/ && r.preview.active && r.preview.autoRefresh",
+          "group": "1_rMarkdown"
+        },
+        {
           "command": "r.browser.refresh",
           "when": "resourceScheme =~ /webview/ && r.browser.active",
           "group": "navigation"
@@ -1188,6 +1208,11 @@
           "type": "string",
           "default": "rgba(128, 128, 128, 0.1)",
           "description": "RMarkdown chunk background color in RGBA or RGB value. Defaults to rgba(128, 128, 128, 0.1). Leave it empty to disable it (use default editor background color). Reload VS Code after changing settings.\n\nLearn how to set colors: https://www.w3schools.com/css/css_colors_rgb.asp.\n\nExamples for syntax rgba(<red>, <green>, <blue>, <alpha>):\nrgba(128, 128, 128, 0.1)\nrgba(128, 128, 128, 0.3)\nrgba(255, 165, 0, 0.1)\n\n"
+        },
+        "r.rmarkdown.preview.autoRefresh": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable automatic refresh of R Markdown preview on file update."
         },
         "r.helpPanel.enableSyntaxHighlighting": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -528,36 +528,36 @@
       },
       {
         "command": "r.markdown.previewSide",
-        "title": "Open preview to the side",
+        "title": "Open Preview to the Side",
         "icon": "$(open-preview)",
         "category": "R"
       },
       {
         "command": "r.markdown.preview",
-        "title": "Open preview",
+        "title": "Open Preview",
         "icon": "$(open-preview)",
         "category": "R"
       },
       {
         "command": "r.markdown.explorerPreview",
-        "title": "Open preview",
+        "title": "Open Preview",
         "category": "R"
       },
       {
         "command": "r.markdown.refresh",
-        "title": "Refresh preview",
+        "title": "Refresh Preview",
         "icon": "$(refresh)",
         "category": "R"
       },
       {
         "command": "r.markdown.openExternal",
-        "title": "Open in external browser",
+        "title": "Open in External Browser",
         "icon": "$(link-external)",
         "category": "R"
       },
       {
         "command": "r.markdown.showSource",
-        "title": "Show source",
+        "title": "Show Source",
         "icon": "$(go-to-file)",
         "category": "R"
       },

--- a/package.json
+++ b/package.json
@@ -557,6 +557,12 @@
         "category": "R"
       },
       {
+        "title": "Toggle Style",
+        "category": "R",
+        "command": "r.markdown.preview.toggleStyle",
+        "icon": "$(symbol-color)"
+      },
+      {
         "title": "Launch RStudio Addin",
         "category": "R",
         "command": "r.launchAddinPicker"
@@ -863,6 +869,11 @@
           "command": "r.markdown.preview.showSource",
           "when": "resourceScheme =~ /webview/ && r.preview.active",
           "group": "navigation@2"
+        },
+        {
+          "command": "r.markdown.preview.toggleStyle",
+          "when": "resourceScheme =~ /webview/ && r.preview.active",
+          "group": "navigation@3"
         },
         {
           "command": "r.markdown.preview.refresh",
@@ -1177,19 +1188,6 @@
           "type": "string",
           "default": "rgba(128, 128, 128, 0.1)",
           "description": "RMarkdown chunk background color in RGBA or RGB value. Defaults to rgba(128, 128, 128, 0.1). Leave it empty to disable it (use default editor background color). Reload VS Code after changing settings.\n\nLearn how to set colors: https://www.w3schools.com/css/css_colors_rgb.asp.\n\nExamples for syntax rgba(<red>, <green>, <blue>, <alpha>):\nrgba(128, 128, 128, 0.1)\nrgba(128, 128, 128, 0.3)\nrgba(255, 165, 0, 0.1)\n\n"
-        },
-        "r.rmarkdown.previewEngine": {
-          "type": "string",
-          "enum": [
-            "rmarkdown::run",
-            "xaringan::infinite_moon_reader"
-          ],
-          "enumDescriptions": [
-            "Use rmarkdown::run() to preview documents",
-            "Use xaringan::infinite_moon_reader() to preview documents"
-          ],
-          "description": "What package command to use for previewing R Markdown documents.",
-          "default": "rmarkdown::run"
         },
         "r.helpPanel.enableSyntaxHighlighting": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1388,6 +1388,7 @@
   "dependencies": {
     "bootstrap": "^5.0.1",
     "cheerio": "1.0.0-rc.10",
+    "crypto": "^1.0.1",
     "datatables.net": "^1.10.25",
     "datatables.net-bs4": "^1.10.25",
     "datatables.net-fixedheader-jqui": "^3.1.9",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.markdown.showPreviewToSide': () => rMarkdownPreview.previewRmd(vscode.ViewColumn.Beside),
         'r.markdown.showPreview': (uri: vscode.Uri) => rMarkdownPreview.previewRmd(vscode.ViewColumn.Active, uri),
         'r.markdown.preview.refresh': () => rMarkdownPreview.refreshPanel(),
-        'r.markdown.preview.openExternal': async () => await rMarkdownPreview.openExternalBrowser(),
+        'r.markdown.preview.openExternal': () => rMarkdownPreview.openExternalBrowser(),
         'r.markdown.preview.showSource': () => rMarkdownPreview.showSource(),
         'r.markdown.preview.toggleStyle': () => rMarkdownPreview.toggleTheme(),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.markdown.showPreviewToSide': () => rMarkdownPreview.previewRmd(vscode.ViewColumn.Beside),
         'r.markdown.showPreview': (uri: vscode.Uri) => rMarkdownPreview.previewRmd(vscode.ViewColumn.Active, uri),
         'r.markdown.preview.refresh': () => rMarkdownPreview.refreshPanel(),
-        'r.markdown.preview.openExternal': () => rMarkdownPreview.openExternalBrowser(),
+        'r.markdown.preview.openExternal': async () => await rMarkdownPreview.openExternalBrowser(),
         'r.markdown.preview.showSource': () => rMarkdownPreview.showSource(),
         'r.markdown.preview.toggleStyle': () => rMarkdownPreview.toggleTheme(),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,6 +83,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.markdown.previewSide': (viewer = vscode.ViewColumn.Beside) => rPreviewProvider.previewRmd(viewer),
         'r.markdown.preview': (viewer = vscode.ViewColumn.Active) => rPreviewProvider.previewRmd(viewer),
         'r.markdown.explorerPreview': (uri: vscode.Uri, viewer = vscode.ViewColumn.Active) => rPreviewProvider.previewRmd(viewer, uri),
+        'r.markdown.refresh': () => rPreviewProvider.refreshPanel(),
+        'r.markdown.openExternal': () => rPreviewProvider.openExternal(),
+        'r.markdown.showSource': () => rPreviewProvider.showSource(),
 
         // editor independent commands
         'r.createGitignore': rGitignore.createGitignore,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,9 @@
 
 // interfaces, functions, etc. provided by vscode
 import * as vscode from 'vscode';
+import * as os from 'os';
+import path = require('path');
+import fs = require('fs');
 
 // functions etc. implemented in this extension
 import * as preview from './preview';
@@ -22,6 +25,8 @@ import * as httpgdViewer from './plotViewer';
 import { RMarkdownPreviewManager } from './rmarkdown/preview';
 
 // global objects used in other files
+export const extDir: string = path.join(os.homedir(), '.vscode-R');
+export const tmpDir: string = path.join(extDir, 'tmp');
 export let rWorkspace: workspaceViewer.WorkspaceDataProvider | undefined = undefined;
 export let globalRHelp: rHelp.RHelp | undefined = undefined;
 export let extensionContext: vscode.ExtensionContext;
@@ -31,6 +36,14 @@ export let rMarkdownPreview: RMarkdownPreviewManager | undefined = undefined;
 
 // Called (once) when the extension is activated
 export async function activate(context: vscode.ExtensionContext): Promise<apiImplementation.RExtensionImplementation> {
+    if (!fs.existsSync(extDir)) {
+        fs.mkdirSync(extDir);
+    }
+
+    if (!fs.existsSync(tmpDir)) {
+        fs.mkdirSync(tmpDir);
+    }
+
     // create a new instance of RExtensionImplementation
     // is used to export an interface to the help panel
     // this export is used e.g. by vscode-r-debugger to show the help panel from within debug sessions

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ export let globalRHelp: rHelp.RHelp | undefined = undefined;
 export let extensionContext: vscode.ExtensionContext;
 export let enableSessionWatcher: boolean = undefined;
 export let globalHttpgdManager: httpgdViewer.HttpgdManager | undefined = undefined;
-export const rPreviewProvider = new PreviewProvider();
+export let rPreviewProvider: PreviewProvider | undefined = undefined;
 
 // Called (once) when the extension is activated
 export async function activate(context: vscode.ExtensionContext): Promise<apiImplementation.RExtensionImplementation> {
@@ -143,6 +143,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
     // initialize the package/help related functions
     globalRHelp = await rHelp.initializeHelp(context, rExtension);
+
+    // init preview provider
+    rPreviewProvider = new PreviewProvider();
+    await rPreviewProvider.init();
 
     // register codelens and complmetion providers for r markdown
     vscode.languages.registerCodeLensProvider(['r', 'rmd'], new rmarkdown.RMarkdownCodeLensProvider());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,6 +99,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.markdown.preview.openExternal': () => void rMarkdownPreview.openExternalBrowser(),
         'r.markdown.preview.showSource': () => rMarkdownPreview.showSource(),
         'r.markdown.preview.toggleStyle': () => rMarkdownPreview.toggleTheme(),
+        'r.markdown.preview.enableAutoRefresh': () => rMarkdownPreview.enableAutoRefresh(),
+        'r.markdown.preview.disableAutoRefresh': () => rMarkdownPreview.disableAutoRefresh(),
 
         // editor independent commands
         'r.createGitignore': rGitignore.createGitignore,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.markdown.showPreviewToSide': () => rMarkdownPreview.previewRmd(vscode.ViewColumn.Beside),
         'r.markdown.showPreview': (uri: vscode.Uri) => rMarkdownPreview.previewRmd(vscode.ViewColumn.Active, uri),
         'r.markdown.preview.refresh': () => rMarkdownPreview.refreshPanel(),
-        'r.markdown.preview.openExternal': async () => await rMarkdownPreview.openExternalBrowser(),
+        'r.markdown.preview.openExternal': () => void rMarkdownPreview.openExternalBrowser(),
         'r.markdown.preview.showSource': () => rMarkdownPreview.showSource(),
         'r.markdown.preview.toggleStyle': () => rMarkdownPreview.toggleTheme(),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import * as completions from './completions';
 import * as rShare from './liveshare';
 import * as httpgdViewer from './plotViewer';
 
-import { PreviewProvider } from './rmarkdown/preview';
+import { RMarkdownPreviewManager } from './rmarkdown/preview';
 
 // global objects used in other files
 export let rWorkspace: workspaceViewer.WorkspaceDataProvider | undefined = undefined;
@@ -27,7 +27,7 @@ export let globalRHelp: rHelp.RHelp | undefined = undefined;
 export let extensionContext: vscode.ExtensionContext;
 export let enableSessionWatcher: boolean = undefined;
 export let globalHttpgdManager: httpgdViewer.HttpgdManager | undefined = undefined;
-export let rPreviewProvider: PreviewProvider | undefined = undefined;
+export let rMarkdownPreview: RMarkdownPreviewManager | undefined = undefined;
 
 // Called (once) when the extension is activated
 export async function activate(context: vscode.ExtensionContext): Promise<apiImplementation.RExtensionImplementation> {
@@ -80,12 +80,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.goToNextChunk': rmarkdown.goToNextChunk,
         'r.runChunks': rTerminal.runChunksInTerm,
 
-        'r.markdown.previewSide': () => rPreviewProvider.previewRmd(vscode.ViewColumn.Beside, null),
-        'r.markdown.preview': () => rPreviewProvider.previewRmd(vscode.ViewColumn.Active, null),
-        'r.markdown.explorerPreview': (uri: vscode.Uri) => rPreviewProvider.previewRmd(vscode.ViewColumn.Active, uri),
-        'r.markdown.refresh': () => rPreviewProvider.refreshPanel(),
-        'r.markdown.openExternal': () => rPreviewProvider.openExternal(),
-        'r.markdown.showSource': () => rPreviewProvider.showSource(),
+        'r.markdown.showPreviewToSide': () => rMarkdownPreview.previewRmd(vscode.ViewColumn.Beside),
+        'r.markdown.showPreview': (uri: vscode.Uri) => rMarkdownPreview.previewRmd(vscode.ViewColumn.Active, uri),
+        'r.markdown.preview.refresh': () => rMarkdownPreview.refreshPanel(),
+        'r.markdown.preview.openExternal': () => rMarkdownPreview.openExternalBrowser(),
+        'r.markdown.preview.showSource': () => rMarkdownPreview.showSource(),
 
         // editor independent commands
         'r.createGitignore': rGitignore.createGitignore,
@@ -145,8 +144,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     globalRHelp = await rHelp.initializeHelp(context, rExtension);
 
     // init preview provider
-    rPreviewProvider = new PreviewProvider();
-    await rPreviewProvider.init();
+    rMarkdownPreview = new RMarkdownPreviewManager();
+    await rMarkdownPreview.init();
 
     // register codelens and complmetion providers for r markdown
     vscode.languages.registerCodeLensProvider(['r', 'rmd'], new rmarkdown.RMarkdownCodeLensProvider());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,8 +96,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.markdown.showPreviewToSide': () => rMarkdownPreview.previewRmd(vscode.ViewColumn.Beside),
         'r.markdown.showPreview': (uri: vscode.Uri) => rMarkdownPreview.previewRmd(vscode.ViewColumn.Active, uri),
         'r.markdown.preview.refresh': () => rMarkdownPreview.refreshPanel(),
-        'r.markdown.preview.openExternal': () => rMarkdownPreview.openExternalBrowser(),
+        'r.markdown.preview.openExternal': async () => await rMarkdownPreview.openExternalBrowser(),
         'r.markdown.preview.showSource': () => rMarkdownPreview.showSource(),
+        'r.markdown.preview.toggleStyle': () => rMarkdownPreview.toggleTheme(),
 
         // editor independent commands
         'r.createGitignore': rGitignore.createGitignore,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,9 +80,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.goToNextChunk': rmarkdown.goToNextChunk,
         'r.runChunks': rTerminal.runChunksInTerm,
 
-        'r.markdown.previewSide': (viewer = vscode.ViewColumn.Beside) => rPreviewProvider.previewRmd(viewer),
-        'r.markdown.preview': (viewer = vscode.ViewColumn.Active) => rPreviewProvider.previewRmd(viewer),
-        'r.markdown.explorerPreview': (uri: vscode.Uri, viewer = vscode.ViewColumn.Active) => rPreviewProvider.previewRmd(viewer, uri),
+        'r.markdown.previewSide': () => rPreviewProvider.previewRmd(vscode.ViewColumn.Beside, null),
+        'r.markdown.preview': () => rPreviewProvider.previewRmd(vscode.ViewColumn.Active, null),
+        'r.markdown.explorerPreview': (uri: vscode.Uri) => rPreviewProvider.previewRmd(vscode.ViewColumn.Active, uri),
         'r.markdown.refresh': () => rPreviewProvider.refreshPanel(),
         'r.markdown.openExternal': () => rPreviewProvider.openExternal(),
         'r.markdown.showSource': () => rPreviewProvider.showSource(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import * as completions from './completions';
 import * as rShare from './liveshare';
 import * as httpgdViewer from './plotViewer';
 
+import { PreviewProvider } from './rmarkdown/preview';
 
 // global objects used in other files
 export let rWorkspace: workspaceViewer.WorkspaceDataProvider | undefined = undefined;
@@ -26,7 +27,7 @@ export let globalRHelp: rHelp.RHelp | undefined = undefined;
 export let extensionContext: vscode.ExtensionContext;
 export let enableSessionWatcher: boolean = undefined;
 export let globalHttpgdManager: httpgdViewer.HttpgdManager | undefined = undefined;
-
+export const rPreviewProvider = new PreviewProvider();
 
 // Called (once) when the extension is activated
 export async function activate(context: vscode.ExtensionContext): Promise<apiImplementation.RExtensionImplementation> {
@@ -78,6 +79,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.goToPreviousChunk': rmarkdown.goToPreviousChunk,
         'r.goToNextChunk': rmarkdown.goToNextChunk,
         'r.runChunks': rTerminal.runChunksInTerm,
+
+        'r.markdown.previewSide': (viewer = vscode.ViewColumn.Beside) => rPreviewProvider.previewRmd(viewer),
+        'r.markdown.preview': (viewer = vscode.ViewColumn.Active) => rPreviewProvider.previewRmd(viewer),
+        'r.markdown.explorerPreview': (uri: vscode.Uri, viewer = vscode.ViewColumn.Active) => rPreviewProvider.previewRmd(viewer, uri),
 
         // editor independent commands
         'r.createGitignore': rGitignore.createGitignore,
@@ -135,7 +140,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
     // initialize the package/help related functions
     globalRHelp = await rHelp.initializeHelp(context, rExtension);
-
 
     // register codelens and complmetion providers for r markdown
     vscode.languages.registerCodeLensProvider(['r', 'rmd'], new rmarkdown.RMarkdownCodeLensProvider());

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -6,7 +6,7 @@ import * as hljs from 'highlight.js';
 
 import * as api from '../api';
 
-import { config, getRpath, doWithProgress, DummyMemento, getRPathConfigEntry } from '../util';
+import { config, getRpath, doWithProgress, DummyMemento, getRPathConfigEntry, escapeHtml } from '../util';
 import { HelpPanel } from './panel';
 import { HelpProvider, AliasProvider } from './helpProvider';
 import { HelpTreeWrapper } from './treeView';
@@ -524,15 +524,3 @@ export class RHelp implements api.HelpPanel, vscode.WebviewPanelSerializer<strin
 	}
 }
 
-// Helper function used to convert raw text files to html
-function escapeHtml(source: string) {
-	const entityMap = new Map<string, string>(Object.entries({
-		'&': '&amp;',
-		'<': '&lt;',
-		'>': '&gt;',
-		'"': '&quot;',
-		'\'': '&#39;',
-		'/': '&#x2F;'
-	}));
-    return String(source).replace(/[&<>"'/]/g, (s: string) => entityMap.get(s) || '');
-}

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -6,11 +6,11 @@ import { isDeepStrictEqual } from 'util';
 
 import * as vscode from 'vscode';
 
-import { extensionContext } from './extension';
+import { extensionContext, extDir } from './extension';
 import * as util from './util';
 import * as selection from './selection';
 import { getSelection } from './selection';
-import { removeSessionFiles, watcherDir } from './session';
+import { removeSessionFiles } from './session';
 import { config, delay, getRterm } from './util';
 import { rGuestService, isGuestSession } from './liveshare';
 export let rTerm: vscode.Terminal;
@@ -124,7 +124,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
                     R_PROFILE_USER_OLD: process.env.R_PROFILE_USER,
                     R_PROFILE_USER: newRprofile,
                     VSCODE_INIT_R: initR,
-                    VSCODE_WATCHER_DIR: watcherDir
+                    VSCODE_WATCHER_DIR: extDir
                 };
             }
             rTerm = vscode.window.createTerminal(termOptions);

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -3,8 +3,8 @@ import {
   CompletionItem, CompletionItemProvider,
   Event, EventEmitter, Position, Range, TextDocument, TextEditorDecorationType, window, Selection, commands
 } from 'vscode';
-import { runChunksInTerm } from './rTerminal';
-import { config } from './util';
+import { runChunksInTerm } from '../rTerminal';
+import { config } from '../util';
 
 function isRDocument(document: TextDocument) {
   return (document.languageId === 'r');

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -71,7 +71,7 @@ class RMarkdownPreview extends vscode.Disposable {
         const isHtml = !!re.exec(content);
 
         if (!isHtml) {
-            const html = escapeHtml(content);
+            const html: string = escapeHtml(content);
             content = `<html><head></head><body><pre>${html}</pre></body></html>`;
         }
 

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -71,7 +71,7 @@ class RMarkdownPreview extends vscode.Disposable {
         const isHtml = !!re.exec(content);
 
         if (!isHtml) {
-            const html: string = escapeHtml(content);
+            const html = escapeHtml(content);
             content = `<html><head></head><body><pre>${html}</pre></body></html>`;
         }
 
@@ -299,19 +299,23 @@ export class RMarkdownPreviewManager {
                 (data: Buffer) => {
                     const dat = data.toString('utf8');
                     this.rMarkdownOutput.appendLine(dat);
-                    const outputUrl = re.exec(dat)?.[0]?.replace(re, '$1');
-                    if (outputUrl) {
-                        if (viewer !== undefined) {
-                            void this.openPreview(
-                                vscode.Uri.parse(outputUrl),
-                                fileUri,
-                                fileName,
-                                childProcess,
-                                viewer,
-                                currentViewColumn
-                            );
-                        }
+                    if (token?.isCancellationRequested) {
                         resolve(childProcess);
+                    } else {
+                        const outputUrl = re.exec(dat)?.[0]?.replace(re, '$1');
+                        if (outputUrl) {
+                            if (viewer !== undefined) {
+                                void this.openPreview(
+                                    vscode.Uri.parse(outputUrl),
+                                    fileUri,
+                                    fileName,
+                                    childProcess,
+                                    viewer,
+                                    currentViewColumn
+                                );
+                            }
+                            resolve(childProcess);
+                        }
                     }
                 }
             );

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -1,89 +1,142 @@
 
 import * as cp from 'child_process';
-import * as kill from 'tree-kill';
 import * as vscode from 'vscode';
+
 import { getBrowserHtml } from '../session';
 import { closeBrowser, isHost, shareBrowser } from '../liveshare';
 import { config, doWithProgress, getRpath,  setContext } from '../util';
+import { extensionContext } from '../extension';
 
-interface IPreviewProcess {
-    cp: cp.ChildProcessWithoutNullStreams,
-    file: string,
-    panel: vscode.WebviewPanel,
+class RMarkdownChild extends vscode.Disposable {
+    title: string;
+    cp: cp.ChildProcessWithoutNullStreams;
+    panel: vscode.WebviewPanel;
+    resourceViewColumn: vscode.ViewColumn;
+    uri: vscode.Uri;
+    externalUri: vscode.Uri;
+
+    constructor(title: string, cp: cp.ChildProcessWithoutNullStreams, panel: vscode.WebviewPanel, resourceViewColumn: vscode.ViewColumn, uri: vscode.Uri, externalUri: vscode.Uri) {
+        super(() => {
+            this.cp.kill('SIGKILL');
+            this.panel?.dispose();
+        });
+
+        this.title = title;
+        this.cp = cp;
+        this.panel = panel;
+        this.resourceViewColumn = resourceViewColumn;
+        this.uri = uri;
+        this.externalUri = externalUri;
+    }
+}
+
+class RMarkdownChildStore extends vscode.Disposable {
+    private store: Set<RMarkdownChild> = new Set<RMarkdownChild>();
+
+    constructor() {
+        super((): void => {
+            for (const child of this.store) {
+                child.dispose();
+            }
+            this.store.clear();
+        });
+    }
+
+    public add(child: RMarkdownChild): void {
+        this.store.add(child);
+    }
+
+    public delete(child: RMarkdownChild): void {
+        child.dispose();
+        this.store.delete(child);
+    }
+
+    public get(uri: vscode.Uri) {
+        for (const child of this.store) {
+            if (child.uri === uri) {
+                return child;
+            }
+        }
+        return undefined;
+    }
+
+    public has(uri: vscode.Uri) {
+        for (const child of this.store) {
+            if (child.uri === uri) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    [Symbol.iterator](): Iterator<RMarkdownChild> {
+        return this.store[Symbol.iterator]();
+    }
 }
 
 export class RMarkdownPreviewManager {
-    private openProcesses: IPreviewProcess[] = [];
-    private activePreview: vscode.WebviewPanel;
-    private activeResource: vscode.Uri;
-    private activeExternalResource: vscode.Uri;
     private rPath: string;
+    private ChildStore: RMarkdownChildStore = new RMarkdownChildStore;
+    private activePreview: RMarkdownChild;
+    private rMarkdownOutput: vscode.OutputChannel = vscode.window.createOutputChannel('R Markdown');
 
     public async init(): Promise<void> {
         this.rPath = await getRpath(false);
+        extensionContext.subscriptions.push(this.ChildStore);
     }
 
     public async previewRmd(viewer: vscode.ViewColumn, uri?: vscode.Uri): Promise<void> {
         const fileUri = uri ?? vscode.window.activeTextEditor.document.uri;
         const fileName = fileUri.path.substring(fileUri.path.lastIndexOf('/') + 1);
         const previewEngine: string = config().get('rmarkdown.previewEngine');
+        const currentViewColumn: vscode.ViewColumn = vscode.window.activeTextEditor.viewColumn ?? vscode.ViewColumn.Active;
         const cmd = (
             `${this.rPath} --silent --slave --no-save --no-restore -e "${previewEngine}('${fileUri.path}')"`
         );
         const reg: RegExp = this.constructRegex(previewEngine);
-        let call = undefined;
 
-
-        if (this.openProcesses.some(e => e.file === fileName)) {
-            this.openProcesses.filter(e => e.file === fileName)[0].panel.reveal();
+        if (this.ChildStore.has(fileUri)) {
+            this.ChildStore.get(fileUri).panel.reveal();
         } else {
-            await doWithProgress(() => {
-                try {
-                    call = cp.spawn(cmd, null, { shell: true });
-                } catch (e) {
-                    console.warn((e as string));
-                }
-                (call as cp.ChildProcessWithoutNullStreams).stderr.on('data',
-                    (data: Buffer) => {
-                        const dat = data.toString('utf8');
-                        const match = reg.exec(dat)?.[0];
-                        const previewUrl = this.constructUrl(previewEngine, match, fileName);
-                        if (match) {
-                            void this.showPreview(previewUrl, fileName, call, viewer, fileUri);
-                        }
-                    });
+            await doWithProgress(async () => {
+                await this.spawnProcess(cmd, reg, previewEngine, fileName, viewer, fileUri, currentViewColumn)
+                    .catch((cp: cp.ChildProcessWithoutNullStreams) => {
+                        void vscode.window.showErrorMessage('There was an error in knitting the document. Please check the R Markdown output stream.');
+                        cp.kill('SIGKILL');
+                    }
+                    );
             },
                 vscode.ProgressLocation.Notification,
-                `Rendering ${fileName}...`
+                `Knitting ${fileName}...`
             );
         }
     }
 
     public refreshPanel(): void {
         if (this.activePreview) {
-            this.activePreview.webview.html = '';
-            this.activePreview.webview.html = getBrowserHtml(this.activeExternalResource);
+            this.activePreview.panel.webview.html = '';
+            this.activePreview.panel.webview.html = getBrowserHtml(this.activePreview.uri);
         }
     }
 
     public async showSource(): Promise<void> {
-        if (this.activeResource) {
-            const viewCol = vscode.window.visibleTextEditors.filter(e => e.document.uri === this.activeResource)[0]?.viewColumn;
-            await vscode.commands.executeCommand('vscode.open', this.activeResource, {
+        if (this.activePreview) {
+            // to fix, kind of buggy
+            await vscode.commands.executeCommand('vscode.open', this.activePreview.uri, {
                 preserveFocus: false,
                 preview: false,
-                viewColumn: viewCol ?? vscode.ViewColumn.Active
+                viewColumn: this.activePreview.resourceViewColumn ?? this.activePreview.panel.viewColumn ?? vscode.ViewColumn.Active
             });
         }
     }
 
     public openExternalBrowser(): void {
-        if (this.activeExternalResource) {
-            void vscode.env.openExternal(this.activeExternalResource);
+        if (this.activePreview) {
+            void vscode.env.openExternal(this.activePreview.externalUri);
         }
     }
 
-    private async showPreview(url: string, title: string, cp: cp.ChildProcessWithoutNullStreams, viewer: vscode.ViewColumn, fileUri: vscode.Uri): Promise<void> {
+    private async showPreview(url: string, title: string, cp: cp.ChildProcessWithoutNullStreams, viewer: vscode.ViewColumn, fileUri: vscode.Uri, resourceViewColumn: vscode.ViewColumn): Promise<void> {
         // construct webview and its related html
         console.info(`[showPreview] uri: ${url}`);
         const uri = vscode.Uri.parse(url);
@@ -104,13 +157,10 @@ export class RMarkdownPreviewManager {
 
         // Push the new rmd webview to the open proccesses array,
         // to keep track of running child processes
-        this.openProcesses.push(
-            {
-                cp: cp,
-                file: title,
-                panel: panel
-            }
-        );
+        // (primarily used in killing the child process, but also
+        // general state tracking)
+        const childProcess = new RMarkdownChild(title, cp, panel, resourceViewColumn, fileUri, externalUri);
+        this.ChildStore.add(childProcess);
 
         if (isHost()) {
             await shareBrowser(url, title);
@@ -118,15 +168,10 @@ export class RMarkdownPreviewManager {
 
         // state change
         panel.onDidDispose(() => {
-            // destroy process on closing window
-            kill(cp.pid);
-
+            // clear values
+            this.activePreview === childProcess ? undefined : this.activePreview;
             void setContext('r.preview.active', false);
-            for (const [key, item] of this.openProcesses.entries()) {
-                if (item.file === title) {
-                    this.openProcesses.splice(key, 1);
-                }
-            }
+            this.ChildStore.delete(childProcess);
 
             if (isHost()) {
                 closeBrowser(url);
@@ -136,9 +181,7 @@ export class RMarkdownPreviewManager {
         panel.onDidChangeViewState(({ webviewPanel }) => {
             void setContext('r.preview.active', webviewPanel.active);
             if (webviewPanel.active) {
-                this.activePreview = webviewPanel;
-                this.activeResource = fileUri;
-                this.activeExternalResource = externalUri;
+                this.activePreview = childProcess;
             }
         });
     }
@@ -175,5 +218,50 @@ export class RMarkdownPreviewManager {
                 break;
             }
         }
+    }
+
+    private async spawnProcess(cmd: string, reg: RegExp, previewEngine: string, fileName: string, viewer: vscode.ViewColumn, fileUri: vscode.Uri, resourceViewColumn: vscode.ViewColumn): Promise<cp.ChildProcessWithoutNullStreams> {
+        return await new Promise<cp.ChildProcessWithoutNullStreams>((resolve, reject) => {
+            let childProcess: cp.ChildProcessWithoutNullStreams;
+            try {
+                childProcess = cp.spawn(cmd, null, { shell: true });
+            } catch (e: unknown) {
+                console.warn(`[VSC-R] error: ${e as string}`);
+                reject(childProcess);
+            }
+
+            this.rMarkdownOutput.appendLine(`[VSC-R] ${fileName} process started`);
+
+            // write the terminal output to R Markdown output stream
+            // (mostly just knitting information)
+            childProcess.stdout.on('data', (data: Buffer) => {
+                this.rMarkdownOutput.appendLine(data.toString('utf8'));
+            });
+
+            childProcess.stderr.on('error', (e: Error) => {
+                this.rMarkdownOutput.appendLine(`[VSC-R] knitting error: ${e.message}`);
+                reject(childProcess);
+            });
+
+            childProcess.stderr.on('data',
+                (data: Buffer) => {
+                    const dat = data.toString('utf8');
+                    this.rMarkdownOutput.appendLine(dat);
+                    const match = reg.exec(dat)?.[0];
+                    const previewUrl = this.constructUrl(previewEngine, match, fileName);
+                    if (match) {
+                        void this.showPreview(previewUrl, fileName, childProcess, viewer, fileUri, resourceViewColumn);
+                        resolve(childProcess);
+                    } else if (dat.includes('Execution halted')) {
+                        reject(childProcess);
+                    }
+                }
+            );
+
+            childProcess.on('exit', (code, signal) => {
+                this.rMarkdownOutput.appendLine(`[VSC-R] ${fileName} process exited ` +
+                    (signal ? `from signal '${signal}'` : `with exit code ${code}`));
+            });
+        });
     }
 }

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -11,8 +11,6 @@ interface IPreviewProcess {
     cp: cp.ChildProcessWithoutNullStreams,
     file: string,
     panel: vscode.WebviewPanel,
-    externalUri: vscode.Uri,
-    browserUri: vscode.Uri
 }
 
 export class PreviewProvider {
@@ -81,10 +79,11 @@ export class PreviewProvider {
 
     public async showSource(): Promise<void> {
         if (this.activeResource) {
+            const viewCol = vscode.window.visibleTextEditors.filter(e => e.document.uri === this.activeResource)[0]?.viewColumn;
             await vscode.commands.executeCommand('vscode.open', this.activeResource, {
                 preserveFocus: false,
                 preview: false,
-                viewColumn: vscode.ViewColumn.Active
+                viewColumn: viewCol ?? vscode.ViewColumn.Active
             });
         }
     }
@@ -116,9 +115,7 @@ export class PreviewProvider {
             {
                 cp: cp,
                 file: title,
-                panel: panel,
-                externalUri: externalUri,
-                browserUri: uri
+                panel: panel
             }
         );
 

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -1,0 +1,118 @@
+
+import * as cp from 'child_process';
+import * as kill from 'tree-kill';
+import * as vscode from 'vscode';
+import { getBrowserHtml } from '../session';
+import { closeBrowser, isHost, shareBrowser } from '../liveshare';
+import { config } from '../util';
+
+
+interface IPreviewProcess {
+    cp: cp.ChildProcessWithoutNullStreams,
+    file: string,
+    panel: vscode.WebviewPanel,
+    externalUri: vscode.Uri,
+    browserUri: vscode.Uri
+}
+
+export class PreviewProvider {
+    private openProcesses: IPreviewProcess[] = [];
+    public previewRmd(viewer: vscode.ViewColumn, uri?: vscode.Uri): void {
+        const fileUri = uri ?? vscode.window.activeTextEditor.document.uri;
+        const fileName = fileUri.path.substring(fileUri.path.lastIndexOf('/') + 1);
+        const previewEngine: string = config().get('rmarkdown.previewEngine');
+        const cmd = (
+            `R --silent --slave --no-save --no-restore -e "${previewEngine}('${fileUri.path}')"`
+        );
+
+        let reg: RegExp = undefined;
+        let call = undefined;
+
+        // the regex can be extended in the future for other
+        // calls
+        switch (previewEngine) {
+            // the rmarkdown::run url is of the structure:
+            // http://127.0.0.1:port/file.Rmd
+            case 'rmarkdown::run': {
+                reg = /(?<=http:\/\/)[0-9.:]*/g;
+                break;
+            }
+            // the inf_mr output url is of the structure:
+            // http://127.0.0.1:port/path/to/file.html
+            case 'xaringan::inf_mr' || 'xaringan::infinite_moon_reader': {
+                reg = /(?<=http:\/\/)(.*)(?=\.html)/g;
+                break;
+            }
+            default: break;
+        }
+
+
+        if (this.openProcesses.some(e => e.file === fileName)) {
+            this.openProcesses.filter(e => e.file === fileName)[0].panel.reveal();
+        } else {
+            try {
+                call = cp.spawn(cmd, null, { shell: true });
+            } catch (e) {
+                console.error((e as unknown).toString());
+            }
+
+            (call as cp.ChildProcessWithoutNullStreams).stderr.on('data',
+                (data: Buffer) => {
+                    const dat = data.toString('utf8');
+                    const match = reg.exec(dat)?.[0];
+                    const previewUrl = previewEngine === 'rmarkdown::run' ? `http://${match}/${fileName}` : `http://${match}.html`;
+                    if (match) {
+                        void this.showPreview(previewUrl, fileName, call, viewer);
+                    }
+                });
+        }
+    }
+
+    private async showPreview(url: string, title: string, cp: cp.ChildProcessWithoutNullStreams, viewer: vscode.ViewColumn): Promise<void> {
+        console.info(`[showPreview] uri: ${url}`);
+        const uri = vscode.Uri.parse(url);
+        const externalUri = await vscode.env.asExternalUri(uri);
+        const panel = vscode.window.createWebviewPanel(
+            'previewRmd',
+            `Preview ${title}`,
+            {
+                preserveFocus: true,
+                viewColumn: viewer
+            },
+            {
+                enableFindWidget: true,
+                enableScripts: true,
+                retainContextWhenHidden: true,
+            });
+
+        this.openProcesses.push(
+            {
+                cp: cp,
+                file: title,
+                panel: panel,
+                externalUri: externalUri,
+                browserUri: uri
+            }
+        );
+
+        if (isHost()) {
+            await shareBrowser(url, title);
+        }
+
+        // destroy process on closing window
+        panel.onDidDispose(() => {
+            if (isHost()) {
+                closeBrowser(url);
+            }
+            kill(cp.pid);
+            for (const [key, item] of this.openProcesses.entries()) {
+                if (item.file === title) {
+                    this.openProcesses.splice(key);
+                }
+            }
+        });
+
+        panel.webview.html = getBrowserHtml(externalUri);
+    }
+
+}

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -223,16 +223,9 @@ export class RMarkdownPreviewManager {
         }
     }
 
-    public openExternalBrowser(): void {
+    public async openExternalBrowser(): Promise<void> {
         if (this.activePreview) {
-            // void open(
-            //     this.activePreview.preview.outputUri.fsPath,
-            //     {
-            //         app: {
-            //             name: 'firefox'
-            //         }
-            //     }
-            // );
+            await vscode.env.openExternal(this.activePreview?.preview?.outputUri);
         }
     }
 

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -101,18 +101,29 @@ export class PreviewProvider {
 
         // destroy process on closing window
         panel.onDidDispose(() => {
-            if (isHost()) {
-                closeBrowser(url);
-            }
+            void vscode.commands.executeCommand('setContext', 'r.preview.active', false);
             kill(cp.pid);
             for (const [key, item] of this.openProcesses.entries()) {
                 if (item.file === title) {
-                    this.openProcesses.splice(key);
+                    this.openProcesses.splice(key, 1);
                 }
+            }
+            if (isHost()) {
+                closeBrowser(url);
             }
         });
 
+        panel.onDidChangeViewState(({ webviewPanel }) => {
+            void vscode.commands.executeCommand('setContext', 'r.preview.active', webviewPanel.active);
+        });
+
         panel.webview.html = getBrowserHtml(externalUri);
+    }
+
+    public refreshPanel(panel: vscode.WebviewPanel): void {
+        const refreshPanel = this.openProcesses.filter(e => e.panel === panel)[0];
+        refreshPanel.panel.webview.html = '';
+        refreshPanel.panel.webview.html = getBrowserHtml(refreshPanel.externalUri);
     }
 
 }

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -12,7 +12,7 @@ interface IPreviewProcess {
     panel: vscode.WebviewPanel,
 }
 
-export class PreviewProvider {
+export class RMarkdownPreviewManager {
     private openProcesses: IPreviewProcess[] = [];
     private activePreview: vscode.WebviewPanel;
     private activeResource: vscode.Uri;
@@ -77,7 +77,7 @@ export class PreviewProvider {
         }
     }
 
-    public openExternal(): void {
+    public openExternalBrowser(): void {
         if (this.activeExternalResource) {
             void vscode.env.openExternal(this.activeExternalResource);
         }

--- a/src/session.ts
+++ b/src/session.ts
@@ -238,7 +238,7 @@ export async function showBrowser(url: string, title: string, viewer: string | b
     console.info('[showBrowser] Done');
 }
 
-export function getBrowserHtml(uri: Uri) {
+export function getBrowserHtml(uri: Uri): string {
     return `
 <!DOCTYPE html>
 <html lang="en">

--- a/src/session.ts
+++ b/src/session.ts
@@ -238,7 +238,7 @@ export async function showBrowser(url: string, title: string, viewer: string | b
     console.info('[showBrowser] Done');
 }
 
-function getBrowserHtml(uri: Uri) {
+export function getBrowserHtml(uri: Uri) {
     return `
 <!DOCTYPE html>
 <html lang="en">

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,12 +14,11 @@ import { FSWatcher } from 'fs-extra';
 import { config, readContent } from './util';
 import { purgeAddinPickerItems, dispatchRStudioAPICall } from './rstudioapi';
 
-import { rWorkspace, globalRHelp, globalHttpgdManager } from './extension';
+import { extDir, rWorkspace, globalRHelp, globalHttpgdManager } from './extension';
 import { UUID, rHostService, rGuestService, isLiveShare, isHost, isGuestSession, closeBrowser, guestResDir, shareBrowser, openVirtualDoc, shareWorkspace } from './liveshare';
 
 export let globalenv: any;
 let resDir: string;
-export let watcherDir: string;
 export let requestFile: string;
 export let requestLockFile: string;
 let requestTimeStamp: number;
@@ -44,22 +43,16 @@ let activeBrowserExternalUri: Uri;
 export function deploySessionWatcher(extensionPath: string): void {
     console.info(`[deploySessionWatcher] extensionPath: ${extensionPath}`);
     resDir = path.join(extensionPath, 'dist', 'resources');
-    watcherDir = path.join(os.homedir(), '.vscode-R');
 
-    console.info(`[deploySessionWatcher] watcherDir: ${watcherDir}`);
-    if (!fs.existsSync(watcherDir)) {
-        console.info('[deploySessionWatcher] watcherDir not exists, create directory');
-        fs.mkdirSync(watcherDir);
-    }
     const initPath = path.join(extensionPath, 'R', 'init.R');
-    const linkPath = path.join(watcherDir, 'init.R');
+    const linkPath = path.join(extDir, 'init.R');
     fs.writeFileSync(linkPath, `local(source("${initPath.replace(/\\/g, '\\\\')}", chdir = TRUE, local = TRUE))\n`);
 }
 
 export function startRequestWatcher(sessionStatusBarItem: StatusBarItem): void {
     console.info('[startRequestWatcher] Starting');
-    requestFile = path.join(watcherDir, 'request.log');
-    requestLockFile = path.join(watcherDir, 'request.lock');
+    requestFile = path.join(extDir, 'request.log');
+    requestLockFile = path.join(extDir, 'request.lock');
     requestTimeStamp = 0;
     responseTimeStamp = 0;
     if (!fs.existsSync(requestLockFile)) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -231,7 +231,7 @@ export async function showBrowser(url: string, title: string, viewer: string | b
     console.info('[showBrowser] Done');
 }
 
-export function getBrowserHtml(uri: Uri): string {
+function getBrowserHtml(uri: Uri): string {
     return `
 <!DOCTYPE html>
 <html lang="en">

--- a/src/util.ts
+++ b/src/util.ts
@@ -339,3 +339,16 @@ export async function setContext(key: string, value: any): Promise<void> {
         'setContext', key, value
     );
 }
+
+// Helper function used to convert raw text files to html
+export function escapeHtml(source: string): string {
+    const entityMap = new Map<string, string>(Object.entries({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        '\'': '&#39;',
+        '/': '&#x2F;'
+    }));
+    return String(source).replace(/[&<>"'/]/g, (s: string) => entityMap.get(s) || '');
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -230,17 +230,17 @@ export async function executeAsTask(name: string, command: string, args?: string
 // executes a callback and shows a 'busy' progress bar during the execution
 // synchronous callbacks are converted to async to properly render the progress bar
 // default location is in the help pages tree view
-export async function doWithProgress<T>(cb: () => T | Promise<T>, location: string | vscode.ProgressLocation = 'rHelpPages', title?: string): Promise<T> {
+export async function doWithProgress<T>(cb: (token?: vscode.CancellationToken) => T | Promise<T>, location: string | vscode.ProgressLocation = 'rHelpPages', title?: string, cancellable?: boolean): Promise<T> {
     const location2 = (typeof location === 'string' ? { viewId: location } : location);
     const options: vscode.ProgressOptions = {
         location: location2,
-        cancellable: false,
+        cancellable: cancellable ?? false,
         title: title
     };
     let ret: T;
-    await vscode.window.withProgress(options, async () => {
+    await vscode.window.withProgress(options, async (_progress, token) => {
         const retPromise = new Promise<T>((resolve) => setTimeout(() => {
-            const ret = cb();
+            const ret = cb(token);
             resolve(ret);
         }));
         ret = await retPromise;

--- a/src/util.ts
+++ b/src/util.ts
@@ -230,11 +230,12 @@ export async function executeAsTask(name: string, command: string, args?: string
 // executes a callback and shows a 'busy' progress bar during the execution
 // synchronous callbacks are converted to async to properly render the progress bar
 // default location is in the help pages tree view
-export async function doWithProgress<T>(cb: () => T | Promise<T>, location: string | vscode.ProgressLocation = 'rHelpPages'): Promise<T> {
+export async function doWithProgress<T>(cb: () => T | Promise<T>, location: string | vscode.ProgressLocation = 'rHelpPages', title?: string): Promise<T> {
     const location2 = (typeof location === 'string' ? { viewId: location } : location);
     const options: vscode.ProgressOptions = {
         location: location2,
-        cancellable: false
+        cancellable: false,
+        title: title
     };
     let ret: T;
     await vscode.window.withProgress(options, async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,6 +913,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+crypto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
+  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
+
 css-select@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"


### PR DESCRIPTION
# What problem did you solve?
Implements changes suggested by @ManuelHentschel for R Markdown preview. Should not have any change in functionality. 

Changes:
- path -> fsPath
- '/' -> path.sep
- themeBool -> useDarkTheme
- command category 'R' -> 'R Markdown'
- getRPath(false) -> true

Tested on Linux, I don't currently have access to Windows