### PR TITLE
Check workspace folder with both original and real path

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -660,13 +660,21 @@ export async function getWebviewHtml(webview: Webview, file: string, title: stri
 
 function isFromWorkspace(dir: string) {
     if (workspace.workspaceFolders === undefined) {
-        const rel = path.relative(os.homedir(), dir);
+        let rel = path.relative(os.homedir(), dir);
+        if (rel === '') {
+            return true;
+        }
+        rel = path.relative(fs.realpathSync(os.homedir()), dir);
         if (rel === '') {
             return true;
         }
     } else {
         for (const folder of workspace.workspaceFolders) {
-            const rel = path.relative(folder.uri.fsPath, dir);
+            let rel = path.relative(folder.uri.fsPath, dir);
+            if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
+                return true;
+            }
+            rel = path.relative(fs.realpathSync(folder.uri.fsPath), dir);
             if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
                 return true;
             }


### PR DESCRIPTION
# What problem did you solve?

Closes #393
Closes #628
Closes #825 

This PR make `isFromWorkspace` also check if the session requests come from the real path of the workspace folders if they are symlinks so that session watcher could work with symlink workspace folders.

## How can I check this pull request?

1. Create a folder `test`.
2. Create a symlink `test2` to that folder.
3. Open workspace folder `test2` in vscode and create an R file to activate vscode-R.
4. Start an R session, `getwd()` shows its working directory is `test` instead of `test2`.
5. But the real path of `test2` is `test`, so the session will be attached.
6. Session watcher features should now work: session symbols, workspace viewer, `View(mtcars)`, `plot(rnorm(100))`, etc.