### PR TITLE
*Proof of concept* accessing VSC settings in R

### DIFF
--- a/R/getSettings.R
+++ b/R/getSettings.R
@@ -18,12 +18,24 @@ fileCon <- if (file.exists("~/.config/Code/User/settings.json")) {
 vsc_settings <- jsonlite::fromJSON(paste(readLines(fileCon), collapse = ""))
 ops <- vsc_settings[grep("r.rOptions", names(vsc_settings))]$r.rOptions
 
+get_val <- function(x) {
+    switch(EXPR = x,
+        "Two" = "Two",
+        "Active" = "Active",
+        "Beside" = "Beside",
+        "FALSE" = FALSE,
+        "TRUE" = TRUE,
+        "0" = 0,
+        "2" = 2,
+        x
+    )
+}
 
-lapply(names(ops), function(x) {
-    val <- ops[[x]]
-    switch(x,
+suppressMessages(lapply(names(ops), function(x) {
+    val <- get_val(ops[[x]])
+    switch(EXPR = x,
         "vsc.plot" = options("vsc.plot" = val),
         "vsc.globalenv" = options("vsc.globalenv" = val)
         # etc.
     )
-})
+}))

--- a/R/getSettings.R
+++ b/R/getSettings.R
@@ -1,16 +1,29 @@
-fileCon <- file("~/.config/Code/User/settings.json")
+fileCon <- if (file.exists("~/.config/Code/User/settings.json")) {
+    # windows
+    file("~/.config/Code/User/settings.json")
+} else if (file.exists("~/Library/Application Support/Code/User/settings.json")) {
+    # mac
+    file("~/.config/Code/User/settings.json")
+} else if (file.exists("~/.config/Code/User/settings.json")) {
+    # linux
+    file("~/.config/Code/User/settings.json")
+} else if (file.exists(paste0("/mnt///c/Users/", Sys.getenv("USER"), "/AppData/Roaming/Code/User/settings.json"))) {
+    # WSL
+    file(paste0("/mnt///c/Users/", Sys.getenv("USER"), "/AppData/Roaming/Code/User/settings.json"))
+} else {
+    NULL
+}
+
+
 vsc_settings <- jsonlite::fromJSON(paste(readLines(fileCon), collapse = ""))
 ops <- vsc_settings[grep("r.rOptions", names(vsc_settings))]$r.rOptions
 
 
-.vsc.setOption <- function(x) {
+lapply(names(ops), function(x) {
     val <- ops[[x]]
-    switch(
-        x,
+    switch(x,
         "vsc.plot" = options("vsc.plot" = val),
         "vsc.globalenv" = options("vsc.globalenv" = val)
         # etc.
     )
-}
-
-lapply(names(ops), .vsc.setOption)
+})

--- a/R/getSettings.R
+++ b/R/getSettings.R
@@ -1,0 +1,16 @@
+fileCon <- file("~/.config/Code/User/settings.json")
+vsc_settings <- jsonlite::fromJSON(paste(readLines(fileCon), collapse = ""))
+ops <- vsc_settings[grep("r.rOptions", names(vsc_settings))]$r.rOptions
+
+
+.vsc.setOption <- function(x) {
+    val <- ops[[x]]
+    switch(
+        x,
+        "vsc.plot" = options("vsc.plot" = val),
+        "vsc.globalenv" = options("vsc.globalenv" = val)
+        # etc.
+    )
+}
+
+lapply(names(ops), .vsc.setOption)

--- a/R/init.R
+++ b/R/init.R
@@ -100,8 +100,11 @@ init_last <- function() {
     rm(".First.sys", envir = globalenv())
   )
 
+
   # Attach to vscode
   exports$.vsc.attach()
+
+  source(file.path(dir_init, "getSettings.R"), local = TRUE)
 
   invisible()
 }

--- a/package.json
+++ b/package.json
@@ -1409,6 +1409,34 @@
           "default": "",
           "markdownDescription": "Path to a custom CSS file to be used when `#r.plot.defaults.colorTheme#` is `vscode`. Replaces the default CSS overwrites!"
         },
+        "r.rOption.bools": {
+          "type": "object",
+          "default": {
+            "vsc.rstudioapi": false,
+            "vsc.useHttpgd": false,
+            "vsc.globalenv": true,
+            "vsc.showObjectSize": true
+          },
+          "properties": {
+            "vsc.rstudioapi": {
+              "type": "boolean",
+              "default": false
+            },
+            "vsc.useHttpgd": {
+              "type": "boolean",
+              "default": false
+            },
+            "vsc.globalEnv": {
+              "type": "boolean",
+              "default": true
+            },
+            "vsc.showObjectSize": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
         "r.rOptions": {
           "type": "object",
           "default": {

--- a/package.json
+++ b/package.json
@@ -1409,13 +1409,14 @@
           "default": "",
           "markdownDescription": "Path to a custom CSS file to be used when `#r.plot.defaults.colorTheme#` is `vscode`. Replaces the default CSS overwrites!"
         },
-        "r.rOption.bools": {
+        "r.rOptions.bools": {
           "type": "object",
+          "markdownDescription": "Toggle vsc bools",
           "default": {
             "vsc.rstudioapi": false,
             "vsc.useHttpgd": false,
             "vsc.globalenv": true,
-            "vsc.showObjectSize": true
+            "vsc.showObjectSize": false
           },
           "properties": {
             "vsc.rstudioapi": {
@@ -1432,24 +1433,22 @@
             },
             "vsc.showObjectSize": {
               "type": "boolean",
-              "default": true
+              "default": false
             }
           },
           "additionalProperties": false
         },
-        "r.rOptions": {
+        "r.rOptions.arrays": {
           "type": "object",
+          "markdownDescription": "Set vsc options",
           "default": {
             "vsc.plot": "Two",
-            "vsc.browser": "Two",
+            "vsc.browser": "Active",
             "vsc.viewer": "Two",
-            "vsc.pageViewer": "Two",
+            "vsc.pageViewer": "Active",
             "vsc.view": "Two",
             "vsc.helpPanel": "Two",
-            "vsc.strMaxLevel": "2",
-            "vsc.showObjectSize": true,
-            "vsc.useHttpgd": false,
-            "vsc.globalEnv": true
+            "vsc.strMaxLevel": "0"
           },
           "properties": {
             "vsc.plot": {
@@ -1470,7 +1469,7 @@
                 "Beside",
                 "FALSE"
               ],
-              "default": "Two"
+              "default": "Active"
             },
             "vsc.viewer": {
               "type": "string",
@@ -1490,7 +1489,7 @@
                 "Beside",
                 "FALSE"
               ],
-              "default": "Two"
+              "default": "Active"
             },
             "vsc.view": {
               "type": "string",
@@ -1518,19 +1517,7 @@
                 "0",
                 "2"
               ],
-              "default": "2"
-            },
-            "vsc.useHttpgd": {
-              "type": "boolean",
-              "default": false
-            },
-            "vsc.globalEnv": {
-              "type": "boolean",
-              "default": true
-            },
-            "vsc.showObjectSize": {
-              "type": "boolean",
-              "default": true
+              "default": "0"
             }
           },
           "additionalProperties": false

--- a/package.json
+++ b/package.json
@@ -1408,6 +1408,104 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Path to a custom CSS file to be used when `#r.plot.defaults.colorTheme#` is `vscode`. Replaces the default CSS overwrites!"
+        },
+        "r.rOptions": {
+          "type": "object",
+          "default": {
+            "vsc.plot": "Two",
+            "vsc.browser": "Two",
+            "vsc.viewer": "Two",
+            "vsc.pageViewer": "Two",
+            "vsc.view": "Two",
+            "vsc.helpPanel": "Two",
+            "vsc.strMaxLevel": "2",
+            "vsc.showObjectSize": true,
+            "vsc.useHttpgd": false,
+            "vsc.globalEnv": true
+          },
+          "properties": {
+            "vsc.plot": {
+              "type": "string",
+                "enum": [
+                  "Two",
+                  "Active",
+                  "Beside",
+                  "FALSE"
+                ],
+                "default": "Two"
+            },
+            "vsc.browser": {
+              "type": "string",
+              "enum": [
+                "Two",
+                "Active",
+                "Beside",
+                "FALSE"
+              ],
+              "default": "Two"
+            },
+            "vsc.viewer": {
+              "type": "string",
+              "enum": [
+                "Two",
+                "Active",
+                "Beside",
+                "FALSE"
+              ],
+              "default": "Two"
+            },
+            "vsc.pageViewer": {
+              "type": "string",
+              "enum": [
+                "Two",
+                "Active",
+                "Beside",
+                "FALSE"
+              ],
+              "default": "Two"
+            },
+            "vsc.view": {
+              "type": "string",
+              "enum": [
+                "Two",
+                "Active",
+                "Beside",
+                "FALSE"
+              ],
+              "default": "Two"
+            },
+            "vsc.helpPanel": {
+              "type": "string",
+              "enum": [
+                "Two",
+                "Active",
+                "Beside",
+                "FALSE"
+              ],
+              "default": "Two"
+            },
+            "vsc.strMaxLevel": {
+              "type": "string",
+              "enum": [
+                "0",
+                "2"
+              ],
+              "default": "2"
+            },
+            "vsc.useHttpgd": {
+              "type": "boolean",
+              "default": false
+            },
+            "vsc.globalEnv": {
+              "type": "boolean",
+              "default": true
+            },
+            "vsc.showObjectSize": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          "additionalProperties": false
         }
       }
     },


### PR DESCRIPTION
# **proof of concept** 

This PR allows loading R-related vsc settings in R. This reduces the reliance on 
setting options in the .Rprofile, and means that you don't need to have settings that have no effect outside of VSC-R. This also allows maintainers to restrict invalid inputs.

This could also be used for increased customisation E.g., as outlined by [@renkun-ken](https://github.com/REditorSupport/vscode-R/issues/584#issuecomment-802927563_), this could be extended to modify .Rprofile execution order

_Caveats_:

- The default value of a setting *must* be identical to the R option default, as VSCode settings are not written to the settings.kson unless the default value is changed.
- May require an environment term to locate the settings.json in some cases
- Could have issues with malformed settings.json files

## Screenshot

![image](https://user-images.githubusercontent.com/60372411/128462956-5e8b9e58-3486-40bd-9240-bc7a071a6462.png)


---

Note: this PR is a proof-of-concept, and is a little rough around the edges. I'd love to hear whether this is something that is useful, and any ideas/issues that you think may exist/occur