### PR TITLE
(Refactoring) Simplify RMD child process disposal

### DIFF
--- a/src/rmarkdown/knit.ts
+++ b/src/rmarkdown/knit.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs-extra';
 import path = require('path');
 import yaml = require('js-yaml');
 
-import { RMarkdownManager, KnitWorkingDirectory } from './manager';
+import { RMarkdownManager, KnitWorkingDirectory, DisposableProcess } from './manager';
 import { runTextInTerm } from '../rTerminal';
 import { rmdPreviewManager } from '../extension';
 
@@ -26,7 +26,7 @@ interface IYamlFrontmatter {
 }
 
 export class RMarkdownKnitManager extends RMarkdownManager {
-	private async renderDocument(rPath: string, docPath: string, docName: string, yamlParams: IYamlFrontmatter, outputFormat?: string) {
+	private async renderDocument(rPath: string, docPath: string, docName: string, yamlParams: IYamlFrontmatter, outputFormat?: string): Promise<DisposableProcess> {
 		const openOutfile: boolean = util.config().get<boolean>('rmarkdown.knit.openOutputFile') ?? false;
 		const knitWorkingDir = this.getKnitDir(knitDir, docPath);
 		const knitWorkingDirText = knitWorkingDir ? `'${knitWorkingDir}'` : `NULL`;

--- a/src/rmarkdown/knit.ts
+++ b/src/rmarkdown/knit.ts
@@ -35,14 +35,12 @@ export class RMarkdownKnitManager extends RMarkdownManager {
 
 		const lim = '---vsc---';
 		const re = new RegExp(`.*${lim}(.*)${lim}.*`, 'gms');
-		const cmd = (
-			`${this.rPath} --silent --slave --no-save --no-restore ` +
-			`-e "knitr::opts_knit[['set']](root.dir = ${knitWorkingDirText})" ` +
-			`-e "cat('${lim}', ` +
+		const cmd =
+			`knitr::opts_knit[['set']](root.dir = ${knitWorkingDirText});` +
+			`cat('${lim}', ` +
 			`${knitCommand}, ` +
 			`'${lim}',` +
-			`sep='')"`
-		);
+			`sep='')`;
 
 		const callback = (dat: string) => {
 			const outputUrl = re.exec(dat)?.[0]?.replace(re, '$1');
@@ -122,7 +120,7 @@ export class RMarkdownKnitManager extends RMarkdownManager {
 				`rmarkdown::render(${docPath})`;
 		}
 
-		return knitCommand.replace(/['"]/g, '\\"');
+		return knitCommand.replace(/['"]/g, '"');
 	}
 
 	// check if the workspace of the document is a R Markdown site.

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -63,23 +63,28 @@ export abstract class RMarkdownManager {
 			(resolve, reject) => {
 				const cmd = args.cmd;
 				const fileName = args.fileName;
+				const processArgs = [
+					`--silent`,
+					`--slave`,
+					`--no-save`,
+					`--no-restore`,
+					`-e`,
+					cmd
+				];
+				const processOptions = {
+					env: process.env
+				};
+
 				let childProcess: DisposableProcess;
 
 				try {
 					childProcess = util.asDisposable(
-						cp.spawn(`${this.rPath}`,
-							[
-								`--silent`,
-								`--slave`,
-								`--no-save`,
-								`--no-restore`,
-								`-e`,
-								cmd
-							],
-							{ windowsVerbatimArguments: true }
+						cp.spawn(
+							`${this.rPath}`,
+							processArgs,
+							processOptions
 						),
 						() => {
-
 							if (childProcess.kill('SIGKILL')) {
 								rMarkdownOutput.appendLine('[VSC-R] terminating R process');
 								printOutput = false;

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -8,6 +8,15 @@ export enum KnitWorkingDirectory {
 	workspaceRoot = 'workspace root',
 }
 
+export type DisposableProcess = cp.ChildProcessWithoutNullStreams & vscode.Disposable;
+
+export interface IKnitRejection {
+	cp: DisposableProcess;
+	wasCancelled: boolean;
+}
+
+const rMarkdownOutput: vscode.OutputChannel = vscode.window.createOutputChannel('R Markdown');
+
 interface IKnitArgs {
 	filePath: string;
 	fileName: string;
@@ -17,13 +26,6 @@ interface IKnitArgs {
 	callback: (...args: unknown[]) => boolean;
 	onRejection?: (...args: unknown[]) => unknown;
 }
-
-export interface IKnitRejection {
-	cp: cp.ChildProcessWithoutNullStreams;
-	wasCancelled: boolean;
-}
-
-const rMarkdownOutput: vscode.OutputChannel = vscode.window.createOutputChannel('R Markdown');
 
 export abstract class RMarkdownManager {
 	protected rPath: string = undefined;
@@ -51,18 +53,26 @@ export abstract class RMarkdownManager {
 		}
 	}
 
-	protected async knitDocument(args: IKnitArgs, token?: vscode.CancellationToken, progress?: vscode.Progress<unknown>): Promise<cp.ChildProcessWithoutNullStreams | IKnitRejection> {
+	protected async knitDocument(args: IKnitArgs, token?: vscode.CancellationToken, progress?: vscode.Progress<unknown>): Promise<DisposableProcess | IKnitRejection> {
 		// vscode.Progress auto-increments progress, so we use this
 		// variable to set progress to a specific number
 		let currentProgress = 0;
-		return await new Promise<cp.ChildProcessWithoutNullStreams>(
+		let printOutput = true;
+		return await new Promise<DisposableProcess>(
 			(resolve, reject) => {
 				const cmd = args.cmd;
 				const fileName = args.fileName;
-				let childProcess: cp.ChildProcessWithoutNullStreams;
+				let childProcess: DisposableProcess;
 
 				try {
-					childProcess = cp.exec(cmd);
+					childProcess = util.asDisposable(
+						cp.exec(cmd),
+						() => {
+							rMarkdownOutput.appendLine('[VSC-R] terminating R process');
+							childProcess.kill('SIGKILL');
+							printOutput = false;
+						}
+					);
 					progress.report({
 						increment: 0,
 						message: '0%'
@@ -81,9 +91,13 @@ export abstract class RMarkdownManager {
 				childProcess.stdout.on('data',
 					(data: Buffer) => {
 						const dat = data.toString('utf8');
-						this.rMarkdownOutput.appendLine(dat);
+						if (printOutput) {
+							this.rMarkdownOutput.appendLine(dat);
+
+						}
 						const percentRegex = /[0-9]+(?=%)/g;
 						const percentRegOutput = dat.match(percentRegex);
+
 						if (percentRegOutput) {
 							for (const item of percentRegOutput) {
 								const perc = Number(item);
@@ -108,7 +122,9 @@ export abstract class RMarkdownManager {
 
 				childProcess.stderr.on('data', (data: Buffer) => {
 					const dat = data.toString('utf8');
-					this.rMarkdownOutput.appendLine(dat);
+					if (printOutput) {
+						this.rMarkdownOutput.appendLine(dat);
+					}
 				});
 
 				childProcess.on('exit', (code, signal) => {
@@ -126,10 +142,10 @@ export abstract class RMarkdownManager {
 		);
 	}
 
-	protected async knitWithProgress(args: IKnitArgs): Promise<cp.ChildProcessWithoutNullStreams> {
-		let childProcess: cp.ChildProcessWithoutNullStreams = undefined;
+	protected async knitWithProgress(args: IKnitArgs): Promise<DisposableProcess> {
+		let childProcess: DisposableProcess = undefined;
 		await util.doWithProgress(async (token: vscode.CancellationToken, progress: vscode.Progress<unknown>) => {
-			childProcess = await this.knitDocument(args, token, progress) as cp.ChildProcessWithoutNullStreams;
+			childProcess = await this.knitDocument(args, token, progress) as DisposableProcess;
 		},
 			vscode.ProgressLocation.Notification,
 			`Knitting ${args.fileName} ${args.rOutputFormat ? 'to ' + args.rOutputFormat : ''} `,
@@ -140,8 +156,8 @@ export abstract class RMarkdownManager {
 				this.rMarkdownOutput.show(true);
 			}
 			// this can occur when a successfuly knitted document is later altered (while still being previewed) and subsequently fails to knit
-			args?.onRejection ? args.onRejection(args.filePath, rejection) :
-				rejection?.cp.kill('SIGKILL');
+			args?.onRejection?.(args.filePath, rejection);
+			rejection.cp?.dispose();
 		});
 		return childProcess;
 	}

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -58,6 +58,7 @@ export abstract class RMarkdownManager {
 		// variable to set progress to a specific number
 		let currentProgress = 0;
 		let printOutput = true;
+
 		return await new Promise<DisposableProcess>(
 			(resolve, reject) => {
 				const cmd = args.cmd;
@@ -66,11 +67,23 @@ export abstract class RMarkdownManager {
 
 				try {
 					childProcess = util.asDisposable(
-						cp.exec(cmd),
+						cp.spawn(`${this.rPath}`,
+							[
+								`--silent`,
+								`--slave`,
+								`--no-save`,
+								`--no-restore`,
+								`-e`,
+								cmd
+							],
+							{ windowsVerbatimArguments: true }
+						),
 						() => {
-							rMarkdownOutput.appendLine('[VSC-R] terminating R process');
-							childProcess.kill('SIGKILL');
-							printOutput = false;
+
+							if (childProcess.kill('SIGKILL')) {
+								rMarkdownOutput.appendLine('[VSC-R] terminating R process');
+								printOutput = false;
+							}
 						}
 					);
 					progress.report({

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -290,14 +290,13 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
         const re = new RegExp(`.*${lim}(.*)${lim}.*`, 'ms');
         const outputFile = path.join(tmpDir(), crypto.createHash('sha256').update(filePath).digest('hex') + '.html');
         const cmd = (
-            `${this.rPath} --silent --slave --no-save --no-restore ` +
-            `-e "knitr::opts_knit[['set']](root.dir = ${knitWorkingDirText})" ` +
-            `-e "cat('${lim}', rmarkdown::render(` +
+            `knitr::opts_knit[['set']](root.dir = ${knitWorkingDirText});` +
+            `cat('${lim}', rmarkdown::render(` +
             `'${filePath.replace(/\\/g, '/')}',` +
             `output_format = rmarkdown::html_document(),` +
             `output_file = '${outputFile.replace(/\\/g, '/')}',` +
             `intermediates_dir = '${tmpDir().replace(/\\/g, '/')}'), '${lim}',` +
-            `sep='')"`
+            `sep='')`
         );
 
         const callback = (dat: string, childProcess: DisposableProcess) => {

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -284,7 +284,7 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
     private async previewDocument(filePath: string, fileName?: string, viewer?: vscode.ViewColumn, currentViewColumn?: vscode.ViewColumn): Promise<DisposableProcess> {
         const knitWorkingDir = this.getKnitDir(knitDir, filePath);
         const knitWorkingDirText = knitWorkingDir ? `'${knitWorkingDir}'` : `NULL`;
-        this.rPath = await getRpath(true);
+        this.rPath = await getRpath();
 
         const lim = '---vsc---';
         const re = new RegExp(`.*${lim}(.*)${lim}.*`, 'ms');

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -1,5 +1,3 @@
-
-import * as cp from 'child_process';
 import * as vscode from 'vscode';
 import * as fs from 'fs-extra';
 import * as cheerio from 'cheerio';
@@ -11,11 +9,11 @@ import crypto = require('crypto');
 import { config, readContent, setContext, escapeHtml, UriIcon, saveDocument, getRpath } from '../util';
 import { extensionContext, tmpDir } from '../extension';
 import { knitDir } from './knit';
-import { IKnitRejection, RMarkdownManager } from './manager';
+import { DisposableProcess, RMarkdownManager } from './manager';
 
 class RMarkdownPreview extends vscode.Disposable {
     title: string;
-    cp: cp.ChildProcessWithoutNullStreams;
+    cp: DisposableProcess;
     panel: vscode.WebviewPanel;
     resourceViewColumn: vscode.ViewColumn;
     outputUri: vscode.Uri;
@@ -25,7 +23,7 @@ class RMarkdownPreview extends vscode.Disposable {
     autoRefresh: boolean;
     mtime: number;
 
-    constructor(title: string, cp: cp.ChildProcessWithoutNullStreams, panel: vscode.WebviewPanel,
+    constructor(title: string, cp: DisposableProcess, panel: vscode.WebviewPanel,
         resourceViewColumn: vscode.ViewColumn, outputUri: vscode.Uri, filePath: string,
         RMarkdownPreviewManager: RMarkdownPreviewManager, useCodeTheme: boolean, autoRefresh: boolean) {
         super(() => {
@@ -268,7 +266,7 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
         toUpdate?.cp?.kill('SIGKILL');
 
         if (toUpdate) {
-            const childProcess: cp.ChildProcessWithoutNullStreams | void = await this.previewDocument(previewUri, toUpdate.title).catch(() => {
+            const childProcess: DisposableProcess | void = await this.previewDocument(previewUri, toUpdate.title).catch(() => {
                 void vscode.window.showErrorMessage('There was an error in knitting the document. Please check the R Markdown output stream.');
                 this.rMarkdownOutput.show(true);
                 this.previewStore.delete(previewUri);
@@ -283,7 +281,7 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
 
     }
 
-    private async previewDocument(filePath: string, fileName?: string, viewer?: vscode.ViewColumn, currentViewColumn?: vscode.ViewColumn) {
+    private async previewDocument(filePath: string, fileName?: string, viewer?: vscode.ViewColumn, currentViewColumn?: vscode.ViewColumn): Promise<DisposableProcess> {
         const knitWorkingDir = this.getKnitDir(knitDir, filePath);
         const knitWorkingDirText = knitWorkingDir ? `'${knitWorkingDir}'` : `NULL`;
         this.rPath = await getRpath(true);
@@ -302,7 +300,7 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
             `sep='')"`
         );
 
-        const callback = (dat: string, childProcess: cp.ChildProcessWithoutNullStreams) => {
+        const callback = (dat: string, childProcess: DisposableProcess) => {
             const outputUrl = re.exec(dat)?.[0]?.replace(re, '$1');
             if (outputUrl) {
                 if (viewer !== undefined) {
@@ -322,11 +320,9 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
             return false;
         };
 
-        const onRejected = (filePath: string, rejection: IKnitRejection) => {
+        const onRejected = (filePath: string) => {
             if (this.previewStore.has(filePath)) {
                 this.previewStore.delete(filePath);
-            } else {
-                rejection.cp.kill('SIGKILL');
             }
         };
 
@@ -342,7 +338,7 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
         );
     }
 
-    private openPreview(outputUri: vscode.Uri, filePath: string, title: string, cp: cp.ChildProcessWithoutNullStreams, viewer: vscode.ViewColumn, resourceViewColumn: vscode.ViewColumn, autoRefresh: boolean): void {
+    private openPreview(outputUri: vscode.Uri, filePath: string, title: string, cp: DisposableProcess, viewer: vscode.ViewColumn, resourceViewColumn: vscode.ViewColumn, autoRefresh: boolean): void {
 
         const panel = vscode.window.createWebviewPanel(
             'previewRmd',

--- a/src/util.ts
+++ b/src/util.ts
@@ -371,3 +371,20 @@ export class UriIcon {
         this.light = vscode.Uri.file(path.join(extIconPath, 'light', id + '.svg'));
     }
 }
+
+/**
+ * As Disposable.
+ *
+ * Create a dispose method for any given object, and push it to the
+ * extension subscriptions array
+ *
+ * @param {T} toDispose - the object to add dispose to
+ * @param {Function} disposeFunction - the method called when the object is disposed
+ * @returns returned object is considered types T and vscode.Disposable
+ */
+export function asDisposable<T>(toDispose: T, disposeFunction: (...args: unknown[]) => unknown): T & vscode.Disposable {
+    type disposeType = T & vscode.Disposable;
+    (toDispose as disposeType).dispose = () => disposeFunction();
+    extensionContext.subscriptions.push(toDispose as disposeType);
+    return toDispose as disposeType;
+}


### PR DESCRIPTION
Minor refactor to the R Markdown preview/knit processes, cleaning up the disposal of child processes. 

Changes:
* Contributes a helper function for creating disposables from objects
* Simplifies disposal of child processes
* Do not print lines to output when the process has already been terminated

Both knitting and previewing should function as before