### PR TITLE
Use r.session.viewers.viewColumn.helpPanel

### DIFF
--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import * as cheerio from 'cheerio';
 
 import { HelpFile, RHelp } from '.';
-import { setContext, UriIcon } from '../util';
+import { setContext, UriIcon, config } from '../util';
 
 //// Declaration of interfaces used/implemented by the Help Panel class
 // specified when creating a new help panel
@@ -117,10 +117,13 @@ export class HelpPanel {
 	}
 
 	// shows (internal) help file object in webview
-	public async showHelpFile(helpFile: HelpFile|Promise<HelpFile>, updateHistory = true, currentScrollY = 0, viewer?: string|any, preserveFocus: boolean = false): Promise<boolean>{
+	public async showHelpFile(helpFile: HelpFile | Promise<HelpFile>, updateHistory = true, currentScrollY = 0, viewer?: vscode.ViewColumn | string, preserveFocus: boolean = false): Promise<boolean>{
+		if (viewer === undefined) {
+			viewer = config().get<string>('session.viewers.viewColumn.helpPanel');
+		}
 
 		// update this.viewColumn if a valid viewer argument was supplied
-		if(typeof viewer === 'string'){
+		if (typeof viewer === 'string'){
 			this.viewColumn = <vscode.ViewColumn>vscode.ViewColumn[String(viewer)];
 		}
 


### PR DESCRIPTION
# What problem did you solve?

Closes #802 

The setting `r.session.viewers.viewColumn.helpPanel` was not respected by the help viewer. Now it is always used before opening a WebView of help viewer.

## (If you do not have screenshot) How can I check this pull request?

1. Open help for selection, and the help viewer should by default appear in view column "Two".
2. Close the help viewer.
3. Change setting `r.session.viewers.viewColumn.helpPanel` to `"Active"`.
4. Open help for selection again, and the help viewer should appear in view column "Active".
