### PR TITLE
Use new terminal API

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,10 +61,19 @@
     "onCommand:r.helpPanel.back",
     "onCommand:r.helpPanel.forward",
     "onCommand:r.helpPanel.openForSelection",
-    "onWebviewPanel:rhelp"
+    "onWebviewPanel:rhelp",
+    "onTerminalProfile:r.terminal-profile"
   ],
   "main": "./out/extension",
   "contributes": {
+    "terminal": {
+      "profiles": [
+        {
+          "title": "R Terminal",
+          "id": "r.terminal-profile"
+        }
+      ]
+    },
     "viewsContainers": {
       "activitybar": [
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,6 +168,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         ],
         wordPattern,
     });
+    
+    // register terminal-provider
+    context.subscriptions.push(vscode.window.registerTerminalProfileProvider('r.terminal-profile',
+        {
+            async provideTerminalProfile() {
+                return {
+                    options: await rTerminal.makeTerminalOptions()
+                };
+            }
+        }
+    ));
 
     // initialize httpgd viewer
     globalHttpgdManager = httpgdViewer.initializeHttpgd();


### PR DESCRIPTION
This PR adds a terminal profile for R using the API discussed e.g. in https://github.com/microsoft/vscode/issues/120369.

The existing "Create R Terminal" command is not affected. Creating a terminal using the terminal profile should behave the same as using the command.

The API to add a custom icon for the terminal profile is still being discussed (https://github.com/microsoft/vscode/issues/127607), so I just left the default icon for now.

**To test:**
Call the command `Terminal: Create new terminal (with profile)` and select `R Terminal` or use the dropdown next to the new terminal button.