### PR TITLE
Enable rstudioapi by default

### DIFF
--- a/R/vsc.R
+++ b/R/vsc.R
@@ -578,7 +578,7 @@ options(
 
 # rstudioapi
 rstudioapi_enabled <- function() {
-  isTRUE(getOption("vsc.rstudioapi"))
+  isTRUE(getOption("vsc.rstudioapi", TRUE))
 }
 
 if (rstudioapi_enabled()) {

--- a/package.json
+++ b/package.json
@@ -1346,7 +1346,7 @@
         },
         "r.session.emulateRStudioAPI": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "Emulate the RStudio API for addin support and other {rstudioapi} calls. Changes the option `vsc.rstudioapi` in R. Requires `#r.sessionWatcher#` to be set to `true`."
         },
         "r.session.viewers.viewColumn": {

--- a/src/rstudioapi.ts
+++ b/src/rstudioapi.ts
@@ -242,7 +242,7 @@ export function projectPath(): { path: string; } {
     }
   }
 
-  // if we got to here either: 
+  // if we got to here either:
   //   - the workspaceFolders array was undefined (no folder open)
   //   - the activeText editor was an unsaved document, which has undefined workspace folder.
   // return undefined and handle with a message in R.
@@ -317,10 +317,12 @@ export function purgeAddinPickerItems(): void {
 export async function launchAddinPicker(): Promise<void> {
 
   if (!config().get<boolean>('sessionWatcher')) {
-    throw ('{rstudioapi} emulation requires session watcher to be enabled in extension config.');
+    void window.showErrorMessage('{rstudioapi} emulation requires session watcher to be enabled in extension config.');
+    return;
   }
   if (!sessionDirectoryExists()) {
-    throw ('No active R terminal session, attach one to use RStudio addins.');
+    void window.showErrorMessage('No active R terminal session, attach one to use RStudio addins.');
+    return;
   }
 
   const addinPickerOptions: QuickPickOptions = {


### PR DESCRIPTION
# What problem did you solve?

* Enables rstudioapi emulation by default, as per #421 
* Minor change to show error message on failure to start quick pick
