### PR TITLE
Use unsafe-inline for script-src

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -632,7 +632,7 @@ export async function getWebviewHtml(webview: Webview, file: string, title: stri
         upgrade-insecure-requests;
         default-src https: data: filesystem:;
         style-src https: data: filesystem: 'unsafe-inline';
-        script-src https: data: filesystem: 'unsafe-eval';
+        script-src https: data: filesystem: 'unsafe-inline';
     `;
 
     return `


### PR DESCRIPTION
# What problem did you solve?

Closes #770

The current content security policy seems too strict for flextable to work since it contains inline scripts. Relaxing the CSP will make it work as expected.

## (If you have)Screenshot

![image](https://user-images.githubusercontent.com/4662568/131978399-7455c15c-0df6-452a-8465-340d203b0205.png)


## (If you do not have screenshot) How can I check this pull request?

```r
flextable::flextable(iris)
```