### PR TITLE
RMD - don't set undefined wd

### DIFF
--- a/R/rmarkdown/knit.R
+++ b/R/rmarkdown/knit.R
@@ -11,7 +11,7 @@ knit_command <- Sys.getenv("VSCR_KNIT_COMMAND")
 
 # set the knitr chunk eval directory
 # mainly affects source calls
-if (!is.null(eval(parse(text = knit_dir)))) {
+if (nzchar(knit_dir)) {
     knitr::opts_knit[["set"]](root.dir = knit_dir)
 }
 

--- a/R/rmarkdown/knit.R
+++ b/R/rmarkdown/knit.R
@@ -11,7 +11,9 @@ knit_command <- Sys.getenv("VSCR_KNIT_COMMAND")
 
 # set the knitr chunk eval directory
 # mainly affects source calls
-knitr::opts_knit[["set"]](root.dir = knit_dir)
+if (!is.null(eval(parse(text = knit_dir)))) {
+    knitr::opts_knit[["set"]](root.dir = knit_dir)
+}
 
 # render and get file output location for use in extension
 cat(

--- a/R/rmarkdown/preview.R
+++ b/R/rmarkdown/preview.R
@@ -29,7 +29,7 @@ set_html <- tryCatch(
 
 # set the knitr chunk eval directory
 # mainly affects source calls
-if (!is.null(eval(parse(text = knit_dir)))) {
+if (nzchar(knit_dir)) {
     knitr::opts_knit[["set"]](root.dir = knit_dir)
 }
 

--- a/R/rmarkdown/preview.R
+++ b/R/rmarkdown/preview.R
@@ -29,7 +29,9 @@ set_html <- tryCatch(
 
 # set the knitr chunk eval directory
 # mainly affects source calls
-knitr::opts_knit[["set"]](root.dir = knit_dir)
+if (!is.null(eval(parse(text = knit_dir)))) {
+    knitr::opts_knit[["set"]](root.dir = knit_dir)
+}
 
 # render and get file output location for use in extension
 cat(

--- a/src/rmarkdown/knit.ts
+++ b/src/rmarkdown/knit.ts
@@ -150,8 +150,8 @@ export class RMarkdownKnitManager extends RMarkdownManager {
 	// the definition of what constitutes an R Markdown site differs
 	// depending on the type of R Markdown site (i.e., "simple" vs. blogdown sites)
 	private async findSiteParam(): Promise<string | undefined> {
-		const rootFolder = vscode.workspace.workspaceFolders[0].uri.fsPath;
 		const wad = vscode.window.activeTextEditor.document.uri.fsPath;
+		const rootFolder = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath ?? path.dirname(wad);
 		const indexFile = (await vscode.workspace.findFiles(new vscode.RelativePattern(rootFolder, 'index.{Rmd,rmd, md}'), null, 1))?.[0];
 		const siteRoot = path.join(path.dirname(wad), '_site.yml');
 

--- a/src/rmarkdown/knit.ts
+++ b/src/rmarkdown/knit.ts
@@ -29,7 +29,7 @@ export class RMarkdownKnitManager extends RMarkdownManager {
 	private async renderDocument(rDocumentPath: string, docPath: string, docName: string, yamlParams: IYamlFrontmatter, outputFormat?: string): Promise<DisposableProcess> {
 		const openOutfile: boolean = util.config().get<boolean>('rmarkdown.knit.openOutputFile') ?? false;
 		const knitWorkingDir = this.getKnitDir(knitDir, docPath);
-		const knitWorkingDirText = knitWorkingDir ? `${knitWorkingDir}` : `NULL`;
+		const knitWorkingDirText = knitWorkingDir ? `${knitWorkingDir}` : '';
 		const knitCommand = await this.getKnitCommand(yamlParams, rDocumentPath, outputFormat);
 		this.rPath = await util.getRpath();
 

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -40,12 +40,12 @@ export abstract class RMarkdownManager {
 		switch (knitDir) {
 			// the directory containing the R Markdown document
 			case KnitWorkingDirectory.documentDirectory: {
-				return path.dirname(docPath).replace(/\\/g, '/').replace(/['"]/g, '\\"');
+				return path.dirname(docPath)?.replace(/\\/g, '/')?.replace(/['"]/g, '\\"') ?? undefined;
 			}
 			// the root of the current workspace
 			case KnitWorkingDirectory.workspaceRoot: {
 				const currentDocumentWorkspace = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(docPath) ?? vscode.window.activeTextEditor?.document?.uri)?.uri?.fsPath ?? undefined;
-				return currentDocumentWorkspace.replace(/\\/g, '/').replace(/['"]/g, '\\"');
+				return currentDocumentWorkspace?.replace(/\\/g, '/')?.replace(/['"]/g, '\\"') ?? undefined;
 			}
 			// the working directory of the attached terminal, NYI
 			// case 'current directory': {

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -291,7 +291,7 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
 
     private async previewDocument(filePath: string, fileName?: string, viewer?: vscode.ViewColumn, currentViewColumn?: vscode.ViewColumn): Promise<DisposableProcess> {
         const knitWorkingDir = this.getKnitDir(knitDir, filePath);
-        const knitWorkingDirText = knitWorkingDir ? `${knitWorkingDir}` : `NULL`;
+        const knitWorkingDirText = knitWorkingDir ? `${knitWorkingDir}` : '';
         this.rPath = await getRpath();
 
         const lim = '<<<vsc>>>';


### PR DESCRIPTION
Closes #895

# What problem did you solve?

- Prevents setting the workspace rmd if the value is undefined
- Fall back to document directory when workspace folder does not exist

## (If you do not have screenshot) How can I check this pull request?

*Without opening a workspace folder* attempt to knit & preview an RMD file. Previously this would result in an error.
