### PR TITLE
RMD Preview fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Note that the above steps only provide basic code editing functionalities and fe
 
 * [Browser viewer](https://github.com/REditorSupport/vscode-R/wiki/Interactive-viewers#browser-viewer): Viewing interactive [shiny](https://shiny.rstudio.com) apps.
 
-* [R Markdown support](https://github.com/REditorSupport/vscode-R/wiki/R-Markdown): R Markdown chunk highlighting, chunk navigation, and execute commands.
+* [R Markdown support](https://github.com/REditorSupport/vscode-R/wiki/R-Markdown): R Markdown chunk highlighting, chunk navigation, execute commands, and preview.
 
 * [RStudio add-in support](https://github.com/REditorSupport/vscode-R/wiki/RStudio-addin-support): Run supported RStudio add-ins in VS Code with a live R session.
 

--- a/package.json
+++ b/package.json
@@ -874,32 +874,32 @@
       "editor/title": [
         {
           "command": "r.markdown.preview.openExternal",
-          "when": "resourceScheme =~ /webview/ && r.preview.active",
+          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active",
           "group": "navigation@1"
         },
         {
           "command": "r.markdown.preview.showSource",
-          "when": "resourceScheme =~ /webview/ && r.preview.active",
+          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active",
           "group": "navigation@2"
         },
         {
           "command": "r.markdown.preview.toggleStyle",
-          "when": "resourceScheme =~ /webview/ && r.preview.active",
+          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active",
           "group": "navigation@3"
         },
         {
           "command": "r.markdown.preview.refresh",
-          "when": "resourceScheme =~ /webview/ && r.preview.active",
+          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active",
           "group": "navigation@4"
         },
         {
           "command": "r.markdown.preview.enableAutoRefresh",
-          "when": "resourceScheme =~ /webview/ && r.preview.active && !r.preview.autoRefresh",
+          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active && !r.markdown.preview.autoRefresh",
           "group": "navigation@5"
         },
         {
           "command": "r.markdown.preview.disableAutoRefresh",
-          "when": "resourceScheme =~ /webview/ && r.preview.active && r.preview.autoRefresh",
+          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active && r.markdown.preview.autoRefresh",
           "group": "navigation@5"
         },
         {

--- a/package.json
+++ b/package.json
@@ -530,47 +530,47 @@
         "command": "r.markdown.showPreviewToSide",
         "title": "Open Preview to the Side",
         "icon": "$(open-preview)",
-        "category": "R"
+        "category": "R Markdown"
       },
       {
         "command": "r.markdown.showPreview",
         "title": "Open Preview",
         "icon": "$(open-preview)",
-        "category": "R"
+        "category": "R Markdown"
       },
       {
         "command": "r.markdown.preview.refresh",
         "title": "Refresh Preview",
         "icon": "$(refresh)",
-        "category": "R"
+        "category": "R Markdown"
       },
       {
         "command": "r.markdown.preview.openExternal",
         "title": "Open in External Browser",
         "icon": "$(link-external)",
-        "category": "R"
+        "category": "R Markdown"
       },
       {
         "command": "r.markdown.preview.showSource",
         "title": "Show Source",
         "icon": "$(go-to-file)",
-        "category": "R"
+        "category": "R Markdown"
       },
       {
         "title": "Toggle Style",
-        "category": "R",
+        "category": "R Markdown",
         "command": "r.markdown.preview.toggleStyle",
         "icon": "$(symbol-color)"
       },
       {
         "title": "Enable Auto Refresh",
-        "category": "R",
+        "category": "R Markdown",
         "command": "r.markdown.preview.enableAutoRefresh",
         "icon": "$(sync)"
       },
       {
         "title": "Disable Auto Refresh",
-        "category": "R",
+        "category": "R Markdown",
         "command": "r.markdown.preview.disableAutoRefresh",
         "icon": "$(sync-ignored)"
       },

--- a/package.json
+++ b/package.json
@@ -527,31 +527,31 @@
         "command": "r.goToNextChunk"
       },
       {
-        "command": "r.markdown.showPreviewToSide",
+        "command": "r.rmarkdown.showPreviewToSide",
         "title": "Open Preview to the Side",
         "icon": "$(open-preview)",
         "category": "R Markdown"
       },
       {
-        "command": "r.markdown.showPreview",
+        "command": "r.rmarkdown.showPreview",
         "title": "Open Preview",
         "icon": "$(open-preview)",
         "category": "R Markdown"
       },
       {
-        "command": "r.markdown.preview.refresh",
+        "command": "r.rmarkdown.preview.refresh",
         "title": "Refresh Preview",
         "icon": "$(refresh)",
         "category": "R Markdown"
       },
       {
-        "command": "r.markdown.preview.openExternal",
+        "command": "r.rmarkdown.preview.openExternal",
         "title": "Open in External Browser",
         "icon": "$(link-external)",
         "category": "R Markdown"
       },
       {
-        "command": "r.markdown.preview.showSource",
+        "command": "r.rmarkdown.preview.showSource",
         "title": "Show Source",
         "icon": "$(go-to-file)",
         "category": "R Markdown"
@@ -559,19 +559,19 @@
       {
         "title": "Toggle Style",
         "category": "R Markdown",
-        "command": "r.markdown.preview.toggleStyle",
+        "command": "r.rmarkdown.preview.toggleStyle",
         "icon": "$(symbol-color)"
       },
       {
         "title": "Enable Auto Refresh",
         "category": "R Markdown",
-        "command": "r.markdown.preview.enableAutoRefresh",
+        "command": "r.rmarkdown.preview.enableAutoRefresh",
         "icon": "$(sync)"
       },
       {
         "title": "Disable Auto Refresh",
         "category": "R Markdown",
-        "command": "r.markdown.preview.disableAutoRefresh",
+        "command": "r.rmarkdown.preview.disableAutoRefresh",
         "icon": "$(sync-ignored)"
       },
       {
@@ -847,13 +847,13 @@
         "when": "editorTextFocus && editorLangId == 'r'"
       },
       {
-        "command": "r.markdown.showPreviewToSide",
+        "command": "r.rmarkdown.showPreviewToSide",
         "key": "Ctrl+k v",
         "mac": "cmd+k v",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
-        "command": "r.markdown.showPreview",
+        "command": "r.rmarkdown.showPreview",
         "key": "Ctrl+shift+v",
         "mac": "cmd+shift+v",
         "when": "editorTextFocus && editorLangId == 'rmd'"
@@ -873,33 +873,33 @@
       ],
       "editor/title": [
         {
-          "command": "r.markdown.preview.openExternal",
-          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active",
+          "command": "r.rmarkdown.preview.openExternal",
+          "when": "resourceScheme =~ /webview/ && r.rmarkdown.preview.active",
           "group": "navigation@1"
         },
         {
-          "command": "r.markdown.preview.showSource",
-          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active",
+          "command": "r.rmarkdown.preview.showSource",
+          "when": "resourceScheme =~ /webview/ && r.rmarkdown.preview.active",
           "group": "navigation@2"
         },
         {
-          "command": "r.markdown.preview.toggleStyle",
-          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active",
+          "command": "r.rmarkdown.preview.toggleStyle",
+          "when": "resourceScheme =~ /webview/ && r.rmarkdown.preview.active",
           "group": "navigation@3"
         },
         {
-          "command": "r.markdown.preview.refresh",
-          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active",
+          "command": "r.rmarkdown.preview.refresh",
+          "when": "resourceScheme =~ /webview/ && r.rmarkdown.preview.active",
           "group": "navigation@4"
         },
         {
-          "command": "r.markdown.preview.enableAutoRefresh",
-          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active && !r.markdown.preview.autoRefresh",
+          "command": "r.rmarkdown.preview.enableAutoRefresh",
+          "when": "resourceScheme =~ /webview/ && r.rmarkdown.preview.active && !r.rmarkdown.preview.autoRefresh",
           "group": "navigation@5"
         },
         {
-          "command": "r.markdown.preview.disableAutoRefresh",
-          "when": "resourceScheme =~ /webview/ && r.markdown.preview.active && r.markdown.preview.autoRefresh",
+          "command": "r.rmarkdown.preview.disableAutoRefresh",
+          "when": "resourceScheme =~ /webview/ && r.rmarkdown.preview.active && r.rmarkdown.preview.autoRefresh",
           "group": "navigation@5"
         },
         {
@@ -998,8 +998,8 @@
           "command": "r.plot.openUrl"
         },
         {
-          "command": "r.markdown.showPreviewToSide",
-          "alt": "r.markdown.showPreview",
+          "command": "r.rmarkdown.showPreviewToSide",
+          "alt": "r.rmarkdown.showPreview",
           "when": "editorLangId == rmd",
           "group": "navigation"
         }
@@ -1139,7 +1139,7 @@
       ],
       "explorer/context": [
         {
-          "command": "r.markdown.showPreview",
+          "command": "r.rmarkdown.showPreview",
           "when": "resourceLangId == rmd",
           "group": "navigation"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,14 +84,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.goToNextChunk': rmarkdown.goToNextChunk,
         'r.runChunks': rTerminal.runChunksInTerm,
 
-        'r.markdown.showPreviewToSide': () => rMarkdownPreview.previewRmd(vscode.ViewColumn.Beside),
-        'r.markdown.showPreview': (uri: vscode.Uri) => rMarkdownPreview.previewRmd(vscode.ViewColumn.Active, uri),
-        'r.markdown.preview.refresh': () => rMarkdownPreview.updatePreview(),
-        'r.markdown.preview.openExternal': () => void rMarkdownPreview.openExternalBrowser(),
-        'r.markdown.preview.showSource': () => rMarkdownPreview.showSource(),
-        'r.markdown.preview.toggleStyle': () => rMarkdownPreview.toggleTheme(),
-        'r.markdown.preview.enableAutoRefresh': () => rMarkdownPreview.enableAutoRefresh(),
-        'r.markdown.preview.disableAutoRefresh': () => rMarkdownPreview.disableAutoRefresh(),
+        'r.rmarkdown.showPreviewToSide': () => rMarkdownPreview.previewRmd(vscode.ViewColumn.Beside),
+        'r.rmarkdown.showPreview': (uri: vscode.Uri) => rMarkdownPreview.previewRmd(vscode.ViewColumn.Active, uri),
+        'r.rmarkdown.preview.refresh': () => rMarkdownPreview.updatePreview(),
+        'r.rmarkdown.preview.openExternal': () => void rMarkdownPreview.openExternalBrowser(),
+        'r.rmarkdown.preview.showSource': () => rMarkdownPreview.showSource(),
+        'r.rmarkdown.preview.toggleStyle': () => rMarkdownPreview.toggleTheme(),
+        'r.rmarkdown.preview.enableAutoRefresh': () => rMarkdownPreview.enableAutoRefresh(),
+        'r.rmarkdown.preview.disableAutoRefresh': () => rMarkdownPreview.disableAutoRefresh(),
 
         // editor independent commands
         'r.createGitignore': rGitignore.createGitignore,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
         'r.markdown.showPreviewToSide': () => rMarkdownPreview.previewRmd(vscode.ViewColumn.Beside),
         'r.markdown.showPreview': (uri: vscode.Uri) => rMarkdownPreview.previewRmd(vscode.ViewColumn.Active, uri),
-        'r.markdown.preview.refresh': () => rMarkdownPreview.refreshPanel(),
+        'r.markdown.preview.refresh': () => rMarkdownPreview.updatePreview(),
         'r.markdown.preview.openExternal': () => void rMarkdownPreview.openExternalBrowser(),
         'r.markdown.preview.showSource': () => rMarkdownPreview.showSource(),
         'r.markdown.preview.toggleStyle': () => rMarkdownPreview.toggleTheme(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,6 @@
 import * as vscode from 'vscode';
 import * as os from 'os';
 import path = require('path');
-import fs = require('fs');
 
 // functions etc. implemented in this extension
 import * as preview from './preview';
@@ -25,8 +24,8 @@ import * as httpgdViewer from './plotViewer';
 import { RMarkdownPreviewManager } from './rmarkdown/preview';
 
 // global objects used in other files
-export const extensionDirectory: string = path.join(os.homedir(), '.vscode-R');
-export const temporaryDirectory: string = path.join(extensionDirectory, 'tmp');
+export const extensionDirectory = (): string => util.getDir(path.join(os.homedir(), '.vscode-R'));
+export const temporaryDirectory = (): string => util.getDir(path.join(extensionDirectory(), 'tmp'));
 export let rWorkspace: workspaceViewer.WorkspaceDataProvider | undefined = undefined;
 export let globalRHelp: rHelp.RHelp | undefined = undefined;
 export let extensionContext: vscode.ExtensionContext;
@@ -36,14 +35,6 @@ export let rMarkdownPreview: RMarkdownPreviewManager | undefined = undefined;
 
 // Called (once) when the extension is activated
 export async function activate(context: vscode.ExtensionContext): Promise<apiImplementation.RExtensionImplementation> {
-    if (!fs.existsSync(extensionDirectory)) {
-        fs.mkdirSync(extensionDirectory);
-    }
-
-    if (!fs.existsSync(temporaryDirectory)) {
-        fs.mkdirSync(temporaryDirectory);
-    }
-
     // create a new instance of RExtensionImplementation
     // is used to export an interface to the help panel
     // this export is used e.g. by vscode-r-debugger to show the help panel from within debug sessions

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,8 +24,8 @@ import * as httpgdViewer from './plotViewer';
 import { RMarkdownPreviewManager } from './rmarkdown/preview';
 
 // global objects used in other files
-export const extensionDirectory = (): string => util.getDir(path.join(os.homedir(), '.vscode-R'));
-export const temporaryDirectory = (): string => util.getDir(path.join(extensionDirectory(), 'tmp'));
+export const homeExtDir = (): string => util.getDir(path.join(os.homedir(), '.vscode-R'));
+export const tmpDir = (): string => util.getDir(path.join(homeExtDir(), 'tmp'));
 export let rWorkspace: workspaceViewer.WorkspaceDataProvider | undefined = undefined;
 export let globalRHelp: rHelp.RHelp | undefined = undefined;
 export let extensionContext: vscode.ExtensionContext;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,8 +25,8 @@ import * as httpgdViewer from './plotViewer';
 import { RMarkdownPreviewManager } from './rmarkdown/preview';
 
 // global objects used in other files
-export const extDir: string = path.join(os.homedir(), '.vscode-R');
-export const tmpDir: string = path.join(extDir, 'tmp');
+export const extensionDirectory: string = path.join(os.homedir(), '.vscode-R');
+export const temporaryDirectory: string = path.join(extensionDirectory, 'tmp');
 export let rWorkspace: workspaceViewer.WorkspaceDataProvider | undefined = undefined;
 export let globalRHelp: rHelp.RHelp | undefined = undefined;
 export let extensionContext: vscode.ExtensionContext;
@@ -36,12 +36,12 @@ export let rMarkdownPreview: RMarkdownPreviewManager | undefined = undefined;
 
 // Called (once) when the extension is activated
 export async function activate(context: vscode.ExtensionContext): Promise<apiImplementation.RExtensionImplementation> {
-    if (!fs.existsSync(extDir)) {
-        fs.mkdirSync(extDir);
+    if (!fs.existsSync(extensionDirectory)) {
+        fs.mkdirSync(extensionDirectory);
     }
 
-    if (!fs.existsSync(tmpDir)) {
-        fs.mkdirSync(tmpDir);
+    if (!fs.existsSync(temporaryDirectory)) {
+        fs.mkdirSync(temporaryDirectory);
     }
 
     // create a new instance of RExtensionImplementation

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -124,7 +124,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
                     R_PROFILE_USER_OLD: process.env.R_PROFILE_USER,
                     R_PROFILE_USER: newRprofile,
                     VSCODE_INIT_R: initR,
-                    VSCODE_WATCHER_DIR: extensionDirectory
+                    VSCODE_WATCHER_DIR: extensionDirectory()
                 };
             }
             rTerm = vscode.window.createTerminal(termOptions);

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -6,7 +6,7 @@ import { isDeepStrictEqual } from 'util';
 
 import * as vscode from 'vscode';
 
-import { extensionContext, extensionDirectory } from './extension';
+import { extensionContext, homeExtDir } from './extension';
 import * as util from './util';
 import * as selection from './selection';
 import { getSelection } from './selection';
@@ -124,7 +124,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
                     R_PROFILE_USER_OLD: process.env.R_PROFILE_USER,
                     R_PROFILE_USER: newRprofile,
                     VSCODE_INIT_R: initR,
-                    VSCODE_WATCHER_DIR: extensionDirectory()
+                    VSCODE_WATCHER_DIR: homeExtDir()
                 };
             }
             rTerm = vscode.window.createTerminal(termOptions);

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -6,7 +6,7 @@ import { isDeepStrictEqual } from 'util';
 
 import * as vscode from 'vscode';
 
-import { extensionContext, extDir } from './extension';
+import { extensionContext, extensionDirectory } from './extension';
 import * as util from './util';
 import * as selection from './selection';
 import { getSelection } from './selection';
@@ -124,7 +124,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
                     R_PROFILE_USER_OLD: process.env.R_PROFILE_USER,
                     R_PROFILE_USER: newRprofile,
                     VSCODE_INIT_R: initR,
-                    VSCODE_WATCHER_DIR: extDir
+                    VSCODE_WATCHER_DIR: extensionDirectory
                 };
             }
             rTerm = vscode.window.createTerminal(termOptions);

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -9,7 +9,7 @@ import crypto = require('crypto');
 
 
 import { config, doWithProgress, getRpath, readContent, setContext, escapeHtml } from '../util';
-import { extensionContext, tmpDir } from '../extension';
+import { extensionContext, temporaryDirectory } from '../extension';
 
 class RMarkdownPreview extends vscode.Disposable {
     title: string;
@@ -24,12 +24,12 @@ class RMarkdownPreview extends vscode.Disposable {
 
     constructor(title: string, cp: cp.ChildProcessWithoutNullStreams, panel: vscode.WebviewPanel,
         resourceViewColumn: vscode.ViewColumn, outputUri: vscode.Uri, uri: vscode.Uri,
-        RMarkdownPreviewManager: RMarkdownPreviewManager, themeBool: boolean, autoRefresh: boolean) {
+        RMarkdownPreviewManager: RMarkdownPreviewManager, useDarkTheme: boolean, autoRefresh: boolean) {
         super(() => {
             this.cp?.kill('SIGKILL');
             this.panel?.dispose();
             this.fileWatcher?.close();
-            fs.removeSync(this.outputUri.path);
+            fs.removeSync(this.outputUri.fsPath);
         });
 
         this.title = title;
@@ -38,26 +38,26 @@ class RMarkdownPreview extends vscode.Disposable {
         this.resourceViewColumn = resourceViewColumn;
         this.outputUri = outputUri;
         this.autoRefresh = autoRefresh;
-        void this.refreshContent(themeBool);
+        void this.refreshContent(useDarkTheme);
         this.startFileWatcher(RMarkdownPreviewManager, uri);
     }
 
-    public styleHtml(themeBool: boolean) {
-        if (themeBool) {
+    public styleHtml(useDarkTheme: boolean) {
+        if (useDarkTheme) {
             this.panel.webview.html = this.htmlDarkContent;
         } else {
             this.panel.webview.html = this.htmlLightContent;
         }
     }
 
-    public async refreshContent(themeBool: boolean) {
-        this.getHtmlContent(await readContent(this.outputUri.path, 'utf8'));
-        this.styleHtml(themeBool);
+    public async refreshContent(useDarkTheme: boolean) {
+        this.getHtmlContent(await readContent(this.outputUri.fsPath, 'utf8'));
+        this.styleHtml(useDarkTheme);
     }
 
     private startFileWatcher(RMarkdownPreviewManager: RMarkdownPreviewManager, uri: vscode.Uri) {
         let fsTimeout: NodeJS.Timeout;
-        const fileWatcher = fs.watch(uri.path, {}, () => {
+        const fileWatcher = fs.watch(uri.fsPath, {}, () => {
             if (this.autoRefresh && !fsTimeout) {
                 fsTimeout = setTimeout(() => { fsTimeout = null; }, 1000);
                 void RMarkdownPreviewManager.updatePreview(this);
@@ -68,8 +68,7 @@ class RMarkdownPreview extends vscode.Disposable {
 
     private getHtmlContent(htmlContent: string): void {
         let content = htmlContent.replace(/<(\w+)\s+(href|src)="(?!\w+:)/g,
-            `<$1 $2="${String(this.panel.webview.asWebviewUri(vscode.Uri.file(tmpDir)))}/`);
-        this.htmlLightContent = content;
+            `<$1 $2="${String(this.panel.webview.asWebviewUri(vscode.Uri.file(temporaryDirectory)))}/`);
 
         const re = new RegExp('<html[^\\n]*>.*</html>', 'ms');
         const isHtml = !!re.exec(content);
@@ -79,7 +78,9 @@ class RMarkdownPreview extends vscode.Disposable {
             content = `<html><head></head><body><pre>${html}</pre></body></html>`;
         }
 
-        const $ = cheerio.load(this.htmlLightContent);
+        this.htmlLightContent = content;
+
+        const $ = cheerio.load(content);
         const chunkCol = String(config().get('rmarkdown.chunkBackgroundColor'));
 
         // make the output chunks a little lighter to stand out
@@ -164,24 +165,22 @@ export class RMarkdownPreviewManager {
     private rMarkdownOutput: vscode.OutputChannel = vscode.window.createOutputChannel('R Markdown');
 
     // the currently selected RMarkdown preview
-    private activePreview: { uri: vscode.Uri, preview: RMarkdownPreview } = { uri: null, preview: null};
+    private activePreview: { uri: vscode.Uri, preview: RMarkdownPreview } = { uri: null, preview: null };
     // store of all open RMarkdown previews
     private previewStore: RMarkdownPreviewStore = new RMarkdownPreviewStore;
     // uri that are in the process of knitting
     // so that we can't spam the preview button
     private busyUriStore: Set<vscode.Uri> = new Set<vscode.Uri>();
-
-    // todo, better name? enum?
-    private vscodeTheme = true;
+    private useDarkTheme = true;
 
     public async init(): Promise<void> {
-        this.rPath = await getRpath(false);
+        this.rPath = await getRpath(true);
         extensionContext.subscriptions.push(this.previewStore);
     }
 
     public async previewRmd(viewer: vscode.ViewColumn, uri?: vscode.Uri): Promise<void> {
         const fileUri = uri ?? vscode.window.activeTextEditor.document.uri;
-        const fileName = fileUri.path.substring(fileUri.path.lastIndexOf('/') + 1);
+        const fileName = fileUri.fsPath.substring(fileUri.fsPath.lastIndexOf(path.sep) + 1);
         const currentViewColumn: vscode.ViewColumn = vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.Active ?? vscode.ViewColumn.One;
         if (this.busyUriStore.has(fileUri)) {
             return;
@@ -196,9 +195,9 @@ export class RMarkdownPreviewManager {
 
     public refreshPanel(preview?: RMarkdownPreview): void {
         if (preview) {
-            void preview.refreshContent(this.vscodeTheme);
+            void preview.refreshContent(this.useDarkTheme);
         } else if (this.activePreview) {
-            void this.activePreview?.preview?.refreshContent(this.vscodeTheme);
+            void this.activePreview?.preview?.refreshContent(this.useDarkTheme);
         }
     }
 
@@ -221,9 +220,9 @@ export class RMarkdownPreviewManager {
     }
 
     public toggleTheme(): void {
-        this.vscodeTheme = !this.vscodeTheme;
+        this.useDarkTheme = !this.useDarkTheme;
         for (const preview of this.previewStore) {
-            void preview[1].styleHtml(this.vscodeTheme);
+            void preview[1].styleHtml(this.useDarkTheme);
         }
     }
 
@@ -279,8 +278,6 @@ export class RMarkdownPreviewManager {
             cp: cp.ChildProcessWithoutNullStreams,
             wasCancelled?: boolean
         }) => {
-            // todo, this section may need to be cleaned up a bit,
-            // move the non-rejection catch to the await knitDocument?
             if (!rejection.wasCancelled) {
                 void vscode.window.showErrorMessage('There was an error in knitting the document. Please check the R Markdown output stream.');
                 this.rMarkdownOutput.show(true);
@@ -299,12 +296,10 @@ export class RMarkdownPreviewManager {
         return await new Promise<cp.ChildProcessWithoutNullStreams>((resolve, reject) => {
             const lim = '---vsc---';
             const re = new RegExp(`.*${lim}(.*)${lim}.*`, 'ms');
-            const outputFile = path.join(tmpDir, crypto.createHash('sha256').update(fileUri.fsPath).digest('hex') + '.html');
+            const outputFile = path.join(temporaryDirectory, crypto.createHash('sha256').update(fileUri.fsPath).digest('hex') + '.html');
             const cmd = (
                 `${this.rPath} --silent --slave --no-save --no-restore -e ` +
-                `"cat('${lim}',
-                rmarkdown::render('${String(fileUri.path)}', output_format = rmarkdown::html_document(), output_file = '${outputFile}', intermediates_dir = '${tmpDir}'),
-                '${lim}', sep='')"`
+                `"cat('${lim}', rmarkdown::render('${fileUri.fsPath}', output_format = rmarkdown::html_document(), output_file = '${outputFile}', intermediates_dir = '${temporaryDirectory}'), '${lim}', sep='')"`
             );
 
             let childProcess: cp.ChildProcessWithoutNullStreams;
@@ -363,7 +358,7 @@ export class RMarkdownPreviewManager {
         });
     }
 
-    private openPreview(outputUri: vscode.Uri, fileUri: vscode.Uri, title: string, cp: cp.ChildProcessWithoutNullStreams, viewer: vscode.ViewColumn, resourceViewColumn: vscode.ViewColumn, autoRefresh:boolean): void {
+    private openPreview(outputUri: vscode.Uri, fileUri: vscode.Uri, title: string, cp: cp.ChildProcessWithoutNullStreams, viewer: vscode.ViewColumn, resourceViewColumn: vscode.ViewColumn, autoRefresh: boolean): void {
         const panel = vscode.window.createWebviewPanel(
             'previewRmd',
             `Preview ${title}`,
@@ -375,7 +370,7 @@ export class RMarkdownPreviewManager {
                 enableFindWidget: true,
                 enableScripts: true,
                 retainContextWhenHidden: true,
-                localResourceRoots: [vscode.Uri.file(tmpDir)],
+                localResourceRoots: [vscode.Uri.file(temporaryDirectory)],
             });
 
         // Push the new rmd webview to the open proccesses array,
@@ -390,7 +385,7 @@ export class RMarkdownPreviewManager {
             outputUri,
             fileUri,
             this,
-            this.vscodeTheme,
+            this.useDarkTheme,
             autoRefresh
         );
         this.previewStore.add(fileUri, preview);
@@ -398,7 +393,7 @@ export class RMarkdownPreviewManager {
         // state change
         panel.onDidDispose(() => {
             // clear values
-            this.activePreview = this.activePreview?.preview === preview ? { uri: null, preview: null} : this.activePreview;
+            this.activePreview = this.activePreview?.preview === preview ? { uri: null, preview: null } : this.activePreview;
             void setContext('r.preview.active', false);
             this.previewStore.delete(fileUri);
         });

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -360,14 +360,14 @@ export class RMarkdownPreviewManager {
             childProcess.stderr.on('data', (data: Buffer) => {
                 const dat = data.toString('utf8');
                 this.rMarkdownOutput.appendLine(dat);
-                if (dat.includes('Execution halted')) {
-                    reject({ cp: childProcess, wasCancelled: false });
-                }
             });
 
             childProcess.on('exit', (code, signal) => {
                 this.rMarkdownOutput.appendLine(`[VSC-R] ${fileName} process exited ` +
                     (signal ? `from signal '${signal}'` : `with exit code ${code}`));
+                if (code !== 0) {
+                    reject({ cp: childProcess, wasCancelled: false });
+                }
             });
 
             token?.onCancellationRequested(() => {

--- a/src/session.ts
+++ b/src/session.ts
@@ -45,14 +45,14 @@ export function deploySessionWatcher(extensionPath: string): void {
     resDir = path.join(extensionPath, 'dist', 'resources');
 
     const initPath = path.join(extensionPath, 'R', 'init.R');
-    const linkPath = path.join(extensionDirectory, 'init.R');
+    const linkPath = path.join(extensionDirectory(), 'init.R');
     fs.writeFileSync(linkPath, `local(source("${initPath.replace(/\\/g, '\\\\')}", chdir = TRUE, local = TRUE))\n`);
 }
 
 export function startRequestWatcher(sessionStatusBarItem: StatusBarItem): void {
     console.info('[startRequestWatcher] Starting');
-    requestFile = path.join(extensionDirectory, 'request.log');
-    requestLockFile = path.join(extensionDirectory, 'request.lock');
+    requestFile = path.join(extensionDirectory(), 'request.log');
+    requestLockFile = path.join(extensionDirectory(), 'request.lock');
     requestTimeStamp = 0;
     responseTimeStamp = 0;
     if (!fs.existsSync(requestLockFile)) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,7 +14,7 @@ import { FSWatcher } from 'fs-extra';
 import { config, readContent } from './util';
 import { purgeAddinPickerItems, dispatchRStudioAPICall } from './rstudioapi';
 
-import { extDir, rWorkspace, globalRHelp, globalHttpgdManager } from './extension';
+import { extensionDirectory, rWorkspace, globalRHelp, globalHttpgdManager } from './extension';
 import { UUID, rHostService, rGuestService, isLiveShare, isHost, isGuestSession, closeBrowser, guestResDir, shareBrowser, openVirtualDoc, shareWorkspace } from './liveshare';
 
 export let globalenv: any;
@@ -45,14 +45,14 @@ export function deploySessionWatcher(extensionPath: string): void {
     resDir = path.join(extensionPath, 'dist', 'resources');
 
     const initPath = path.join(extensionPath, 'R', 'init.R');
-    const linkPath = path.join(extDir, 'init.R');
+    const linkPath = path.join(extensionDirectory, 'init.R');
     fs.writeFileSync(linkPath, `local(source("${initPath.replace(/\\/g, '\\\\')}", chdir = TRUE, local = TRUE))\n`);
 }
 
 export function startRequestWatcher(sessionStatusBarItem: StatusBarItem): void {
     console.info('[startRequestWatcher] Starting');
-    requestFile = path.join(extDir, 'request.log');
-    requestLockFile = path.join(extDir, 'request.lock');
+    requestFile = path.join(extensionDirectory, 'request.log');
+    requestLockFile = path.join(extensionDirectory, 'request.lock');
     requestTimeStamp = 0;
     responseTimeStamp = 0;
     if (!fs.existsSync(requestLockFile)) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,7 +14,7 @@ import { FSWatcher } from 'fs-extra';
 import { config, readContent } from './util';
 import { purgeAddinPickerItems, dispatchRStudioAPICall } from './rstudioapi';
 
-import { extensionDirectory, rWorkspace, globalRHelp, globalHttpgdManager } from './extension';
+import { homeExtDir, rWorkspace, globalRHelp, globalHttpgdManager } from './extension';
 import { UUID, rHostService, rGuestService, isLiveShare, isHost, isGuestSession, closeBrowser, guestResDir, shareBrowser, openVirtualDoc, shareWorkspace } from './liveshare';
 
 export let globalenv: any;
@@ -45,14 +45,14 @@ export function deploySessionWatcher(extensionPath: string): void {
     resDir = path.join(extensionPath, 'dist', 'resources');
 
     const initPath = path.join(extensionPath, 'R', 'init.R');
-    const linkPath = path.join(extensionDirectory(), 'init.R');
+    const linkPath = path.join(homeExtDir(), 'init.R');
     fs.writeFileSync(linkPath, `local(source("${initPath.replace(/\\/g, '\\\\')}", chdir = TRUE, local = TRUE))\n`);
 }
 
 export function startRequestWatcher(sessionStatusBarItem: StatusBarItem): void {
     console.info('[startRequestWatcher] Starting');
-    requestFile = path.join(extensionDirectory(), 'request.log');
-    requestLockFile = path.join(extensionDirectory(), 'request.lock');
+    requestFile = path.join(homeExtDir(), 'request.log');
+    requestLockFile = path.join(homeExtDir(), 'request.lock');
     requestTimeStamp = 0;
     responseTimeStamp = 0;
     if (!fs.existsSync(requestLockFile)) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -352,3 +352,12 @@ export function escapeHtml(source: string): string {
     }));
     return String(source).replace(/[&<>"'/]/g, (s: string) => entityMap.get(s) || '');
 }
+
+// creates a directory if it doesn't exist,
+// returns the input string
+export function getDir(dirPath: string): string {
+    if (!fs.existsSync(dirPath)) {
+        fs.mkdirSync(dirPath);
+    }
+    return dirPath;
+}


### PR DESCRIPTION
Implements changes suggested by @ManuelHentschel for R Markdown preview. Should not have any major change in functionality.

Changes:
- path -> fsPath
- ~~'/' -> path.sep~~
- themeBool -> useDarkTheme
- command category 'R' -> 'R Markdown'
- getRPath(false) -> true
- extDir -> ~~extensionDirectory~~ homeExtDir
- ~~tmpDir -> temporaryDirectory~~
- Handle untitled documents by prompting the user to save the doc prior to rendering
- Less eager directory creation 
- check exit code rather than error message for knitting errors
- refresh now re-knits the doc, rather than refreshing the html

Tested on Linux, I don't currently have access to Windows.
