### PR TITLE
Fix  issues with c() in function args

### DIFF
--- a/syntax/r.json
+++ b/syntax/r.json
@@ -1,9 +1,4 @@
 {
-    "information_for_contributors": [
-        "This file has been converted from https://github.com/randy3k/R-Box/blob/master/syntax/R%20Extended.sublime-syntax",
-        "If you want to provide a fix or improvement, please create a pull request against the original repository.",
-        "Once accepted there, we are happy to receive an update request."
-    ],
     "fileTypes": [
         "R",
         "r",

--- a/syntax/r.json
+++ b/syntax/r.json
@@ -340,8 +340,8 @@
         "function-declarations": {
             "patterns": [
                 {
-                    "begin": "^\\s*([a-zA-Z._][\\w.:]*)\\s*(<<?-|=)\\s*(?=function\\s*\\()",
-                    "beginCaptures": {
+                    "match": "((?:`[^`\\\\]*(?:\\\\.[^`\\\\]*)*`)|(?:[[:alpha:].][[:alnum:]._]*))\\s*(<?<-|=(?!=))\\s*(function)",
+                    "captures": {
                         "1": {
                             "name": "entity.name.function.r"
                         },
@@ -352,7 +352,6 @@
                             "name": "keyword.control.r"
                         }
                     },
-                    "end": "(?<=\\))",
                     "name": "meta.function.r",
                     "patterns": [
                         {


### PR DESCRIPTION
Uses the match pattern for functions from the textmate R grammar in place of the previous function pattern. I don't have experience with using textmate grammar, but from testing on my code I haven't seen any issues thus far. If anyone is more knowledgeable with textmate and would like to chime in, that would be greatly appreciated :)

The grammar's [repo](https://github.com/textmate/r.tmbundle) indicates that there shouldn't be any licensing issues either.

# What problem did you solve?
Fixes #713 and incidentally #120.

## How can I check this pull request?

The following should not have issues with text decoration when using the PR.

```r
# issue 713
fun <- function(a, c = c("a", "()"), d) {
    function body, not a quoted string
}

# issue 120
f <- function(a=c("a", "b", "c")) {}

```

