### PR TITLE
Update r.rmarkdown.codeLensCommands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1193,13 +1193,25 @@
         "r.rmarkdown.codeLensCommands": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "r.selectCurrentChunk",
+              "r.runCurrentChunk",
+              "r.runAboveChunks",
+              "r.runCurrentAndBelowChunks",
+              "r.runBelowChunks",
+              "r.runAllChunks",
+              "r.runPreviousChunk",
+              "r.runNextChunk",
+              "r.goToPreviousChunk",
+              "r.goToNextChunk"
+            ]
           },
           "default": [
             "r.runCurrentChunk",
             "r.runAboveChunks"
           ],
-          "description": "Customize RMarkdown CodeLens, which are inline commands/buttons e.g. 'Run Chunk' shown on the first line of each code chunk. Available commands:\n\nr.selectCurrentChunk\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.runPreviousChunk\nr.runNextChunk\nr.goToPreviousChunk\nr.goToNextChunk\n\n----------------------------------\nCustomize both the commands AND its orders (that is, CodeLens respect user-specified orders):"
+          "description": "Customize RMarkdown CodeLens, which are inline commands/buttons e.g. 'Run Chunk' shown on the first line of each code chunk. \nCustomize both the commands AND its orders (that is, CodeLens respect user-specified orders):"
         },
         "r.rmarkdown.enableCodeLens": {
           "type": "boolean",


### PR DESCRIPTION
# What problem did you solve?
The current r.rmarkdown.codeLensCommands setting is prone to typos. This PR uses an enum to restrict the input. As this does not change the setting's input type, user settings should be unaffected.

![image](https://user-images.githubusercontent.com/60372411/125753046-a1a2ea32-1dfb-4481-b3f1-06d0c09329ba.png)