### PR TITLE
Respect preview output format 

### DIFF
--- a/R/rmarkdown/knit.R
+++ b/R/rmarkdown/knit.R
@@ -1,5 +1,5 @@
 # requires rmarkdown package to run (and knitr)
-if (!requireNamespace(rmarkdown, quietly = TRUE)) {
+if (!requireNamespace("rmarkdown", quietly = TRUE)) {
     stop("Knitting requires the {rmarkdown} package.")
 }
 

--- a/R/rmarkdown/preview.R
+++ b/R/rmarkdown/preview.R
@@ -1,15 +1,31 @@
 # requires rmarkdown package to run (and knitr)
-if (!requireNamespace(rmarkdown, quietly = TRUE)) {
+if (!requireNamespace("rmarkdown", quietly = TRUE)) {
     stop("Previewing documents requires the {rmarkdown} package.")
 }
 
 # get values from extension-set env values
-
 knit_dir <- Sys.getenv("VSCR_KNIT_DIR")
 lim <- Sys.getenv("VSCR_LIM")
 file_path <- Sys.getenv("VSCR_FILE_PATH")
 output_file_loc <- Sys.getenv("VSCR_OUTPUT_FILE")
 tmp_dir <- Sys.getenv("VSCR_TMP_DIR")
+
+# if an output format ends up as html, we should not overwrite
+# the format with rmarkdown::html_document()
+set_html <- tryCatch(
+    expr = {
+        lines <- suppressWarnings(readLines(file_path, encoding = "UTF-8"))
+        out <- rmarkdown:::output_format_from_yaml_front_matter(lines)
+        output_format <- rmarkdown:::create_output_format(out$name, out$options)
+        if (!output_format$pandoc$to == "html") {
+            rmarkdown::html_document()
+        } else {
+            NULL
+        }
+    }, error = function(e) {
+        rmarkdown::html_document()
+    }
+)
 
 # set the knitr chunk eval directory
 # mainly affects source calls
@@ -20,7 +36,7 @@ cat(
     lim,
     rmarkdown::render(
         file_path,
-        output_format = rmarkdown::html_document(),
+        output_format = set_html,
         output_file = output_file_loc,
         intermediates_dir = tmp_dir
     ),

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -113,6 +113,9 @@ class RMarkdownPreview extends vscode.Disposable {
             pre > code {
                 background: transparent;
             }
+            h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
+                color: inherit;
+            }
         </style>
         `;
         $('head').append(style);

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -71,7 +71,7 @@ class RMarkdownPreview extends vscode.Disposable {
     }
 
     private getHtmlContent(htmlContent: string): void {
-        let content = htmlContent.replace(/<(\w+)\s+(href|src)="(?!\w+:)/g,
+        let content = htmlContent.replace(/<(\w+)\s+(href|src)="(?!(\w+:)|#)/g,
             `<$1 $2="${String(this.panel.webview.asWebviewUri(vscode.Uri.file(tmpDir())))}/`);
 
         const re = new RegExp('<html[^\\n]*>.*</html>', 'ms');
@@ -82,12 +82,11 @@ class RMarkdownPreview extends vscode.Disposable {
             content = `<html><head></head><body><pre>${html}</pre></body></html>`;
         }
 
-        this.htmlLightContent = content;
-
         const $ = cheerio.load(content);
-        const chunkCol = String(config().get('rmarkdown.chunkBackgroundColor'));
+        this.htmlLightContent = $.html();
 
         // make the output chunks a little lighter to stand out
+        const chunkCol = String(config().get('rmarkdown.chunkBackgroundColor'));
         const colReg = /[0-9.]+/g;
         const regOut = chunkCol.match(colReg);
         const outCol = `rgba(${regOut[0] ?? 100}, ${regOut[1] ?? 100}, ${regOut[2] ?? 100}, ${Number(regOut[3]) + 0.05 ?? .5})`;


### PR DESCRIPTION
Closes #779 

At the moment, previewing R Markdown documents forces the `rmarkdown::html_document()` format. However, this overwrites all output formats, even if they can result in a .html file. 

This PR uses the object `pandoc$to` from `rmarkdown:::create_output_format` to check if the document's output format == html. This way, we only override the output format if `pandoc$to` does not equal html.


## Screenshot

![image](https://user-images.githubusercontent.com/60372411/132839343-d77167f0-bfcb-4619-85d9-6620aa234359.png)

## How can I check this pull request?

The following renders incorrectly on master, which is fixed in this PR:

````r
---
title: "R Notebook"
output:
  bookdown::html_document2: default
---

```{r table1}
knitr::kable(mtcars[1:5, 1:5], caption = "The mtcars data.")
```

`mtcar` data is shown in Table \@ref(tab:table1).
````

