### PR TITLE
Write NA as string

### DIFF
--- a/R/vsc.R
+++ b/R/vsc.R
@@ -418,13 +418,13 @@ if (show_view) {
     if (is.data.frame(x) || is.matrix(x)) {
       data <- dataview_table(x)
       file <- tempfile(tmpdir = tempdir, fileext = ".json")
-      jsonlite::write_json(data, file, auto_unbox = TRUE)
+      jsonlite::write_json(data, file, na = "string", null = "null", auto_unbox = TRUE)
       request("dataview", source = "table", type = "json",
         title = title, file = file, viewer = viewer, uuid = uuid)
     } else if (is.list(x)) {
       tryCatch({
         file <- tempfile(tmpdir = tempdir, fileext = ".json")
-        jsonlite::write_json(x, file, auto_unbox = TRUE)
+        jsonlite::write_json(x, file, na = "string", null = "null", auto_unbox = TRUE)
         request("dataview", source = "list", type = "json",
           title = title, file = file, viewer = viewer, uuid = uuid)
       }, error = function(e) {


### PR DESCRIPTION
# What problem did you solve?

Closes #776 

Since JSON does not support `NA`, `NaN`, `Inf` values, they can only be written as strings in the following way:

```r
jsonlite::write_json(x, file, na = "string", null = "null", auto_unbox = TRUE)
```

One remaining issue is that these values will not work properly when filtering is used in the data viewer, i.e. if one filters a column by "Greater than 0", `Inf` is not regarded as Inf > 0 but ignored.

## (If you have)Screenshot

![image](https://user-images.githubusercontent.com/4662568/132635831-a7ef5b82-5343-479b-ba03-63e6b9ca9f3f.png)

## How can I check this pull request?

The following code should open a data viewer where `Inf` and `NA` values are correctly displayed in the data grid.

```r
dt <- data.frame(
  id = 1:6,
  x = c(1, 2, NA, 3, Inf, -Inf),
  y = c("A", "B", NA, NA, NA, "D")
)

View(dt)
```
