### PR TITLE
Add object length limit

### DIFF
--- a/R/vsc.R
+++ b/R/vsc.R
@@ -134,6 +134,8 @@ inspect_env <- function(env, cache) {
   is_promise <- rlang::env_binding_are_lazy(env, all_names)
   is_active <- rlang::env_binding_are_active(env, all_names)
   show_object_size <- getOption("vsc.show_object_size", FALSE)
+  object_length_limit <- getOption("vsc.object_length_limit", 2000)
+  str_max_level <- getOption("vsc.str.max.level", 0)
   objs <- lapply(all_names, function(name) {
     if (is_promise[[name]]) {
       info <- list(
@@ -171,12 +173,10 @@ inspect_env <- function(env, cache) {
         info$size <- scalar(cobj$size)
       }
 
-      length_limit <- getOption("vsc.object_length_limit", 2000)
-      if (length(obj) > length_limit) {
+      if (length(obj) > object_length_limit) {
         info$str <- scalar(trimws(capture_str(obj, 0)))
       } else {
-        max_level <- getOption("vsc.str.max.level", 0)
-        info$str <- scalar(trimws(capture_str(obj, max_level)))
+        info$str <- scalar(trimws(capture_str(obj, str_max_level)))
         obj_names <- if (is.object(obj)) {
           .DollarNames(obj, pattern = "")
         } else if (is.recursive(obj)) {

--- a/R/vsc.R
+++ b/R/vsc.R
@@ -20,6 +20,7 @@ load_settings <- function() {
     vsc.show_object_size = workspaceViewer$showObjectSize,
     vsc.rstudioapi = session$emulateRStudioAPI,
     vsc.str.max.level = session$levelOfObjectDetail,
+    vsc.object_length_limit = session$objectLengthLimit,
     vsc.globalenv = session$watchGlobalEnvironment,
     vsc.plot = session$viewers$viewColumn$plot,
     vsc.browser = session$viewers$viewColumn$browser,
@@ -154,8 +155,7 @@ inspect_env <- function(env, cache) {
       info <- list(
         class = class(obj),
         type = scalar(typeof(obj)),
-        length = scalar(length(obj)),
-        str = scalar(trimws(capture_str(obj)))
+        length = scalar(length(obj))
       )
 
       if (show_object_size) {
@@ -171,14 +171,21 @@ inspect_env <- function(env, cache) {
         info$size <- scalar(cobj$size)
       }
 
-      obj_names <- if (is.object(obj)) {
-        .DollarNames(obj, pattern = "")
-      } else if (is.recursive(obj)) {
-        names(obj)
-      } else NULL
+      length_limit <- getOption("vsc.object_length_limit", 2000)
+      if (length(obj) > length_limit) {
+        info$str <- scalar(trimws(capture_str(obj, 0)))
+      } else {
+        max_level <- getOption("vsc.str.max.level", 0)
+        info$str <- scalar(trimws(capture_str(obj, max_level)))
+        obj_names <- if (is.object(obj)) {
+          .DollarNames(obj, pattern = "")
+        } else if (is.recursive(obj)) {
+          names(obj)
+        } else NULL
 
-      if (length(obj_names)) {
-        info$names <- obj_names
+        if (length(obj_names)) {
+          info$names <- obj_names
+        }
       }
 
       if (isS4(obj)) {

--- a/package.json
+++ b/package.json
@@ -1398,6 +1398,11 @@
           "default": true,
           "markdownDescription": "Watch the global environment to provide hover, autocompletions, and workspace viewer information. Changes the option `vsc.globalenv` in R. Requires `#r.sessionWatcher#` to be set to `true`."
         },
+        "r.session.objectLengthLimit": {
+          "type": "integer",
+          "default": 2000,
+          "markdownDescription": "The upper limit of object length to show object details in workspace viewer and provide session symbol completion. Decrease this value if you experience significant delay after executing R commands caused by large global objects with many elements. Changes the option `vsc.object_length_limit` in R. Requires `#r.sessionWatcher#` to be set to `true`."
+        },
         "r.session.levelOfObjectDetail": {
           "type": "string",
           "markdownDescription": "How much of the object to show on hover, autocompletion, and in the workspace viewer? Changes the option `vsc.str.max.level` in R. Requires `#r.sessionWatcher#` to be set to `true`.",


### PR DESCRIPTION
# What problem did you solve?

Closes #174 

This PR introduces a new setting `r.session.objectLengthLimit` corresponding to R option `vsc.object_length_limit` to limit the length of objects to provide names in session symbol completion, hover, and workspace viewer item.

Then large named objects with many elements will not be called `names()`. The overhead of calling `names()` (on environment) and writing the names to `globalenv.json` should be reduced.

## (If you do not have screenshot) How can I check this pull request?

For the following code, before this PR, the delay will be more and more significant if more objects with many elements are created in the global environment.

```r
n1 <- seq_len(1000)
lst1 <- lapply(n1, function(i) i)
names(lst1) <- paste0("name", n1)

1 + 1 # no delay

n2 <- seq_len(5000)
lst2 <- lapply(n2, function(i) i)
names(lst2) <- paste0("name", n2)

1 + 1 # slight delay

n3 <- seq_len(100000)
lst3 <- lapply(n3, function(i) i)
names(lst3) <- paste0("name", n3)

1 + 1 # significant delay
```

With this PR being effective, creating `lst2` and `lst3` should no longer cause a permanent delay on all subsequent calculations. One should also observe that the auto-completion works with `lst1` but not `lst2` or `lst3` due to object length limit, and the workspace viewer item of `lst1` should show object details while `lst2` and `lst3` do not if `r.session.levelOfObjectDetail` is set to `Detailed`. Adjusting `r.session.objectLengthLimit` should work accordingly.