### PR TITLE
Auto refresh help

### DIFF
--- a/R/help/helpServer.R
+++ b/R/help/helpServer.R
@@ -1,8 +1,6 @@
 # get values from extension-set env values
 lim <- Sys.getenv("VSCR_LIM")
 
-SLEEP_DURATION <- 1
-
 NEW_PACKAGE_STRING <- "NEW_PACKAGES"
 
 cat(
@@ -12,13 +10,15 @@ cat(
     sep = ""
 )
 
-currentPackages <- .packages(all.available = TRUE)
+currentPackages <- NULL
 
 while (TRUE) {
-    Sys.sleep(1)
-    newPackages <- .packages(all.available = TRUE)
+    newPackages <- installed.packages(fields = "Packaged")[, c("Version", "Packaged")]
     if (!identical(currentPackages, newPackages)) {
-        cat(NEW_PACKAGE_STRING, "\n")
+        if (!is.null(currentPackages)) {
+            cat(NEW_PACKAGE_STRING, "\n")
+        }
         currentPackages <- newPackages
     }
+    Sys.sleep(1)
 }

--- a/R/help/helpServer.R
+++ b/R/help/helpServer.R
@@ -1,6 +1,10 @@
 # get values from extension-set env values
 lim <- Sys.getenv("VSCR_LIM")
 
+SLEEP_DURATION <- 1
+
+NEW_PACKAGE_STRING <- "NEW_PACKAGES"
+
 cat(
     lim,
     tools::startDynamicHelp(),
@@ -8,4 +12,13 @@ cat(
     sep = ""
 )
 
-while (TRUE) Sys.sleep(1)
+currentPackages <- .packages(all.available = TRUE)
+
+while (TRUE) {
+    Sys.sleep(1)
+    newPackages <- .packages(all.available = TRUE)
+    if (!identical(currentPackages, newPackages)) {
+        cat(NEW_PACKAGE_STRING, "\n")
+        currentPackages <- newPackages
+    }
+}

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -175,7 +175,7 @@ export class RHelp implements api.HelpPanel, vscode.WebviewPanelSerializer<strin
 		this.webviewScriptFile = vscode.Uri.file(options.webviewScriptPath);
 		this.webviewStyleFile = vscode.Uri.file(options.webviewStylePath);
 		const pkgListener = () => {
-			void vscode.window.showInformationMessage('Restarting Help Server...');
+			void console.log('Restarting Help Server...');
 			void this.refresh(true);
 		};
 		this.helpProvider = new HelpProvider({...options, pkgListener: pkgListener});

--- a/src/helpViewer/packages.ts
+++ b/src/helpViewer/packages.ts
@@ -114,10 +114,10 @@ export class PackageManager {
 
     // Functions to force a refresh of listed packages
     // Useful e.g. after installing/removing packages
-    public refresh(): void {
+    public async refresh(): Promise<void> {
+        await this.clearCachedFiles();
         this.cranUrl = undefined;
         this.pullFavoriteNames();
-        void this.clearCachedFiles();
     }
 
     // Funciton to clear only the cached files regarding an individual package etc.

--- a/src/helpViewer/treeView.ts
+++ b/src/helpViewer/treeView.ts
@@ -74,6 +74,10 @@ export class HelpTreeWrapper {
             listener(node);
         }
     }
+    
+    public refreshPackageRootNode(): void {
+        this.helpViewProvider.rootItem?.pkgRootNode?.refresh();
+    }
 }
 
 
@@ -164,7 +168,7 @@ abstract class Node extends vscode.TreeItem{
     // Only internal commands are handled here, custom commands are implemented in _handleCommand!
     public handleCommand(cmd: cmdName){
         if(cmd === 'CALLBACK' && this.callBack){
-            this.callBack();
+            void this.callBack();
         } else if(cmd === 'QUICKPICK'){
             if(this.quickPickCommand){
                 this._handleCommand(this.quickPickCommand);
@@ -186,7 +190,7 @@ abstract class Node extends vscode.TreeItem{
 
     // implement this to handle callBacks (simple clicks on a node)
     // can also be implemented in _handleCommand('CALLBACK')
-    public callBack?(): void;
+    public callBack?(): void | Promise<void>;
 
     // Shows a quickpick containing the children of a node
     // If the picked child has children itself, another quickpick is shown
@@ -580,8 +584,8 @@ class RefreshNode extends MetaNode {
 	label = 'Clear Cached Index Files & Restart Help Server';
     iconPath = new vscode.ThemeIcon('refresh');
 
-    callBack(){
-        this.rHelp.refresh();
+    async callBack(){
+        await this.rHelp.refresh();
         this.parent.pkgRootNode.refresh();
     }
 }


### PR DESCRIPTION
Fix #854

Ho to check:
 - Have vscode open, install a new package in a separate process, use R help viewer. The Package should show up in the corresponding lists.
 - Open the treeview `R > Help Pages > Help Topics by Package`, install/remove a package in a separate process. The treeview should automatically refresh to reflect the change.

*Edit:*
I also refactored a bit of help-related code to make implementing this a bit easier. The most relevant changes are in [helpServer.R](https://github.com/ManuelHentschel/vscode-R/blob/d0154b35cfee01b8082027dd1683d609bbe5becc/R/help/helpServer.R#L19-L23) and [helpProvider.ts](https://github.com/ManuelHentschel/vscode-R/blob/d0154b35cfee01b8082027dd1683d609bbe5becc/src/helpViewer/helpProvider.ts#L74-L77).
