### PR TITLE
Clean up of help related files

### DIFF
--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -11,7 +11,6 @@ export declare class RExtension {
 export type HelpSubMenu = 'doc' | 'pkgList' | 'refresh' | '?' | '??';
 
 export interface HelpPanel {
-	showHelpMenu(): void;
 	showHelpForPath(requestPath?: string): void;
 	dispose(): void;
 	refresh(): void;

--- a/src/helpViewer/cran.ts
+++ b/src/helpViewer/cran.ts
@@ -46,13 +46,13 @@ export async function getPackagesFromCran(cranUrl: string): Promise<Package[]> {
 }
 
 function parseCranPackagesFile(html: string): Package[] {
-    const packageNames = html.match(/^Package: .*$/gm)?.map(s => s.replace(/^Package: /, ''));
-    const packages: Package[] = packageNames?.map(s => ({
+    const packageNames = html.match(/^Package: .*$/gm)?.map(s => s.replace(/^Package: /, '')) || [];
+    const packages: Package[] = packageNames.map(s => ({
         name: s,
         description: '',
         isCran: true
     }));
-    return packages || [];
+    return packages;
 }
 
 function parseCranJson(jsonString: string): Package[] {
@@ -91,16 +91,16 @@ function parseCranTable(html: string, baseUrl: string): Package[] {
                 const e2 = elements[2];
                 if(
                     e0.type === 'tag' && e1.type === 'tag' &&
-                    e0.firstChild.type === 'text' && e1.children[1].type === 'tag' &&
+                    e0.firstChild?.type === 'text' && e1.children[1].type === 'tag' &&
                     e2.type === 'tag'
                 ){
                     const href = e1.children[1].attribs['href'];
                     const url = new URL(href, baseUrl).toString();
                     ret.push({
                         date: (e0.firstChild.data || '').trim(),
-                        name: (e1.children[1].firstChild.data || '').trim(),
+                        name: (e1.children[1].firstChild?.data || '').trim(),
                         href: url,
-                        description: (e2.firstChild.data || '').trim(),
+                        description: (e2.firstChild?.data || '').trim(),
                         isCran: true
                     });
                 }

--- a/src/helpViewer/cran.ts
+++ b/src/helpViewer/cran.ts
@@ -1,0 +1,117 @@
+
+import * as cheerio from 'cheerio';
+import { Package} from './packages';
+import fetch from 'node-fetch';
+
+type ParseFunction = (html: string, baseUrl: string) => Package[];
+
+export async function getPackagesFromCran(cranUrl: string): Promise<Package[]> {
+    const cranSites: {url: string, parseFunction: ParseFunction}[] = [
+        {
+            url: new URL('stats/descriptions', cranUrl).toString(),
+            parseFunction: parseCranJson
+        },
+        {
+            url: new URL('web/packages/available_packages_by_date.html', cranUrl).toString(),
+            parseFunction: parseCranTable
+        },
+        {
+            url: new URL('src/contrib/PACKAGES', cranUrl).toString(),
+            parseFunction: parseCranPackagesFile
+        }
+    ];
+    let packages: Package[] = [];
+    for(const site of cranSites){
+        try{
+            // fetch html
+            process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // seems to fail otherwise?
+            const res = await fetch(site.url);
+            const html = await (res).text();
+
+            // parse html
+            packages = site.parseFunction(html, site.url);
+        } catch(e) {
+            // These errors are expected, if the repo does not serve a specific URL
+        } finally {
+            // make sure to use safe https again
+            process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
+        }
+
+        // break if successfully fetched & parsed
+        if(packages?.length){
+            break;
+        }
+    }
+    return packages;
+}
+
+function parseCranPackagesFile(html: string): Package[] {
+    const packageNames = html.match(/^Package: .*$/gm)?.map(s => s.replace(/^Package: /, ''));
+    const packages: Package[] = packageNames?.map(s => ({
+        name: s,
+        description: '',
+        isCran: true
+    }));
+    return packages || [];
+}
+
+function parseCranJson(jsonString: string): Package[] {
+    const lines = jsonString.split('\n').filter(v => v);
+    const pkgs = lines.map(line => {
+        const j = JSON.parse(line) as {[key: string]: string};
+        const pkg: Package = {
+            name: j['Package'],
+            description: j['Title'],
+            date: j['modified'],
+            isCran: true
+        };
+        return pkg;
+    });
+    return pkgs;
+}
+
+function parseCranTable(html: string, baseUrl: string): Package[] {
+    if(!html){
+        return [];
+    }
+    const $ = cheerio.load(html);
+    const tables = $('table');
+    const ret: Package[] = [];
+
+    // loop over all tables on document and each row as one index entry
+    // assumes that the provided html is from a valid index file
+    tables.each((tableIndex, table) => {
+        const rows = $('tr', table);
+        rows.each((rowIndex, row) => {
+            const elements = $('td', row);
+            if(elements.length === 3){
+
+                const e0 = elements[0];
+                const e1 = elements[1];
+                const e2 = elements[2];
+                if(
+                    e0.type === 'tag' && e1.type === 'tag' &&
+                    e0.firstChild.type === 'text' && e1.children[1].type === 'tag' &&
+                    e2.type === 'tag'
+                ){
+                    const href = e1.children[1].attribs['href'];
+                    const url = new URL(href, baseUrl).toString();
+                    ret.push({
+                        date: (e0.firstChild.data || '').trim(),
+                        name: (e1.children[1].firstChild.data || '').trim(),
+                        href: url,
+                        description: (e2.firstChild.data || '').trim(),
+                        isCran: true
+                    });
+                }
+            }
+        });
+    });
+
+    const retSorted = ret.sort((a, b) => a.name.localeCompare(b.name));
+
+    return retSorted;
+}
+
+
+

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -34,9 +34,10 @@ export class HelpProvider {
         this.port = this.launchRHelpServer(); // is a promise for now!
     }
 
-    public refresh(): void {
+    public async refresh(): Promise<void> {
         kill(this.cp.pid); // more reliable than cp.kill (?)
         this.port = this.launchRHelpServer();
+        await this.port;
     }
 
     public async launchRHelpServer(): Promise<number>{

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -35,7 +35,9 @@ export class HelpProvider {
     }
 
     public async refresh(): Promise<void> {
-        kill(this.cp.pid); // more reliable than cp.kill (?)
+        if(!this.cp.exitCode){
+            kill(this.cp.pid); // more reliable than cp.kill (?)
+        }
         this.port = this.launchRHelpServer();
         await this.port;
     }

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -21,7 +21,7 @@ export interface RHelpProviderOptions {
 
 // Class to forward help requests to a backgorund R instance that is running a help server
 export class HelpProvider {
-    private cp: cp.ChildProcess;
+    private cp?: cp.ChildProcess;
     private port: number|Promise<number>;
     private readonly rPath: string;
     private readonly cwd?: string;
@@ -35,7 +35,7 @@ export class HelpProvider {
     }
 
     public async refresh(): Promise<void> {
-        if(!this.cp.exitCode){
+        if(this.cp){
             kill(this.cp.pid); // more reliable than cp.kill (?)
         }
         this.port = this.launchRHelpServer();
@@ -58,12 +58,20 @@ export class HelpProvider {
             cwd: this.cwd,
             env: { ...process.env, 'VSCR_LIM': lim }
         };
-        this.cp = cp.exec(cmd, cpOptions);
+        const childProcess = cp.exec(cmd, cpOptions);
+        this.cp = childProcess;
+
+        const onCpExit = () => {
+            this.cp = undefined;
+            this.port = 0;
+        };
+        childProcess.on('exit', onCpExit);
+        childProcess.on('error', onCpExit);
 
         let str = '';
         // promise containing the first output of the r process (contains only the port number)
         const portPromise = new Promise<string>((resolve) => {
-            this.cp.stdout?.on('data', (data) => {
+            childProcess.stdout?.on('data', (data) => {
                 try{
                     // eslint-disable-next-line
                     str += data.toString();
@@ -79,7 +87,7 @@ export class HelpProvider {
                     str = str.replace(newPackageRegex, '');
                 }
             });
-            this.cp.on('close', () => {
+            childProcess.on('close', () => {
                 resolve('');
             });
         });
@@ -161,6 +169,7 @@ export class HelpProvider {
 
 
     dispose(): void {
+        this.port = 0;
         if(this.cp){
             kill(this.cp.pid);
         }

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -81,7 +81,10 @@ export class HelpPanel {
 		return this.panel.webview;
     }
 
-	private initializePanel() {
+	private initializePanel(): void {
+		if(!this.panel){
+			return;
+		}
 		this.panel.iconPath = new UriIcon('help');
 		// virtual uris used to access local files
 		this.webviewScriptUri = this.panel.webview.asWebviewUri(this.webviewScriptFile);

--- a/src/helpViewer/treeView.ts
+++ b/src/helpViewer/treeView.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { RHelp } from '.';
+import { doWithProgress } from '../util';
 import { Package, Topic, TopicType } from './packages';
 
 // this enum is re-assigned just for code readability
@@ -581,11 +582,11 @@ class Search2Node extends MetaNode {
 
 class RefreshNode extends MetaNode {
     parent: RootNode;
-	label = 'Clear Cached Index Files & Restart Help Server';
+	label = 'Clear Cache & Restart Help Server';
     iconPath = new vscode.ThemeIcon('refresh');
 
     async callBack(){
-        await this.rHelp.refresh();
+        await doWithProgress(() => this.rHelp.refresh());
         this.parent.pkgRootNode.refresh();
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -268,7 +268,7 @@ export async function doWithProgress<T>(cb: (token?: vscode.CancellationToken, p
 // argument path is optional and should be relative to the cran root
 // currently the CRAN root url is hardcoded, this could be replaced by reading
 // the url from config, R, or both
-export async function getCranUrl(path?: string, cwd?: string): Promise<string> {
+export async function getCranUrl(path: string = '', cwd?: string): Promise<string> {
     const defaultCranUrl = 'https://cran.r-project.org/';
     // get cran URL from R. Returns empty string if option is not set.
     const baseUrl = await executeRCommand('cat(getOption(\'repos\')[\'CRAN\'])', undefined, cwd);


### PR DESCRIPTION
Includes some general clean up of help related files.
 - Convert methods to functions if they can be standalone
 - Correctly handle `null`/`undefiend` (set `"strictNullChecks": true` in tsconfig.json to check)