### PR TITLE
Check conflict extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,11 @@ export let rMarkdownPreview: RMarkdownPreviewManager | undefined = undefined;
 
 // Called (once) when the extension is activated
 export async function activate(context: vscode.ExtensionContext): Promise<apiImplementation.RExtensionImplementation> {
+    if (vscode.extensions.getExtension('mikhail-arkhipov.r')) {
+        void vscode.window.showInformationMessage('The R Tools (Mikhail-Arkhipov.r) extension is enabled and will have conflicts with vscode-R. To use vscode-R, please disable or uninstall the extension.');
+        void vscode.commands.executeCommand('workbench.extensions.search', '@installed R Tools');
+    }
+
     // create a new instance of RExtensionImplementation
     // is used to export an interface to the help panel
     // this export is used e.g. by vscode-r-debugger to show the help panel from within debug sessions


### PR DESCRIPTION
# What problem did you solve?

Closes #731 
Closes #482 

This PR checks if `mikhail-arkhipov.r` is enabled on activation. If so, a message will show and the extension panel will search "R Tools" so that it is easier for the user to disable or uninstall the extension in conflict.

## (If you do not have screenshot) How can I check this pull request?

1. Install `mikhail-arkhipov.r`
2. Open any `.R` file to activate both `vscode-R` and `R Tools`.
3. A message about the conflict will show up, and the extension panel will search `R Tools`.
4. Uninstall the `R Tools` extension and reload window
5. Everything becomes normal.