### PR TITLE
Extend providers to rmd

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,9 +175,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
 
     // register (session) hover and completion providers
-    vscode.languages.registerHoverProvider('r', new completions.HoverProvider());
-    vscode.languages.registerHoverProvider('r', new completions.HelpLinkHoverProvider());
-    vscode.languages.registerCompletionItemProvider('r', new completions.StaticCompletionItemProvider(), '@');
+    vscode.languages.registerHoverProvider(['r', 'rmd'], new completions.HoverProvider());
+    vscode.languages.registerHoverProvider(['r', 'rmd'], new completions.HelpLinkHoverProvider());
+    vscode.languages.registerCompletionItemProvider(['r', 'rmd'], new completions.StaticCompletionItemProvider(), '@');
 
     // deploy liveshare listener
     await rShare.initLiveShare(context);
@@ -235,7 +235,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
         // if session watcher is active, register dyamic completion provider
         const liveTriggerCharacters = ['', '[', '(', ',', '$', '@', '"', '\''];
-        vscode.languages.registerCompletionItemProvider('r', new completions.LiveCompletionItemProvider(), ...liveTriggerCharacters);
+        vscode.languages.registerCompletionItemProvider(['r', 'rmd'], new completions.LiveCompletionItemProvider(), ...liveTriggerCharacters);
     }
 
 

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -171,7 +171,7 @@ interface RMarkdownChunk {
 }
 
 // Scan document and return chunk info (e.g. ID, chunk range) from all chunks
-function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
+export function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
   const lines = document.getText().split(/\r?\n/);
   const chunks: RMarkdownChunk[] = [];
 


### PR DESCRIPTION
# What problem did you solve?

Closes #762

This PR extends the following providers to `rmd`:

* HoverProvider: show session symbol value on hover
* HelpLinkHoverProvider: show help links on hover
* StaticCompletionItemProvider: complete roxygen tags
* LiveCompletionItemProvider: complete session symbols

## (If you do not have screenshot) How can I check this pull request?

All above providers should now work within rmd R code chunks but not outside R chunks.