### PR TITLE
Fixed `"punctuation.section.parens.end.r"` under `"function-parameters"`

### DIFF
--- a/syntax/r.json
+++ b/syntax/r.json
@@ -560,14 +560,6 @@
                     "name": "punctuation.separator.parameters.r"
                 },
                 {
-                    "end": "\\)",
-                    "endCaptures": {
-                        "0": {
-                            "name": "punctuation.section.parens.end.r"
-                        }
-                    }
-                },
-                {
                     "include": "source.r"
                 }
             ]

--- a/syntax/r.json
+++ b/syntax/r.json
@@ -562,7 +562,9 @@
                 {
                     "end": "\\)",
                     "endCaptures": {
-                        "0": "punctuation.section.parens.end.r"
+                        "0": {
+                            "name": "punctuation.section.parens.end.r"
+                        }
                     }
                 },
                 {


### PR DESCRIPTION
# What problem did you solve?
Fixed end bracket not being tokenized `"punctuation.section.parens.end.r"` under `"function-parameters"` because `"name"` was not used

Happened to see it while looking through random vscode extensions
(in red at the bottom)
![image](https://user-images.githubusercontent.com/33529441/148005033-8215d640-d4c8-47b9-8f13-e115d3be25bc.png)
