### PR TITLE
Update vsc.R

### DIFF
--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -494,11 +494,23 @@ request_browser <- function(url, title, ..., viewer) {
 
 show_browser <- function(url, title = url, ...,
                          viewer = getOption("vsc.browser", "Active")) {
+  if (nzchar(Sys.getenv("VSCODE_PROXY_URI"))) {
+    is.base_path <- grepl("\\:\\d+$", url)
+    url <- sub("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:)?",
+      sub("\\{port\\}", "", Sys.getenv("VSCODE_PROXY_URI")), url)
+    if (is.base_path) {
+      url <- paste0(url, "/")
+    }
+  }
   if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
     request_browser(url = url, title = title, ..., viewer = viewer)
   } else if (grepl("^https?\\://", url)) {
     message(
-      "VSCode WebView only supports showing local http content.\n",
+      if (nzchar(Sys.getenv("VSCODE_PROXY_URI"))) {
+        "VSCode is not running on localhost but on a remote server.\n"
+      } else {
+        "VSCode WebView only supports showing local http content.\n"
+      },
       "Opening in external browser..."
     )
     request_browser(url = url, title = title, ..., viewer = FALSE)
@@ -535,11 +547,23 @@ show_webview <- function(url, title, ..., viewer) {
       stop("Invalid object")
     }
   }
+  if (nzchar(Sys.getenv("VSCODE_PROXY_URI"))) {
+    is.base_path <- grepl("\\:\\d+$", url)
+    url <- sub("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:)?",
+      sub("\\{port\\}", "", Sys.getenv("VSCODE_PROXY_URI")), url)
+    if (is.base_path) {
+      url <- paste0(url, "/")
+    }
+  }
   if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
     request_browser(url = url, title = title, ..., viewer = viewer)
   } else if (grepl("^https?\\://", url)) {
     message(
-      "VSCode WebView only supports showing local http content.\n",
+      if (nzchar(Sys.getenv("VSCODE_PROXY_URI"))) {
+        "VSCode WebView only supports showing local http content.\n"
+      } else {
+        "VSCode WebView only supports showing local http content.\n"
+      },
       "Opening in external browser..."
     )
     request_browser(url = url, title = title, ..., viewer = FALSE)

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -562,7 +562,7 @@ show_webview <- function(url, title, ..., viewer) {
   } else if (grepl("^https?\\://", url)) {
     message(
       if (nzchar(proxy_uri)) {
-        "VSCode WebView only supports showing local http content.\n"
+        "VSCode is not running on localhost but on a remote server.\n"
       } else {
         "VSCode WebView only supports showing local http content.\n"
       },

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -494,11 +494,12 @@ request_browser <- function(url, title, ..., viewer) {
 
 show_browser <- function(url, title = url, ...,
                          viewer = getOption("vsc.browser", "Active")) {
-  if (nzchar(Sys.getenv("VSCODE_PROXY_URI"))) {
-    is.base_path <- grepl("\\:\\d+$", url)
+  proxy_uri <- Sys.getenv("VSCODE_PROXY_URI")
+  if (nzchar(proxy_uri)) {
+    is_base_path <- grepl("\\:\\d+$", url)
     url <- sub("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:)?",
-      sub("\\{port\\}", "", Sys.getenv("VSCODE_PROXY_URI")), url)
-    if (is.base_path) {
+      sub("{port}", "", proxy_uri, fixed = TRUE), url)
+    if (is_base_path) {
       url <- paste0(url, "/")
     }
   }
@@ -506,7 +507,7 @@ show_browser <- function(url, title = url, ...,
     request_browser(url = url, title = title, ..., viewer = viewer)
   } else if (grepl("^https?\\://", url)) {
     message(
-      if (nzchar(Sys.getenv("VSCODE_PROXY_URI"))) {
+      if (nzchar(proxy_uri)) {
         "VSCode is not running on localhost but on a remote server.\n"
       } else {
         "VSCode WebView only supports showing local http content.\n"
@@ -547,11 +548,12 @@ show_webview <- function(url, title, ..., viewer) {
       stop("Invalid object")
     }
   }
-  if (nzchar(Sys.getenv("VSCODE_PROXY_URI"))) {
-    is.base_path <- grepl("\\:\\d+$", url)
+  proxy_uri <- Sys.getenv("VSCODE_PROXY_URI")
+  if (nzchar(proxy_uri)) {
+    is_base_path <- grepl("\\:\\d+$", url)
     url <- sub("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:)?",
-      sub("\\{port\\}", "", Sys.getenv("VSCODE_PROXY_URI")), url)
-    if (is.base_path) {
+      sub("{port}", "", proxy_uri, fixed = TRUE), url)
+    if (is_base_path) {
       url <- paste0(url, "/")
     }
   }
@@ -559,7 +561,7 @@ show_webview <- function(url, title, ..., viewer) {
     request_browser(url = url, title = title, ..., viewer = viewer)
   } else if (grepl("^https?\\://", url)) {
     message(
-      if (nzchar(Sys.getenv("VSCODE_PROXY_URI"))) {
+      if (nzchar(proxy_uri)) {
         "VSCode WebView only supports showing local http content.\n"
       } else {
         "VSCode WebView only supports showing local http content.\n"


### PR DESCRIPTION
*  Modify url to allow proxied requests

See https://github.com/REditorSupport/vscode-R/issues/275

>Shiny apps, htmlwidgets, etc. will open in separate browser windows on code-server if environment variable `VSCODE_PROXY_URI` is set. Should `options(vsc.helpPanel = FALSE)`, this is also true for the help panel when called from R terminal.
> 
> This does not affect the behaviour of the 'Help viewer' from the R extension itself, though.

## (If you do not have screenshot) How can I check this pull request?

https://github.com/REditorSupport/vscode-R/issues/275#issuecomment-929253126