### PR TITLE
Clean-up child processes on dispose

### DIFF
--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -65,7 +65,9 @@ export class HelpProvider {
         ];
         const cpOptions = {
             cwd: this.cwd,
-            env: { ...process.env, 'VSCR_LIM': lim }
+            env: { ...process.env, 'VSCR_LIM': lim },
+            shell: false,
+            detached: false,
         };
 
         const childProcess: ChildProcessWithPort = cp.spawn(this.rPath, args, cpOptions);

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -51,15 +51,21 @@ export class HelpProvider {
 
         // starts the background help server and waits forever to keep the R process running
         const scriptPath = extensionContext.asAbsolutePath('R/help/helpServer.R');
-        const cmd = (
-            `"${this.rPath}" --silent --slave --no-save --no-restore -f "${scriptPath}"`
-        );
+        // const cmd = `${this.rPath} --silent --slave --no-save --no-restore -f "${scriptPath}"`;
+        const args = [
+            '--slient',
+            '--slave',
+            '--no-save',
+            '--no-restore',
+            '-f',
+            scriptPath
+        ];
         const cpOptions = {
             cwd: this.cwd,
             env: { ...process.env, 'VSCR_LIM': lim },
         };
 
-        const childProcess: ChildProcessWithPort = exec(cmd, cpOptions);
+        const childProcess: ChildProcessWithPort = exec(this.rPath, args, cpOptions);
 
         let str = '';
         // promise containing the port number of the process (or 0)

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -285,13 +285,13 @@ export class AliasProvider {
 		const re = new RegExp(`^.*?${lim}(.*)${lim}.*$`, 'ms');
         const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-R-aliases'));
         const tempFile = path.join(tempDir, 'aliases.json');
-        const cmd = `${this.rPath} --silent --no-save --no-restore --slave -f "${this.rScriptFile}" > "${tempFile}"`;
+        const cmd = `"${this.rPath}" --silent --no-save --no-restore --slave -f "${this.rScriptFile}" > "${tempFile}"`;
 
         let allPackageAliases: undefined | AllPackageAliases = undefined;
         try{
             // execute R script 'getAliases.R'
             // aliases will be written to tempFile
-            cp.execSync(cmd, {cwd: this.cwd});
+            cp.execSync(cmd, { cwd: this.cwd });
 
             // read and parse aliases
             const txt = fs.readFileSync(tempFile, 'utf-8');

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -2,7 +2,7 @@
 import { Memento, window } from 'vscode';
 import * as http from 'http';
 import * as cp from 'child_process';
-import * as kill from 'tree-kill';
+// import * as kill from 'tree-kill';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -40,8 +40,8 @@ export class HelpProvider {
 
     public async refresh(): Promise<void> {
         if (this.cp.running) {
-            // this.cp.kill('SIGKILL');
-            kill(this.cp.pid, 'SIGKILL'); // more reliable than cp.kill (?)
+            this.cp.kill('SIGKILL');
+            // kill(this.cp.pid, 'SIGKILL'); // more reliable than cp.kill (?)
         }
         this.cp = this.launchRHelpServer();
         await this.cp.port;
@@ -55,16 +55,20 @@ export class HelpProvider {
 
         // starts the background help server and waits forever to keep the R process running
         const scriptPath = extensionContext.asAbsolutePath('R/help/helpServer.R');
-        const cmd = (
-            `${this.rPath} --silent --slave --no-save --no-restore -f ` +
-            `${scriptPath}`
-        );
+        const args: string[] = [
+            '--silent',
+            '--slave',
+            '--no-save',
+            '--no-restore',
+            '-f',
+            scriptPath
+        ];
         const cpOptions = {
             cwd: this.cwd,
             env: { ...process.env, 'VSCR_LIM': lim }
         };
 
-        const childProcess: ChildProcessWithPort = cp.exec(cmd, cpOptions);
+        const childProcess: ChildProcessWithPort = cp.spawn(this.rPath, args, cpOptions);
         childProcess.running = true;
 
         let str = '';
@@ -175,8 +179,8 @@ export class HelpProvider {
 
     dispose(): void {
         if (this.cp.running) {
-            // this.cp.kill('SIGKILL');
-            kill(this.cp.pid, 'SIGKILL');
+            this.cp.kill('SIGKILL');
+            // kill(this.cp.pid, 'SIGKILL');
         }
     }
 }

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 
 import * as rHelp from '.';
 import { extensionContext } from '../extension';
-import { DisposableProcess, execCommand } from '../util';
+import { DisposableProcess, exec } from '../util';
 
 export interface RHelpProviderOptions {
 	// path of the R executable
@@ -59,7 +59,7 @@ export class HelpProvider {
             env: { ...process.env, 'VSCR_LIM': lim },
         };
 
-        const childProcess: ChildProcessWithPort = execCommand(cmd, cpOptions);
+        const childProcess: ChildProcessWithPort = exec(cmd, cpOptions);
 
         let str = '';
         // promise containing the port number of the process (or 0)

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -29,7 +29,7 @@ export async function initializeHelp(
     void vscode.commands.executeCommand('setContext', 'r.helpViewer.show', true);
 
     // get the "vanilla" R path from config
-    const rPath = await getRpath(true);
+    const rPath = await getRpath(false);
 
     // get the current working directory from vscode
     const cwd = vscode.workspace.workspaceFolders?.length

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -9,7 +9,7 @@ import net = require('net');
 import url = require('url');
 import { LanguageClient, LanguageClientOptions, StreamInfo, DocumentFilter, ErrorAction, CloseAction, RevealOutputChannelOn } from 'vscode-languageclient/node';
 import { Disposable, workspace, Uri, TextDocument, WorkspaceConfiguration, OutputChannel, window, WorkspaceFolder } from 'vscode';
-import { DisposableProcess, getRpath, execCommand } from './util';
+import { DisposableProcess, getRpath, exec } from './util';
 
 export class LanguageService implements Disposable {
   private readonly clients: Map<string, LanguageClient> = new Map();
@@ -67,7 +67,7 @@ export class LanguageService implements Disposable {
         const port = (server.address() as net.AddressInfo).port;
         const expr = debug ? `languageserver::run(port=${port},debug=TRUE)` : `languageserver::run(port=${port})`;
         const cmd = `"${rPath}" ${initArgs.join(' ')} -e "${expr}"`;
-        const childProcess = execCommand(cmd, options);
+        const childProcess = exec(cmd, options);
         client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) started`);
         childProcess.stderr.on('data', (chunk: Buffer) => {
           client.outputChannel.appendLine(chunk.toString());

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -66,7 +66,7 @@ export class LanguageService implements Disposable {
       server.listen(0, '127.0.0.1', () => {
         const port = (server.address() as net.AddressInfo).port;
         const expr = debug ? `languageserver::run(port=${port},debug=TRUE)` : `languageserver::run(port=${port})`;
-        const cmd = `"${rPath}" ${initArgs.join(' ')} -e ${expr}`;
+        const cmd = `"${rPath}" ${initArgs.join(' ')} -e "${expr}"`;
         const childProcess = execCommand(cmd, options);
         client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) started`);
         childProcess.stderr.on('data', (chunk: Buffer) => {

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -66,8 +66,9 @@ export class LanguageService implements Disposable {
       server.listen(0, '127.0.0.1', () => {
         const port = (server.address() as net.AddressInfo).port;
         const expr = debug ? `languageserver::run(port=${port},debug=TRUE)` : `languageserver::run(port=${port})`;
-        const cmd = `"${rPath}" ${initArgs.join(' ')} -e "${expr}"`;
-        const childProcess = exec(cmd, options);
+        // const cmd = `${rPath} ${initArgs.join(' ')} -e "${expr}"`;
+        const args = initArgs.concat(['-e', expr]);
+        const childProcess = exec(rPath, args, options);
         client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) started`);
         childProcess.stderr.on('data', (chunk: Buffer) => {
           client.outputChannel.appendLine(chunk.toString());

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -7,10 +7,9 @@ import os = require('os');
 import path = require('path');
 import net = require('net');
 import url = require('url');
-import { spawn, ChildProcess } from 'child_process';
 import { LanguageClient, LanguageClientOptions, StreamInfo, DocumentFilter, ErrorAction, CloseAction, RevealOutputChannelOn } from 'vscode-languageclient/node';
 import { Disposable, workspace, Uri, TextDocument, WorkspaceConfiguration, OutputChannel, window, WorkspaceFolder } from 'vscode';
-import { getRpath } from './util';
+import { DisposableProcess, getRpath, execCommand } from './util';
 
 export class LanguageService implements Disposable {
   private readonly clients: Map<string, LanguageClient> = new Map();
@@ -29,9 +28,9 @@ export class LanguageService implements Disposable {
     let client: LanguageClient;
 
     const debug = config.get<boolean>('lsp.debug');
-    const path = await getRpath();
+    const rPath = await getRpath();
     if (debug) {
-      console.log(`R binary: ${path}`);
+      console.log(`R path: ${rPath}`);
     }
     const use_stdio = config.get<boolean>('lsp.use_stdio');
     const env = Object.create(process.env);
@@ -45,10 +44,10 @@ export class LanguageService implements Disposable {
       console.log(`LANG: ${env.LANG}`);
     }
 
-    const options = { cwd: cwd, env: env, shell: false, detached: false };
-    const initArgs: string[] = config.get<string[]>('lsp.args').concat('--quiet', '--slave');
+    const options = { cwd: cwd, env: env };
+    const initArgs: string[] = config.get<string[]>('lsp.args').concat('--silent', '--slave');
 
-    const tcpServerOptions = () => new Promise<ChildProcess | StreamInfo>((resolve, reject) => {
+    const tcpServerOptions = () => new Promise<DisposableProcess | StreamInfo>((resolve, reject) => {
       // Use a TCP socket because of problems with blocking STDIO
       const server = net.createServer(socket => {
         // 'connection' listener
@@ -66,14 +65,9 @@ export class LanguageService implements Disposable {
       // Listen on random port
       server.listen(0, '127.0.0.1', () => {
         const port = (server.address() as net.AddressInfo).port;
-        let args: string[];
-        // The server is implemented in R
-        if (debug) {
-          args = initArgs.concat(['-e', `languageserver::run(port=${port},debug=TRUE)`]);
-        } else {
-          args = initArgs.concat(['-e', `languageserver::run(port=${port})`]);
-        }
-        const childProcess = spawn(path, args, options);
+        const expr = debug ? `languageserver::run(port=${port},debug=TRUE)` : `languageserver::run(port=${port})`;
+        const cmd = `"{path}" ${initArgs.join(' ')} -e ${expr}`;
+        const childProcess = execCommand(cmd, options);
         client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) started`);
         childProcess.stderr.on('data', (chunk: Buffer) => {
           client.outputChannel.appendLine(chunk.toString());
@@ -122,7 +116,7 @@ export class LanguageService implements Disposable {
       } else {
         args = initArgs.concat(['-e', `languageserver::run()`]);
       }
-      client = new LanguageClient('r', 'R Language Server', { command: path, args: args, options: options }, clientOptions);
+      client = new LanguageClient('r', 'R Language Server', { command: rPath, args: args, options: options }, clientOptions);
     } else {
       client = new LanguageClient('r', 'R Language Server', tcpServerOptions, clientOptions);
     }

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -66,7 +66,7 @@ export class LanguageService implements Disposable {
       server.listen(0, '127.0.0.1', () => {
         const port = (server.address() as net.AddressInfo).port;
         const expr = debug ? `languageserver::run(port=${port},debug=TRUE)` : `languageserver::run(port=${port})`;
-        const cmd = `"{path}" ${initArgs.join(' ')} -e ${expr}`;
+        const cmd = `"${rPath}" ${initArgs.join(' ')} -e ${expr}`;
         const childProcess = execCommand(cmd, options);
         client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) started`);
         childProcess.stderr.on('data', (chunk: Buffer) => {

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -45,7 +45,7 @@ export class LanguageService implements Disposable {
       console.log(`LANG: ${env.LANG}`);
     }
 
-    const options = { cwd: cwd, env: env };
+    const options = { cwd: cwd, env: env, shell: false, detached: false };
     const initArgs: string[] = config.get<string[]>('lsp.args').concat('--quiet', '--slave');
 
     const tcpServerOptions = () => new Promise<ChildProcess | StreamInfo>((resolve, reject) => {

--- a/src/rmarkdown/knit.ts
+++ b/src/rmarkdown/knit.ts
@@ -4,9 +4,10 @@ import * as fs from 'fs-extra';
 import path = require('path');
 import yaml = require('js-yaml');
 
-import { RMarkdownManager, KnitWorkingDirectory, DisposableProcess } from './manager';
+import { RMarkdownManager, KnitWorkingDirectory } from './manager';
 import { runTextInTerm } from '../rTerminal';
 import { extensionContext, rmdPreviewManager } from '../extension';
+import { DisposableProcess } from '../util';
 
 export let knitDir: KnitWorkingDirectory = util.config().get<KnitWorkingDirectory>('rmarkdown.knit.defaults.knitWorkingDirectory') ?? undefined;
 

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -65,7 +65,15 @@ export abstract class RMarkdownManager {
 				const scriptArgs = args.scriptArgs;
 				const scriptPath = args.scriptPath;
 				const fileName = args.fileName;
-				const cmd = `"${this.rPath}" --silent --slave --no-save --no-restore -f "${scriptPath}"`;
+				// const cmd = `${this.rPath} --silent --slave --no-save --no-restore -f "${scriptPath}"`;
+				const cpArgs = [
+					'--slient',
+					'--slave',
+					'--no-save',
+					'--no-restore',
+					'-f',
+					scriptPath
+				];
 				const processOptions: cp.SpawnOptions = {
 					env: {
 						...process.env,
@@ -76,7 +84,7 @@ export abstract class RMarkdownManager {
 
 				let childProcess: DisposableProcess;
 				try {
-					childProcess = exec(cmd, processOptions, () => {
+					childProcess = exec(this.rPath, cpArgs, processOptions, () => {
 						rMarkdownOutput.appendLine('[VSC-R] terminating R process');
 						printOutput = false;
 					});

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -2,7 +2,7 @@ import * as util from '../util';
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import path = require('path');
-import { DisposableProcess, execCommand } from '../util';
+import { DisposableProcess, exec } from '../util';
 
 export enum KnitWorkingDirectory {
 	documentDirectory = 'document directory',
@@ -76,7 +76,7 @@ export abstract class RMarkdownManager {
 
 				let childProcess: DisposableProcess;
 				try {
-					childProcess = execCommand(cmd, processOptions, () => {
+					childProcess = exec(cmd, processOptions, () => {
 						rMarkdownOutput.appendLine('[VSC-R] terminating R process');
 						printOutput = false;
 					});

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -6,10 +6,10 @@ import path = require('path');
 import crypto = require('crypto');
 
 
-import { config, readContent, setContext, escapeHtml, UriIcon, saveDocument, getRpath } from '../util';
+import { config, readContent, setContext, escapeHtml, UriIcon, saveDocument, getRpath, DisposableProcess } from '../util';
 import { extensionContext, tmpDir } from '../extension';
 import { knitDir } from './knit';
-import { DisposableProcess, RMarkdownManager } from './manager';
+import { RMarkdownManager } from './manager';
 
 class RMarkdownPreview extends vscode.Disposable {
     title: string;
@@ -27,7 +27,7 @@ class RMarkdownPreview extends vscode.Disposable {
         resourceViewColumn: vscode.ViewColumn, outputUri: vscode.Uri, filePath: string,
         RMarkdownPreviewManager: RMarkdownPreviewManager, useCodeTheme: boolean, autoRefresh: boolean) {
         super(() => {
-            this.cp?.kill('SIGKILL');
+            this.cp?.dispose();
             this.panel?.dispose();
             this.fileWatcher?.close();
             fs.removeSync(this.outputUri.fsPath);
@@ -271,7 +271,7 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
     public async updatePreview(preview?: RMarkdownPreview): Promise<void> {
         const toUpdate = preview ?? this.activePreview?.preview;
         const previewUri = this.previewStore?.getFilePath(toUpdate);
-        toUpdate?.cp?.kill('SIGKILL');
+        toUpdate?.cp?.dispose();
 
         if (toUpdate) {
             const childProcess: DisposableProcess | void = await this.previewDocument(previewUri, toUpdate.title).catch(() => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -410,8 +410,14 @@ export function asDisposable<T>(toDispose: T, disposeFunction: (...args: unknown
 }
 
 export type DisposableProcess = cp.ChildProcessWithoutNullStreams & vscode.Disposable;
-export function exec(command: string, options?: cp.CommonOptions, onDisposed?: () => unknown): DisposableProcess {
-    const proc = cp.exec(command, options);
+export function exec(command: string, args?: ReadonlyArray<string>, options?: cp.CommonOptions, onDisposed?: () => unknown): DisposableProcess {
+    let proc: cp.ChildProcess;
+    if (process.platform === 'linux') {
+        proc = cp.spawn(command, args, options);
+    } else {
+        const cmd = `"${command}" ${args.map(s => `"${s}"`).join(' ')}`;
+        proc = cp.exec(cmd, options);
+    }
     let running = true;
     const exitHandler = () => {
         running = false;

--- a/src/util.ts
+++ b/src/util.ts
@@ -410,7 +410,7 @@ export function asDisposable<T>(toDispose: T, disposeFunction: (...args: unknown
 }
 
 export type DisposableProcess = cp.ChildProcessWithoutNullStreams & vscode.Disposable;
-export function execCommand(command: string, options?: cp.CommonOptions, onDisposed?: () => unknown): DisposableProcess {
+export function exec(command: string, options?: cp.CommonOptions, onDisposed?: () => unknown): DisposableProcess {
     const proc = cp.exec(command, options);
     let running = true;
     const exitHandler = () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import { rGuestService, isGuestSession } from './liveShare';
 import { extensionContext } from './extension';
-import { kill } from 'process';
+import * as kill from 'tree-kill';
 
 export function config(): vscode.WorkspaceConfiguration {
     return vscode.workspace.getConfiguration('r');

--- a/src/util.ts
+++ b/src/util.ts
@@ -412,11 +412,11 @@ export function asDisposable<T>(toDispose: T, disposeFunction: (...args: unknown
 export type DisposableProcess = cp.ChildProcessWithoutNullStreams & vscode.Disposable;
 export function exec(command: string, args?: ReadonlyArray<string>, options?: cp.CommonOptions, onDisposed?: () => unknown): DisposableProcess {
     let proc: cp.ChildProcess;
-    if (process.platform === 'linux') {
-        proc = cp.spawn(command, args, options);
-    } else {
+    if (process.platform === 'win32') {
         const cmd = `"${command}" ${args.map(s => `"${s}"`).join(' ')}`;
         proc = cp.exec(cmd, options);
+    } else {
+        proc = cp.spawn(command, args, options);
     }
     let running = true;
     const exitHandler = () => {


### PR DESCRIPTION
# What problem did you solve?

Closes #902 
Closes #911 

It looks like the behavior of child processes created by `cp.spawn()` and `cp.exec()` are platform-dependent in terms of whether they could be killed by `tree-kill` or `cp.kill()` in `dispose()`.

This PR tracks all long-running child processes (e.g. help server, rmarkdown preview, langauge server) and explictly kill them on dispose so that it is unlikely to leave orphan processes when vscode exits.

Note that the way to kill process is platform-dependent. This PR uses `cp.exec()` in Windows and `cp.spawn` otherwise to start child process and uses `tree-kill` on Windows and `cp.kill()` on other platforms. It is the only way I find working on Windows, Linux, and macOS.

## (If you do not have screenshot) How can I check this pull request?

1. Open an R file
2. Open a task manager or `watch -d 'ps aux | grep /exec/R'` to monitor R processes
3. Click "Clear cache and restart help server"
4. Open a Rmd file and preview.
5. Reload vscode window
6. Exit vscode

The help server, language server, and rmarkdown preview processes should be properly killed on reload or exit.