### PR TITLE
browser handles `file://`

### DIFF
--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -516,7 +516,7 @@ show_browser <- function(url, title = url, ...,
     )
     request_browser(url = url, title = title, ..., viewer = FALSE)
   } else {
-    path <- if (grepl("^file\\://", url)) sub("^file\\://", "", url) else url
+    path <- sub("^file\\://", "", url)
     if (file.exists(path)) {
       path <- normalizePath(path, "/", mustWork = TRUE)
       if (grepl("\\.html?$", path, ignore.case = TRUE)) {


### PR DESCRIPTION
# What problem did you solve?

Closes #812 

`show_browser` now handles `file://` input so that the file could be open by system.

## How can I check this pull request?

Create a file, start R and run `.vsc.browser("file:///path/to/the/file.abc")`.