### PR TITLE
Completely replace `View()`

### DIFF
--- a/R/session/init.R
+++ b/R/session/init.R
@@ -64,13 +64,7 @@ init_last <- function() {
     .vsc.browser <- .vsc$show_browser
     .vsc.viewer <- .vsc$show_viewer
     .vsc.page_viewer <- .vsc$show_page_viewer
-
-    # assign functions that are optional:
-    for (funcName in c("View")) {
-      if (funcName %in% ls(.vsc)) {
-        assign(funcName, .vsc[[funcName]])
-      }
-    }
+    View <- .vsc.view
     environment()
   })
   attach(exports, name = .vsc.name, warn.conflicts = FALSE)

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -454,7 +454,7 @@ if (show_view) {
     }
   }
 
-  View <- show_dataview
+  rebind("View", show_dataview, "utils")
 }
 
 attach <- function() {


### PR DESCRIPTION
# What problem did you solve?

Closes https://github.com/randy3k/radian/issues/316.

This PR completely replaces `View()` and `utils::View()` in favor of the session watcher version so that `tibble::view` also opens a data viewer in vscode.

## (If you do not have screenshot) How can I check this pull request?

The following should all open a data viewer in vscode:

```r
View(mtcars)
utils::View(mtcars)
tibble::view(mtcars)
```
