### PR TITLE
Add raw string tokens

### DIFF
--- a/syntax/r.json
+++ b/syntax/r.json
@@ -208,6 +208,96 @@
         "strings": {
             "patterns": [
                 {
+                    "begin": "[rR]\"(-*)\\[",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.begin.r"
+                        }
+                    },
+                    "end": "\\]\\1\"",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.end.r"
+                        }
+                    },
+                    "name": "string.quoted.double.raw.r"
+                },
+                {
+                    "begin": "[rR]'(-*)\\[",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.begin.r"
+                        }
+                    },
+                    "end": "\\]\\1'",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.end.r"
+                        }
+                    },
+                    "name": "string.quoted.single.raw.r"
+                },
+                {
+                    "begin": "[rR]\"(-*)\\{",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.begin.r"
+                        }
+                    },
+                    "end": "\\}\\1\"",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.end.r"
+                        }
+                    },
+                    "name": "string.quoted.double.raw.r"
+                },
+                {
+                    "begin": "[rR]'(-*)\\{",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.begin.r"
+                        }
+                    },
+                    "end": "\\}\\1'",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.end.r"
+                        }
+                    },
+                    "name": "string.quoted.single.raw.r"
+                },
+                {
+                    "begin": "[rR]\"(-*)\\(",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.begin.r"
+                        }
+                    },
+                    "end": "\\)\\1\"",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.end.r"
+                        }
+                    },
+                    "name": "string.quoted.double.raw.r"
+                },
+                {
+                    "begin": "[rR]'(-*)\\(",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.begin.r"
+                        }
+                    },
+                    "end": "\\)\\1'",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.raw.end.r"
+                        }
+                    },
+                    "name": "string.quoted.single.raw.r"
+                },
+                {
                     "begin": "\"",
                     "beginCaptures": {
                         "0": {


### PR DESCRIPTION
## What problem did you solve?
Adds support for raw strings introduced in R 4.0.0. For details, see `? Quotes`


## How can I check this pull request?
E.g. the following expressions are valid raw strings in R 4.x.x:
``` 
r'(asdf\qwer)'
R"-[test]-"
r'--{\/'\/}--'
```
producing the output 
```
> r'(asdf\qwer)'
[1] "asdf\\qwer"
> R"-[test]-"
[1] "test"
> r'--{\/'\/}--'
[1] "\\/'\\/"
```

With this PR, they should be highlighted correctly in the editor.

**Note:** I'm not very familiar with textmate grammars, so if this can be implemented more efficiently or should use different names etc., feel free to modify.