### PR TITLE
Add support for indented Roxygen

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,7 +163,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
                 // Automatically continue roxygen comments: #'
                 action: { indentAction: vscode.IndentAction.None, appendText: '#\' ' },
                 beforeText: /^\s*#'/, // matches any roxygen comment line, even an empty one
-                previousLineText: /^\s*([^#].*|#[^'].*|#'\s*[^\s].*|)$/, // matches everything but an empty roxygen line
+                previousLineText: /^\s*([^#\s].*|#[^'\s].*|#'\s*[^\s].*|)$/, // matches everything but an empty roxygen line
             },
         ],
         wordPattern,


### PR DESCRIPTION
Fix #845 

I am having an issue where `#'` is sometimes auto-closed as `#'<CURSOR HERE>'`, but this seems to be caused by neovim or some other extension.

*Edit: The roxygen-block is now automatically exited after two empty lines (after a single empty line would be too early, I think), just let me know if this feels more like a bug or a feature.*