### PR TITLE
Add full window mode for plots

### DIFF
--- a/html/httpgd/index.js
+++ b/html/httpgd/index.js
@@ -21,9 +21,14 @@ function getSmallPlots() {
     return smallPlots;
 }
 let isHandlerDragging = false;
+let isFullWindow = false;
 function postResizeMessage(userTriggered = false) {
-    const newHeight = largePlotDiv.clientHeight;
-    const newWidth = largePlotDiv.clientWidth;
+    let newHeight = largePlotDiv.clientHeight;
+    let newWidth = largePlotDiv.clientWidth;
+    if (isFullWindow) {
+        newHeight = window.innerHeight;
+        newWidth = window.innerWidth;
+    }
     if (userTriggered || newHeight !== oldHeight || newWidth !== oldWidth) {
         const msg = {
             message: 'resize',
@@ -65,6 +70,9 @@ window.addEventListener('message', (ev) => {
     }
     else if (msg.message === 'togglePreviewPlotLayout') {
         togglePreviewPlotLayout(msg.style);
+    }
+    else if (msg.message === 'toggleFullWindow') {
+        toggleFullWindowMode(msg.useFullWindow);
     }
 });
 function addPlot(html) {
@@ -124,10 +132,21 @@ function togglePreviewPlotLayout(newStyle) {
     smallPlotDiv.classList.remove('multirow', 'scroll', 'hidden');
     smallPlotDiv.classList.add(newStyle);
 }
+function toggleFullWindowMode(useFullWindow) {
+    isFullWindow = useFullWindow;
+    if (useFullWindow) {
+        document.body.classList.add('fullWindow');
+    }
+    else {
+        document.body.classList.remove('fullWindow');
+    }
+    postResizeMessage(true);
+}
 ////
 // On window load
 ////
 window.onload = () => {
+    isFullWindow = document.body.classList.contains('fullWindow');
     largePlotDiv.style.height = `${largeSvg.clientHeight}px`;
     postResizeMessage(true);
 };
@@ -136,7 +155,7 @@ window.onload = () => {
 ////
 document.addEventListener('mousedown', (e) => {
     // If mousedown event is fired from .handler, toggle flag to true
-    if (e.target === handler) {
+    if (!isFullWindow && e.target === handler) {
         isHandlerDragging = true;
         handler.classList.add('dragging');
         document.body.style.cursor = 'ns-resize';
@@ -144,7 +163,7 @@ document.addEventListener('mousedown', (e) => {
 });
 document.addEventListener('mousemove', (e) => {
     // Don't do anything if dragging flag is false
-    if (!isHandlerDragging) {
+    if (isFullWindow || !isHandlerDragging) {
         return false;
     }
     // postLogMessage('mousemove');

--- a/html/httpgd/index.js
+++ b/html/httpgd/index.js
@@ -136,6 +136,7 @@ function toggleFullWindowMode(useFullWindow) {
     isFullWindow = useFullWindow;
     if (useFullWindow) {
         document.body.classList.add('fullWindow');
+        window.scrollTo(0, 0);
     }
     else {
         document.body.classList.remove('fullWindow');
@@ -146,7 +147,6 @@ function toggleFullWindowMode(useFullWindow) {
 // On window load
 ////
 window.onload = () => {
-    isFullWindow = document.body.classList.contains('fullWindow');
     largePlotDiv.style.height = `${largeSvg.clientHeight}px`;
     postResizeMessage(true);
 };

--- a/html/httpgd/index.ts
+++ b/html/httpgd/index.ts
@@ -176,6 +176,7 @@ function toggleFullWindowMode(useFullWindow): void {
   isFullWindow = useFullWindow;
   if(useFullWindow){
     document.body.classList.add('fullWindow');
+    window.scrollTo(0, 0);
   } else {
     document.body.classList.remove('fullWindow');
   }
@@ -187,7 +188,6 @@ function toggleFullWindowMode(useFullWindow): void {
 ////
 
 window.onload = () => {
-  isFullWindow = document.body.classList.contains('fullWindow');
   largePlotDiv.style.height = `${largeSvg.clientHeight}px`;
   postResizeMessage(true);
 };

--- a/html/httpgd/style.css
+++ b/html/httpgd/style.css
@@ -12,6 +12,10 @@ body {
     padding-left: 1px;
     padding-right: 1px;
 } 
+body.fullWindow {
+    overflow-x: hidden;
+    overflow-y: hidden;
+}
 
 svg {
     user-select: none;
@@ -29,6 +33,13 @@ svg {
     overflow-x: auto;
     overflow-y: hidden;
     padding: 10px;
+    width: 100%;
+    height: 100%;
+}
+body.fullWindow #largePlot {
+    overflow-x: hidden;
+    width: 100vw !important;
+    height: 100vh !important;
 }
 
 /* Dragbar to resize main plot: */
@@ -42,9 +53,15 @@ svg {
     transition: background-color .1s ease-out;
     transition-delay: .2s;
 }
+body.fullWindow #handler {
+    display: none;
+}
 
 #placeholder {
     height: 95vh;
+}
+body.fullWindow #placeHolder {
+    display: none;
 }
 
 /* Plot history: */
@@ -57,6 +74,9 @@ svg {
     flex-direction: row;
     overflow-y: hidden;
     padding: 10px;
+}
+body.fullWindow #smallPlots {
+    display: none;
 }
 
 #smallPlots.multirow {

--- a/html/httpgd/webviewMessages.d.ts
+++ b/html/httpgd/webviewMessages.d.ts
@@ -41,6 +41,11 @@ interface ToggleStyleMessage extends IMessage {
   useOverwrites: boolean
 }
 
+interface ToggleFullWindowMessage extends IMessage {
+  message: 'toggleFullWindow',
+  useFullWindow: boolean
+}
+
 type PreviewPlotLayout = 'multirow' | 'scroll' | 'hidden';
 interface PreviewPlotLayoutMessage extends IMessage {
   message: 'togglePreviewPlotLayout',
@@ -57,5 +62,5 @@ interface AddPlotMessage extends IMessage {
   html: string
 }
 
-type InMessage = UpdatePlotMessage | FocusPlotMessage | ToggleStyleMessage | HidePlotMessage | AddPlotMessage | PreviewPlotLayoutMessage;
+type InMessage = UpdatePlotMessage | FocusPlotMessage | ToggleStyleMessage | HidePlotMessage | AddPlotMessage | PreviewPlotLayoutMessage | ToggleFullWindowMessage;
 

--- a/package.json
+++ b/package.json
@@ -692,6 +692,12 @@
         "icon": "$(symbol-color)"
       },
       {
+        "title": "Toggle Full Window Mode",
+        "category": "R Plot",
+        "command": "r.plot.toggleFullWindow",
+        "icon": "$(screen-full)"
+      },
+      {
         "title": "Toggle Preview Plot Layout",
         "category": "R Plot",
         "command": "r.plot.togglePreviewPlots",
@@ -936,6 +942,11 @@
           "group": "navigation",
           "when": "resourceScheme =~ /webview/ && r.plot.active",
           "command": "r.plot.toggleStyle"
+        },
+        {
+          "group": "navigation",
+          "when": "resourceScheme =~ /webview/ && r.plot.active",
+          "command": "r.plot.toggleFullWindow"
         },
         {
           "group": "httpgd",

--- a/package.json
+++ b/package.json
@@ -1359,6 +1359,11 @@
           ],
           "markdownDescription": "How to display plot previews if more than one row required."
         },
+        "r.plot.defaults.fullWindowMode": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Whether to use full window mode when launching the plot viewer."
+        },
         "r.plot.timing.resizeInterval": {
           "type": "number",
           "default": 100,

--- a/src/plotViewer/httpgdTypes.d.ts
+++ b/src/plotViewer/httpgdTypes.d.ts
@@ -86,6 +86,7 @@ export interface HttpgdViewerOptions {
     viewColumn?: vscode.ViewColumn;
     htmlRoot: string;
     stripStyles?: boolean;
+    fullWindow?: boolean;
     previewPlotLayout?: PreviewPlotLayout,
     resizeTimeoutLength?: number;
     refreshTimeoutLength?: number;

--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -12,7 +12,7 @@ import { config, setContext } from '../util';
 
 import { extensionContext } from '../extension';
 
-import { FocusPlotMessage, InMessage, OutMessage, ToggleStyleMessage, UpdatePlotMessage, HidePlotMessage, AddPlotMessage, PreviewPlotLayout, PreviewPlotLayoutMessage } from './webviewMessages';
+import { FocusPlotMessage, InMessage, OutMessage, ToggleStyleMessage, UpdatePlotMessage, HidePlotMessage, AddPlotMessage, PreviewPlotLayout, PreviewPlotLayoutMessage, ToggleFullWindowMessage } from './webviewMessages';
 
 import { isHost, rHostService, shareBrowser } from '../liveshare';
 
@@ -22,6 +22,7 @@ const commands = [
     'openExternal',
     'showIndex',
     'toggleStyle',
+    'toggleFullWindow',
     'togglePreviewPlots',
     'exportPlot',
     'nextPlot',
@@ -209,6 +210,9 @@ export class HttpgdManager {
             } case 'openExternal': {
                 void viewer.openExternal();
                 break;
+            } case 'toggleFullWindow': {
+                void viewer.toggleFullWindow();
+                break;
             } default: {
                 break;
             }
@@ -267,6 +271,9 @@ export class HttpgdViewer implements IHttpgdViewer {
 
     readonly defaultPreviewPlotLayout: PreviewPlotLayout = 'multirow';
     previewPlotLayout: PreviewPlotLayout;
+    
+    readonly defaultFullWindow: boolean = false;
+    fullWindow: boolean;
 
     // Custom file to be used instead of `styleOverwrites.css`
     customOverwriteCssPath?: string;
@@ -360,6 +367,8 @@ export class HttpgdViewer implements IHttpgdViewer {
         this.stripStyles = this.defaultStripStyles;
         this.defaultPreviewPlotLayout = options.previewPlotLayout ?? this.defaultPreviewPlotLayout;
         this.previewPlotLayout = this.defaultPreviewPlotLayout;
+        this.defaultFullWindow = options.fullWindow ?? this.defaultFullWindow;
+        this.fullWindow = this.defaultFullWindow;
         this.resizeTimeoutLength = options.refreshTimeoutLength ?? this.resizeTimeoutLength;
         this.refreshTimeoutLength = options.refreshTimeoutLength ?? this.refreshTimeoutLength;
         this.api.start();
@@ -465,6 +474,15 @@ export class HttpgdViewer implements IHttpgdViewer {
         const msg: ToggleStyleMessage = {
             message: 'toggleStyle',
             useOverwrites: this.stripStyles
+        };
+        this.postWebviewMessage(msg);
+    }
+    
+    public toggleFullWindow(force?: boolean): void {
+        this.fullWindow = force ?? !this.fullWindow;
+        const msg: ToggleFullWindowMessage = {
+            message: 'toggleFullWindow',
+            useFullWindow: this.fullWindow
         };
         this.postWebviewMessage(msg);
     }

--- a/src/plotViewer/webviewMessages.d.ts
+++ b/src/plotViewer/webviewMessages.d.ts
@@ -46,6 +46,12 @@ export interface ToggleStyleMessage extends IMessage {
   useOverwrites: boolean
 }
 
+export interface ToggleFullWindowMessage extends IMessage {
+  message: 'toggleFullWindow',
+  useFullWindow: boolean
+}
+
+
 export type PreviewPlotLayout = 'multirow' | 'scroll' | 'hidden';
 export interface PreviewPlotLayoutMessage extends IMessage {
   message: 'togglePreviewPlotLayout',
@@ -62,4 +68,4 @@ export interface AddPlotMessage extends IMessage {
   html: string
 }
 
-export type InMessage = UpdatePlotMessage | FocusPlotMessage | ToggleStyleMessage | HidePlotMessage | AddPlotMessage | PreviewPlotLayoutMessage;
+export type InMessage = UpdatePlotMessage | FocusPlotMessage | ToggleStyleMessage | HidePlotMessage | AddPlotMessage | PreviewPlotLayoutMessage | ToggleFullWindowMessage;


### PR DESCRIPTION
Fix #705 

Adds a menu item "toggle full window mode" to the httpgd plot viewer, which toggles a full window mode.

Todo:
* ~Add a config entry to make it possible to have this as default behavior~