### PR TITLE
Fix detecting yaml frontmatter

### DIFF
--- a/src/rmarkdown/knit.ts
+++ b/src/rmarkdown/knit.ts
@@ -100,7 +100,7 @@ export class RMarkdownKnitManager extends RMarkdownManager {
 		}
 
 		let yamlText = undefined;
-		if (startLine >= 0 && endLine >= 0 && startLine + 1 < endLine) {
+		if (startLine + 1 < endLine) {
 			yamlText = lines.slice(startLine + 1, endLine).join('\n');
 		}
 

--- a/src/rmarkdown/knit.ts
+++ b/src/rmarkdown/knit.ts
@@ -78,16 +78,37 @@ export class RMarkdownKnitManager extends RMarkdownManager {
 	}
 
 	private getYamlFrontmatter(docPath: string): IYamlFrontmatter {
-		const parseData = fs.readFileSync(docPath, 'utf8');
-		const yamlDat = /(?<=(---)).*(?=(---))/gs.exec(
-			parseData
-		);
+		const text = fs.readFileSync(docPath, 'utf8');
+		const lines = text.split('\n');
+		let startLine = -1;
+		let endLine = -1;
+		for (let i = 0; i < lines.length; i++) {
+			if (/\S/.test(lines[i])) {
+				if (startLine < 0) {
+					if (lines[i].startsWith('---')) {
+						startLine = i;
+					} else {
+						break;
+					}
+				} else {
+					if (lines[i].startsWith('---')) {
+						endLine = i;
+						break;
+					}
+				}
+			}
+		}
+
+		let yamlText = undefined;
+		if (startLine >= 0 && endLine >= 0 && startLine + 1 < endLine) {
+			yamlText = lines.slice(startLine + 1, endLine).join('\n');
+		}
 
 		let paramObj = {};
-		if (yamlDat) {
+		if (yamlText) {
 			try {
 				paramObj = yaml.load(
-					yamlDat[0]
+					yamlText
 				);
 			} catch (e) {
 				console.error(`Could not parse YAML frontmatter for "${docPath}". Error: ${String(e)}`);


### PR DESCRIPTION
# What problem did you solve?

Closes #855

This PR fixes the detection of yaml frontmatter in rmd. It only tries to capture the first yaml chunk surrounded by `---` at the top of the document.

## (If you do not have screenshot) How can I check this pull request?

Knit the following document should use `bookdown::render_book` instead of `rmarkdown::render`.

```
---
output: bookdown::gitbook
knit: bookdown::render_book
---

# Test

Para.

---

# Next
```