### PR TITLE
adding devtools tasks to command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -433,22 +433,22 @@
       {
         "title": "Check",
         "category": "R Package",
-        "command": "r.checkTask"
+        "command": "r.check"
       },
       {
         "title": "Document",
         "category": "R Package",
-        "command": "r.documentTask"
+        "command": "r.document"
       },
       {
         "title": "Install",
         "category": "R Package",
-        "command": "r.installTask"
+        "command": "r.install"
       },
       {
         "title": "Test",
         "category": "R Package",
-        "command": "r.testTask"
+        "command": "r.test"
       },
       {
         "title": "Attach Active Terminal",

--- a/package.json
+++ b/package.json
@@ -422,33 +422,33 @@
       },
       {
         "title": "Load All",
-        "category": "R",
+        "category": "R Package",
         "command": "r.loadAll"
       },
       {
-        "title": "Test Package",
-        "category": "R",
-        "command": "r.test"
-      },
-      {
-        "title": "Install Package",
-        "category": "R",
-        "command": "r.install"
-      },
-      {
-        "title": "Build Package",
-        "category": "R",
+        "title": "Build",
+        "category": "R Package",
         "command": "r.build"
       },
       {
-        "title": "Document",
-        "category": "R",
-        "command": "r.document"
+        "title": "Check",
+        "category": "R Package",
+        "command": "r.checkTask"
       },
       {
-        "title": "Check",
-        "category": "R",
-        "command": "r.check"
+        "title": "Document",
+        "category": "R Package",
+        "command": "r.documentTask"
+      },
+      {
+        "title": "Install",
+        "category": "R Package",
+        "command": "r.installTask"
+      },
+      {
+        "title": "Test",
+        "category": "R Package",
+        "command": "r.testTask"
       },
       {
         "title": "Attach Active Terminal",

--- a/package.json
+++ b/package.json
@@ -446,6 +446,11 @@
         "command": "r.document"
       },
       {
+        "title": "Check",
+        "category": "R",
+        "command": "r.check"
+      },
+      {
         "title": "Attach Active Terminal",
         "category": "R",
         "command": "r.attachActive"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,11 +108,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
-        'r.buildTask': () => vscode.commands.executeCommand("workbench.action.tasks.runTask", "R: Build"),
-        'r.checkTask': () => vscode.commands.executeCommand("workbench.action.tasks.runTask", "R: Check"),
-        'r.documentTask': () => vscode.commands.executeCommand("workbench.action.tasks.runTask", "R: Document"),
-        'r.installTask': () => vscode.commands.executeCommand("workbench.action.tasks.runTask", "R: Install"),
-        'r.testTask': () => vscode.commands.executeCommand("workbench.action.tasks.runTask", "R: Test"),
+        'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),
+        'r.check': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Check'),
+        'r.document': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Document'),
+        'r.install': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Install'),
+        'r.test': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Test'),
 
         // interaction with R sessions
         'r.previewDataframe': preview.previewDataframe,
@@ -171,7 +171,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         ],
         wordPattern,
     });
-    
+
     // register terminal-provider
     context.subscriptions.push(vscode.window.registerTerminalProfileProvider('r.terminal-profile',
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,6 +110,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.install': () => rTerminal.runTextInTerm('devtools::install()'),
         'r.build': () => rTerminal.runTextInTerm('devtools::build()'),
         'r.document': () => rTerminal.runTextInTerm('devtools::document()'),
+        'r.check': () => rTerminal.runTextInTerm('devtools::check()'),
 
         // interaction with R sessions
         'r.previewDataframe': preview.previewDataframe,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,11 +106,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         // editor independent commands
         'r.createGitignore': rGitignore.createGitignore,
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
-        'r.test': () => rTerminal.runTextInTerm('devtools::test()'),
-        'r.install': () => rTerminal.runTextInTerm('devtools::install()'),
-        'r.build': () => rTerminal.runTextInTerm('devtools::build()'),
-        'r.document': () => rTerminal.runTextInTerm('devtools::document()'),
-        'r.check': () => rTerminal.runTextInTerm('devtools::check()'),
+
+        // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
+        'r.buildTask': () => vscode.commands.executeCommand("workbench.action.tasks.runTask", "R: Build"),
+        'r.checkTask': () => vscode.commands.executeCommand("workbench.action.tasks.runTask", "R: Check"),
+        'r.documentTask': () => vscode.commands.executeCommand("workbench.action.tasks.runTask", "R: Document"),
+        'r.installTask': () => vscode.commands.executeCommand("workbench.action.tasks.runTask", "R: Install"),
+        'r.testTask': () => vscode.commands.executeCommand("workbench.action.tasks.runTask", "R: Test"),
 
         // interaction with R sessions
         'r.previewDataframe': preview.previewDataframe,
@@ -205,6 +207,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     vscode.tasks.registerTaskProvider(type, {
         provideTasks() {
             return [
+                new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Build', 'R',
+                    new vscode.ShellExecution('Rscript -e "devtools::build()"')),
                 new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Check', 'R',
                     new vscode.ShellExecution('Rscript -e "devtools::check()"')),
                 new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Document', 'R',


### PR DESCRIPTION
# What problem did you solve?
while the majority of `devtools::*` package develop/build shortcuts were available, `devtools::check()` was missing.

## (If you have)Screenshot

![R: Check available in Command Palette and sends to R console](https://user-images.githubusercontent.com/5963623/143293553-589486f9-399b-4f54-a55c-f1a03ea715be.png)

## (If you do not have screenshot) How can I check this pull request?
Build version > `Cmd + Shift + P` > Type `R: Check` > Press Enter
