### PR TITLE
Use `SIGKILL` to kill help server

### DIFF
--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -2,7 +2,6 @@
 import { Memento, window } from 'vscode';
 import * as http from 'http';
 import * as cp from 'child_process';
-import * as kill from 'tree-kill';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -39,8 +38,8 @@ export class HelpProvider {
     }
 
     public async refresh(): Promise<void> {
-        if(this.cp.running){
-            kill(this.cp.pid); // more reliable than cp.kill (?)
+        if (this.cp.running) {
+            this.cp.kill();
         }
         this.cp = this.launchRHelpServer();
         await this.cp.port;
@@ -173,8 +172,8 @@ export class HelpProvider {
 
 
     dispose(): void {
-        if(this.cp.running){
-            kill(this.cp.pid);
+        if (this.cp.running) {
+            this.cp.kill();
         }
     }
 }

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -2,6 +2,7 @@
 import { Memento, window } from 'vscode';
 import * as http from 'http';
 import * as cp from 'child_process';
+import * as kill from 'tree-kill';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -39,7 +40,8 @@ export class HelpProvider {
 
     public async refresh(): Promise<void> {
         if (this.cp.running) {
-            this.cp.kill();
+            // this.cp.kill('SIGKILL');
+            kill(this.cp.pid, 'SIGKILL'); // more reliable than cp.kill (?)
         }
         this.cp = this.launchRHelpServer();
         await this.cp.port;
@@ -173,7 +175,8 @@ export class HelpProvider {
 
     dispose(): void {
         if (this.cp.running) {
-            this.cp.kill();
+            // this.cp.kill('SIGKILL');
+            kill(this.cp.pid, 'SIGKILL');
         }
     }
 }


### PR DESCRIPTION
# What problem did you solve?

Closes #902 
Cloese #911 

`kill()` from `tree-kill` package does not seem to work properly on Linux and macOS. I tested using ~~`cp.kill()`~~ `SIGKILL` signal and it works as expected on Windows, Linux and macOS.

## (If you do not have screenshot) How can I check this pull request?

1. Open an R file
2. Open a task manager or `watch -d 'ps aux | grep helpServer.R'`
3. Reload vscode window
4. Exit vscode

The helpServer process should be properly killed on reload or exit. At most only one help server should appear at any time.