### PR TITLE
Remove show plot history command

### DIFF
--- a/R/vsc.R
+++ b/R/vsc.R
@@ -176,13 +176,10 @@ if (use_httpgd && "httpgd" %in% .packages(all.available = TRUE)) {
 } else if (use_httpgd) {
   message("Install package `httpgd` to use vscode-R with httpgd!")
 } else if (show_plot) {
-  dir_plot_history <- file.path(dir_session, "images")
-  dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
   plot_file <- file.path(dir_session, "plot.png")
   plot_lock_file <- file.path(dir_session, "plot.lock")
   file.create(plot_file, plot_lock_file, showWarnings = FALSE)
 
-  plot_history_file <- NULL
   plot_updated <- FALSE
   null_dev_id <- c(pdf = 2L)
   null_dev_size <- c(7 + pi, 7 + pi)
@@ -194,8 +191,6 @@ if (use_httpgd && "httpgd" %in% .packages(all.available = TRUE)) {
 
   new_plot <- function() {
     if (check_null_dev()) {
-      plot_history_file <<- file.path(dir_plot_history,
-        format(Sys.time(), "%Y%m%d-%H%M%OS6.png"))
       plot_updated <<- TRUE
     }
   }
@@ -221,9 +216,6 @@ if (use_httpgd && "httpgd" %in% .packages(all.available = TRUE)) {
           on.exit({
             dev.off()
             cat(get_timestamp(), file = plot_lock_file)
-            if (!is.null(plot_history_file)) {
-              file.copy(plot_file, plot_history_file, overwrite = TRUE)
-            }
           })
           replayPlot(record)
         }

--- a/package.json
+++ b/package.json
@@ -442,11 +442,6 @@
         "command": "r.attachActive"
       },
       {
-        "title": "Show Plot History",
-        "category": "R",
-        "command": "r.showPlotHistory"
-      },
-      {
         "title": "Run Command With Selection or Word in Terminal",
         "category": "R",
         "command": "r.runCommandWithSelectionOrWord"
@@ -1418,7 +1413,6 @@
     "datatables.net-bs4": "^1.10.25",
     "datatables.net-fixedheader-jqui": "^3.1.9",
     "ejs": "^3.1.6",
-    "fotorama": "^4.6.4",
     "fs-extra": "^10.0.0",
     "highlight.js": "^10.7.2",
     "jquery": "^3.6.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,7 +105,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.previewDataframe': preview.previewDataframe,
         'r.previewEnvironment': preview.previewEnvironment,
         'r.attachActive': session.attachActive,
-        'r.showPlotHistory': session.showPlotHistory,
         'r.launchAddinPicker': rstudioapi.launchAddinPicker,
 
         // workspace viewer

--- a/src/session.ts
+++ b/src/session.ts
@@ -33,7 +33,6 @@ let plotView: string;
 let plotFile: string;
 let plotLockFile: string;
 let plotTimeStamp: number;
-let plotDir: string;
 let globalEnvWatcher: FSWatcher;
 let plotWatcher: FSWatcher;
 let activeBrowserPanel: WebviewPanel;
@@ -440,68 +439,6 @@ export async function getListHtml(webview: Webview, file: string): Promise<strin
 `;
 }
 
-export async function showPlotHistory(): Promise<void> {
-    if (config().get<boolean>('sessionWatcher')) {
-        if (plotDir === undefined) {
-            void window.showErrorMessage('No session is attached.');
-        } else {
-            const files = await fs.readdir(plotDir);
-            if (files.length > 0) {
-                const panel = window.createWebviewPanel('plotHistory', 'Plot History',
-                    {
-                        preserveFocus: true,
-                        viewColumn: ViewColumn.Active,
-                    },
-                    {
-                        retainContextWhenHidden: true,
-                        enableScripts: true,
-                        localResourceRoots: [Uri.file(resDir), Uri.file(plotDir)],
-                    });
-                const html = getPlotHistoryHtml(panel.webview, files);
-                panel.webview.html = html;
-            } else {
-                void window.showInformationMessage('There is no plot to show yet.');
-            }
-        }
-    } else {
-        void window.showInformationMessage('This command requires that r.sessionWatcher be enabled.');
-    }
-}
-
-function getPlotHistoryHtml(webview: Webview, files: string[]) {
-    const imgs = files
-        .map((file) => `<img src="${String(webview.asWebviewUri(Uri.file(path.join(plotDir, file))))}" />`)
-        .join('\n');
-
-    return `
-<!doctype HTML>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'bootstrap.min.css'))))}" rel="stylesheet">
-  <link href="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'fotorama.css'))))}" rel="stylesheet">
-  <style type="text/css">
-    body {
-        background-color: white;
-    }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="text-center">
-      <div class="fotorama" data-width="100%" data-maxheight="100%" data-nav="thumbs" data-keyboard="true">
-        ${imgs}
-      </div>
-    </div>
-  </div>
-  <script src="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'jquery.min.js'))))}"></script>
-  <script src="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'fotorama.js'))))}"></script>
-</body>
-</html>
-`;
-}
-
 function isFromWorkspace(dir: string) {
     if (workspace.workspaceFolders === undefined) {
         const rel = path.relative(os.homedir(), dir);
@@ -572,7 +509,6 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                         pid = String(request.pid);
                         sessionDir = path.join(request.tempdir, 'vscode-R');
                         workingDir = request.wd;
-                        plotDir = path.join(sessionDir, 'images');
                         plotView = String(request.plot);
                         console.info(`[updateRequest] attach PID: ${pid}`);
                         sessionStatusBarItem.text = `R: ${pid}`;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,10 +50,6 @@ module.exports = {
       { from: './node_modules/datatables.net-fixedheader/js/dataTables.fixedHeader.min.js', to: 'resources' },
       { from: './node_modules/datatables.net-fixedheader-jqui/js/fixedHeader.jqueryui.min.js', to: 'resources' },
       { from: './node_modules/datatables.net-fixedheader-jqui/css/fixedHeader.jqueryui.min.css', to: 'resources' },
-      { from: './node_modules/fotorama/fotorama.js', to: 'resources' },
-      { from: './node_modules/fotorama/fotorama.css', to: 'resources' },
-      { from: './node_modules/fotorama/fotorama.png', to: 'resources' },
-      { from: './node_modules/fotorama/fotorama@2x.png', to: 'resources' },
     ]
   }),
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,13 +1405,6 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-fotorama@^4.6.4:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/fotorama/-/fotorama-4.6.4.tgz#7376961b6c7eeccb6c76411aceba7795ffe22eae"
-  integrity sha1-c3aWG2x+7MtsdkEazrp3lf/iLq4=
-  dependencies:
-    jquery ">=1.8"
-
 fs-extra@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
@@ -1753,7 +1746,7 @@ jquery.json-viewer@^1.4.0:
   resolved "https://registry.yarnpkg.com/jquery.json-viewer/-/jquery.json-viewer-1.4.0.tgz#6e0ede8ae3239cb20ac359f663b9aae4ec8a9d94"
   integrity sha512-6H1U/w+/8vMwDH5Im0OveuKPZ1fZWy7hgvR3Cn+HeamQIoWrVqBuRaE2TF/xEc6Hmi3vhQVRqZBmYGKTdOo2tw==
 
-jquery@>=1.7, jquery@>=1.8, jquery@^3.6.0:
+jquery@>=1.7, jquery@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==


### PR DESCRIPTION
# What problem did you solve?

Closes #686 

Since the old plot viewer based on png replays is quite limited and in some cases it does not produce desired result (e.g. plot in a for loop, multi-page plots), I suggest we remove this feature in favor of the httpgd approach.

This PR removes the command "R: Show plot history" and related code that copies replayed png files in a history folder and removes the dependency on `fotorama`.

For better plot history support, use [httpgd](https://github.com/nx10/httpgd) instead as introduced in the [wiki](https://github.com/REditorSupport/vscode-R/wiki/Plot-viewer).

## (If you do not have screenshot) How can I check this pull request?

Disable httpgd plot viewer.

```r
plot(rnorm(100))
```

should correctly produce a png file which is open in a new tab. The "R: Show plot history" command is gone.
