### PR TITLE
Show httpgd plot on attach

### DIFF
--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -480,16 +480,13 @@ attach <- function() {
   request("attach",
     version = sprintf("%s.%s", R.version$major, R.version$minor),
     tempdir = tempdir,
-    plot = getOption("vsc.plot", "Two"),
     info = list(
       command = commandArgs()[[1L]],
       version = R.version.string,
       start_time = format(file.info(tempdir)$ctime)
-    )
+    ),
+    plot_url = if (identical(names(dev.cur()), "httpgd")) httpgd::hgd_url()
   )
-  if (identical(names(dev.cur()), "httpgd")) {
-    .vsc$request("httpgd", url = httpgd::hgd_url())
-  }
 }
 
 path_to_uri <- function(path) {

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -11,7 +11,6 @@ import { docProvider, docScheme } from './virtualDocs';
 
 // Workspace Vars
 let guestPid: string;
-let guestPlotView: string;
 export let guestGlobalenv: unknown;
 export let guestResDir: string;
 let rVer: string;
@@ -103,7 +102,6 @@ export async function updateGuestRequest(file: string, force: boolean = false): 
                     }
                     case 'attach': {
                         guestPid = String(request.pid);
-                        guestPlotView = String(request.plot);
                         console.info(`[updateGuestRequest] attach PID: ${guestPid}`);
                         sessionStatusBarItem.text = `Guest R ${rVer}: ${guestPid}`;
                         sessionStatusBarItem.tooltip = `${info.version}\nProcess ID: ${guestPid}\nCommand: ${info.command}\nStart time: ${info.start_time}\nClick to attach to host terminal.`;
@@ -133,7 +131,6 @@ export async function updateGuestRequest(file: string, force: boolean = false): 
             }
         } else {
             guestPid = String(request.pid);
-            guestPlotView = String(request.plot);
             rVer = String(request.version);
             info = request.info;
 
@@ -159,16 +156,17 @@ export function updateGuestGlobalenv(hostEnv: string): void {
 let panel: vscode.WebviewPanel = undefined;
 export async function updateGuestPlot(file: string): Promise<void> {
     const plotContent = await readContent(file, 'base64');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const guestPlotView: vscode.ViewColumn = vscode.ViewColumn[config().get<string>('session.viewers.viewColumn.plot')];
     if (plotContent) {
         if (panel) {
             panel.webview.html = getGuestImageHtml(plotContent);
-            panel.reveal(vscode.ViewColumn[guestPlotView], true);
+            panel.reveal(guestPlotView, true);
         } else {
             panel = vscode.window.createWebviewPanel('dataview', 'R Guest Plot',
                 {
                     preserveFocus: true,
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    viewColumn: vscode.ViewColumn[guestPlotView],
+                    viewColumn: guestPlotView,
                 },
                 {
                     enableScripts: true,

--- a/src/session.ts
+++ b/src/session.ts
@@ -31,7 +31,6 @@ let info: any;
 export let globalenvFile: string;
 let globalenvLockFile: string;
 let globalenvTimeStamp: number;
-let plotView: string;
 let plotFile: string;
 let plotLockFile: string;
 let plotTimeStamp: number;
@@ -163,7 +162,7 @@ async function updatePlot() {
             void commands.executeCommand('vscode.open', Uri.file(plotFile), {
                 preserveFocus: true,
                 preview: true,
-                viewColumn: ViewColumn[plotView],
+                viewColumn: ViewColumn[config().get<string>('session.viewers.viewColumn.plot')],
             });
             console.info('[updatePlot] Done');
             if (isLiveShare()) {
@@ -740,13 +739,15 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                         info = request.info;
                         sessionDir = path.join(request.tempdir, 'vscode-R');
                         workingDir = request.wd;
-                        plotView = String(request.plot);
                         console.info(`[updateRequest] attach PID: ${pid}`);
                         sessionStatusBarItem.text = `R ${rVer}: ${pid}`;
                         sessionStatusBarItem.tooltip = `${info.version}\nProcess ID: ${pid}\nCommand: ${info.command}\nStart time: ${info.start_time}\nClick to attach to active terminal.`;
                         sessionStatusBarItem.show();
                         updateSessionWatcher();
                         purgeAddinPickerItems();
+                        if (request.plot_url) {
+                            globalHttpgdManager?.showViewer(request.plot_url);
+                        }
                         break;
                     }
                     case 'browser': {


### PR DESCRIPTION
# What problem did you solve?

Close #832 

This PR moves the separate `httpgd` request url into the `attach` request. If a `httpgd` device is open, then its url is also sent to session watcher on attach.

This PR also removes the code to send `vsc.plot` back to session watcher as it is already defined as `r.session.viewers.viewColumn.plot` in vscode settings.

## (If you do not have screenshot) How can I check this pull request?

1. Open a workspace folder.
2. Create R terminal and session watcher attaches to the R session.
3. Run `plot(rnorm(100))` and close the httpgd plot viewer.
4. Create another R terminal and session watcher attaches to the new R session.
5. Go to the first R terminal and run "Attach active terminal" or click the status bar item.
6. The first session should be attached and the httpgd plot viewer should also appear.