### PR TITLE
Add backtick to list of quote characters for syntax highlighting.

### DIFF
--- a/syntax/r.json
+++ b/syntax/r.json
@@ -262,11 +262,11 @@
                             "name": "punctuation.definition.string.end.r"
                         }
                     },
-                    "name": "string.quoted.single.r",
+                    "name": "variable.parameter.r",
                     "patterns": [
                         {
                             "match": "\\\\.",
-                            "name": "constant.character.escape.r"
+                            "name": "variable.parameter.r"
                         }
                     ]
                 }

--- a/syntax/r.json
+++ b/syntax/r.json
@@ -248,6 +248,27 @@
                             "name": "constant.character.escape.r"
                         }
                     ]
+                },
+                {
+                    "begin": "`",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.begin.r"
+                        }
+                    },
+                    "end": "`",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.end.r"
+                        }
+                    },
+                    "name": "string.quoted.single.r",
+                    "patterns": [
+                        {
+                            "match": "\\\\.",
+                            "name": "constant.character.escape.r"
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
# What problem did you solve?
Backticks are a legal way to quote strings in R. Added backticks to list of quote characters for syntax highlighting.

## Screenshot
Before:
<img width="209" alt="before" src="https://user-images.githubusercontent.com/55784605/140644520-97a64897-cb84-4f5e-a3c1-0825d5f4a651.png">
After:
<img width="256" alt="after" src="https://user-images.githubusercontent.com/55784605/140644521-272151ed-9eae-44e0-8425-b10c522f8c8c.png">

