### PR TITLE
Reenable 'unsafe-eval' in script-src CSP

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -632,7 +632,7 @@ export async function getWebviewHtml(webview: Webview, file: string, title: stri
         upgrade-insecure-requests;
         default-src https: data: filesystem:;
         style-src https: data: filesystem: 'unsafe-inline';
-        script-src https: data: filesystem: 'unsafe-inline';
+        script-src https: data: filesystem: 'unsafe-inline' 'unsafe-eval';
     `;
 
     return `


### PR DESCRIPTION
# What problem did you solve?

PR #771 replaced `unsafe-eval` with `unsafe-inline` in script-src CSP to make `flextable` work, but disabling `unsafe-eval` broke some of my package code which uses `htmlwidgets::JS`.

I think that putting both `unsafe-eval` and `unsafe-inline` in CSP allows to make both code work :

```
script-src https: data: filesystem: 'unsafe-inline' 'unsafe-eval';
```


## (If you do not have screenshot) How can I check this pull request?

The following code should produce a line plot with a red "Hello, world!" text.

```r
remotes::install_github("juba/obsplot")
library(obsplot)
library(htmlwidgets)
obsplot(aapl) |>
  mark_line(x = "Date", y = "Close") |>
  mark_function(JS("() => svg`<text x=20% y=20% fill=red>Hello, world!</text>`"))
```

Many thanks !