### PR TITLE
Httpgd plot viewer respects `r.session.viewers.viewColumn.plot`

### DIFF
--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 
@@ -60,8 +61,7 @@ export class HttpgdManager {
         this.viewerOptions = {
             parent: this,
             htmlRoot: htmlRoot,
-            preserveFocus: true,
-            viewColumn: vscode.ViewColumn.Two
+            preserveFocus: true
         };
     }
 
@@ -345,7 +345,8 @@ export class HttpgdViewer implements IHttpgdViewer {
                 this.checkStateDelayed();
             }
         });
-        this.customOverwriteCssPath = config().get('plot.customStyleOverwrites', '');
+        const conf = config();
+        this.customOverwriteCssPath = conf.get('plot.customStyleOverwrites', '');
         const localResourceRoots = (
             this.customOverwriteCssPath ?
             [extensionContext.extensionUri, vscode.Uri.file(path.dirname(this.customOverwriteCssPath))] :
@@ -355,7 +356,7 @@ export class HttpgdViewer implements IHttpgdViewer {
         this.htmlTemplate = fs.readFileSync(path.join(this.htmlRoot, 'index.ejs'), 'utf-8');
         this.smallPlotTemplate = fs.readFileSync(path.join(this.htmlRoot, 'smallPlot.ejs'), 'utf-8');
         this.showOptions = {
-            viewColumn: options.viewColumn ?? vscode.ViewColumn.Two,
+            viewColumn: options.viewColumn ?? vscode.ViewColumn[conf.get<string>('session.viewers.viewColumn.plot') || 'Two'],
             preserveFocus: !!options.preserveFocus
         };
         this.webviewOptions = {


### PR DESCRIPTION
# What problem did you solve?

Closes #814 

This PR makes httpgd plot viewer now respect `r.session.viewers.viewColumn.plot`. The value of plot view column is obtained from the settings on the creation of each httpgd plot viewer. The change of plot view column could be updated on creating new devices with new plot viewers.

## (If you have)Screenshot

## (If you do not have screenshot) How can I check this pull request?

Change the value of `r.session.viewers.viewColumn.plot` and create a new plot. Use `dev.off()` and create a new plot to use the latest setting.
