### PR TITLE
Bump @types/vscode from 1.57.0 to 1.60.0

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -331,6 +331,10 @@ export class DummyMemento implements vscode.Memento {
     public async update(key: string, value: any): Promise<void> {
         this.items.set(key, value);
     }
+
+    public keys(): readonly string[] {
+        return Object.keys(this.items);
+    }
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,9 +261,9 @@
   integrity sha512-dchbFCWfVgUSWEvhOkXGS7zjm+K7jCUvGrQkAHPk2Fmslfofp4HQTH2pqnQ3Pw5GPYv0zWa2AQjKtsfZThuemQ==
 
 "@types/vscode@^1.57.0":
-  version "1.57.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.57.0.tgz#cc648e0573b92f725cd1baf2621f8da9f8bc689f"
-  integrity sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.60.0.tgz#9330c317691b4f53441a18b598768faeeb71618a"
+  integrity sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==
 
 "@types/winreg@^1.2.30":
   version "1.2.30"


### PR DESCRIPTION
Updates the type definitions for vscode. I'm not sure where to obtain the changelog from!


---

I thought this was automated, but while looking into vscode's new features I was getting type errors.