### PR TITLE
Use cwd in knit process

### DIFF
--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -74,11 +74,12 @@ export abstract class RMarkdownManager {
 					`-f`,
 					`${scriptPath}`
 				];
-				const processOptions = {
+				const processOptions: cp.SpawnOptions = {
 					env: {
 						...process.env,
 						...scriptArgs
-					}
+					},
+					cwd: vscode.workspace.workspaceFolders[0].uri.fsPath
 				};
 
 				let childProcess: DisposableProcess;


### PR DESCRIPTION
Make knitting sessions use the current workspace folder as cwd, so that .Rprofile is respected. Closes #800.

## How can I check this pull request?
1. Create a project with renv. 
2. Try (and fail) to preview/knit a document. 
3. Install rmarkdown
4. Successfully preview/knit the document