### PR TITLE
Handle error in capture_str

### DIFF
--- a/R/vsc.R
+++ b/R/vsc.R
@@ -88,7 +88,7 @@ request <- function(command, ...) {
 }
 
 capture_str <- function(object, max.level = getOption("vsc.str.max.level", 0)) {
-  paste0(
+  text <- tryCatch(
     utils::capture.output(
       utils::str(object,
         max.level = max.level,
@@ -96,8 +96,22 @@ capture_str <- function(object, max.level = getOption("vsc.str.max.level", 0)) {
         vec.len = 1
       )
     ),
-    collapse = "\n"
+    error = function(e) {
+      tryCatch(
+        utils::capture.output(
+          utils::str(object,
+            max.level = 0,
+            give.attr = FALSE,
+            vec.len = 1
+          )
+        ),
+        error = function(e) {
+          paste0(class(object), collapse = ", ")
+        }
+      )
+    }
   )
+  paste0(text, collapse = "\n")
 }
 
 rebind <- function(sym, value, ns) {

--- a/R/vsc.R
+++ b/R/vsc.R
@@ -88,30 +88,18 @@ request <- function(command, ...) {
 }
 
 capture_str <- function(object, max.level = getOption("vsc.str.max.level", 0)) {
-  text <- tryCatch(
-    utils::capture.output(
+  tryCatch(
+    paste0(utils::capture.output(
       utils::str(object,
         max.level = max.level,
         give.attr = FALSE,
         vec.len = 1
       )
-    ),
+    ), collapse = "\n"),
     error = function(e) {
-      tryCatch(
-        utils::capture.output(
-          utils::str(object,
-            max.level = 0,
-            give.attr = FALSE,
-            vec.len = 1
-          )
-        ),
-        error = function(e) {
-          paste0(class(object), collapse = ", ")
-        }
-      )
+      paste0(class(object), collapse = ", ")
     }
   )
-  paste0(text, collapse = "\n")
 }
 
 rebind <- function(sym, value, ns) {
@@ -167,7 +155,7 @@ inspect_env <- function(env, cache) {
         class = class(obj),
         type = scalar(typeof(obj)),
         length = scalar(length(obj)),
-        str = scalar(trimws(capture_str(obj)[[1L]]))
+        str = scalar(trimws(capture_str(obj)))
       )
 
       if (show_object_size) {


### PR DESCRIPTION
# What problem did you solve?

Closes #755 

`capture_str` now handles error internally in the following way:

1. Capture `str()` with user specified `max.level`.
2. If error occurs, fall back to show class.

## (If you do not have screenshot) How can I check this pull request?

The following examples no longer produce errors:

Simple flawed `str`:

```r
errobj <- structure(list(x = 1), class = "err")
str.err <- function(obj) 0 + obj
options(vsc.str.max.level = 1)
```

Original issue with flawed `str` implementation:

```r
library(tidyverse)
library(igraph)
library(tidygraph)

# setting workspace level to anything > 0 creates error
options(vsc.str.max.level = 1)

# create a simple igraph object
g <- erdos.renyi.game(10, .1)

# converting to a tbl_graph object produces the error (note that code still runs)
g <- as_tbl_graph(g)
```