### PR TITLE
Add row limit setting of data viewer and support Apache Arrow Table

### DIFF
--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -32,6 +32,7 @@ load_settings <- function() {
     vsc.viewer = setting(session$viewers$viewColumn$viewer, Disable = FALSE),
     vsc.page_viewer = setting(session$viewers$viewColumn$pageViewer, Disable = FALSE),
     vsc.row_limit = setting(session$data$rowLimit, Disable = FALSE),
+    vsc.show_arrow_table = setting(session$data$showArrowTable, Disable = FALSE),
     vsc.view = setting(session$viewers$viewColumn$view, Disable = FALSE),
     vsc.helpPanel = setting(session$viewers$viewColumn$helpPanel, Disable = FALSE)
   ))
@@ -384,6 +385,15 @@ if (show_view) {
     if (missing(title)) {
       sub <- substitute(x)
       title <- deparse(sub, nlines = 1)
+    }
+    if (getOption("vsc.show_arrow_table", FALSE) && inherits(x, "ArrowTabular")) {
+      .nrow <- nrow(x)
+      if (row_limit != 0 && row_limit < .nrow) {
+        title <- sprintf("%s (Limited to %s rows)", title, row_limit)
+        .nrow <- row_limit
+        x <- utils::head(x, n = .nrow)
+      }
+      x <- as.data.frame(x)
     }
     if (is.environment(x)) {
       all_names <- ls(x)

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -31,8 +31,8 @@ load_settings <- function() {
     vsc.browser = setting(session$viewers$viewColumn$browser, Disable = FALSE),
     vsc.viewer = setting(session$viewers$viewColumn$viewer, Disable = FALSE),
     vsc.page_viewer = setting(session$viewers$viewColumn$pageViewer, Disable = FALSE),
-    vsc.row_limit = setting(session$data$rowLimit, Disable = FALSE),
-    vsc.show_arrow_table = setting(session$data$showArrowTable, Disable = FALSE),
+    vsc.row_limit = session$data$rowLimit,
+    vsc.show_arrow_table = session$data$showArrowTable,
     vsc.view = setting(session$viewers$viewColumn$view, Disable = FALSE),
     vsc.helpPanel = setting(session$viewers$viewColumn$helpPanel, Disable = FALSE)
   ))

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -385,7 +385,7 @@ if (show_view) {
     as_truncated_data <- function(.data) {
       .nrow <- nrow(.data)
       if (row_limit != 0 && row_limit < .nrow) {
-        title <<- sprintf("%s (Limited to %s rows)", title, row_limit)
+        title <<- sprintf("%s (limited to %d/%d)", title, row_limit, .nrow)
         .data <- utils::head(.data, n = row_limit)
       }
       return(.data)

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -32,7 +32,6 @@ load_settings <- function() {
     vsc.viewer = setting(session$viewers$viewColumn$viewer, Disable = FALSE),
     vsc.page_viewer = setting(session$viewers$viewColumn$pageViewer, Disable = FALSE),
     vsc.row_limit = session$data$rowLimit,
-    vsc.show_arrow_table = session$data$showArrowTable,
     vsc.view = setting(session$viewers$viewColumn$view, Disable = FALSE),
     vsc.helpPanel = setting(session$viewers$viewColumn$helpPanel, Disable = FALSE)
   ))
@@ -386,7 +385,7 @@ if (show_view) {
       sub <- substitute(x)
       title <- deparse(sub, nlines = 1)
     }
-    if (getOption("vsc.show_arrow_table", FALSE) && inherits(x, "ArrowTabular")) {
+    if (inherits(x, "ArrowTabular")) {
       .nrow <- nrow(x)
       if (row_limit != 0 && row_limit < .nrow) {
         title <- sprintf("%s (Limited to %s rows)", title, row_limit)

--- a/package.json
+++ b/package.json
@@ -1453,6 +1453,11 @@
           "default": 0,
           "markdownDescription": "The maximum number of rows to be displayed in the data viewer. `0` means no limit. Changes the option `vsc.row_limit` in R. Requires `#r.sessionWatcher#` to be set to `true`."
         },
+        "r.session.data.showArrowTable": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Show a Apache Arrow table as a data frame in the data viewer. Convert a `ArrowTabular` class object to a `data.frame` and then display it. Changes the option `vsc.show_arrow_table` in R. Requires `#r.sessionWatcher#` to be set to `true`."
+        },
         "r.session.viewers.viewColumn": {
           "type": "object",
           "markdownDescription": "Which view column should R-related webviews be displayed? Requires `#r.sessionWatcher#` to be set to `true`.",

--- a/package.json
+++ b/package.json
@@ -1453,11 +1453,6 @@
           "default": 0,
           "markdownDescription": "The maximum number of rows to be displayed in the data viewer. `0` means no limit. Changes the option `vsc.row_limit` in R. Requires `#r.sessionWatcher#` to be set to `true`."
         },
-        "r.session.data.showArrowTable": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Show a Apache Arrow table as a data frame in the data viewer. Convert a `ArrowTabular` class object to a `data.frame` and then display it. Changes the option `vsc.show_arrow_table` in R. Requires `#r.sessionWatcher#` to be set to `true`."
-        },
         "r.session.viewers.viewColumn": {
           "type": "object",
           "markdownDescription": "Which view column should R-related webviews be displayed? Requires `#r.sessionWatcher#` to be set to `true`.",

--- a/package.json
+++ b/package.json
@@ -1448,6 +1448,11 @@
           "default": true,
           "markdownDescription": "Emulate the RStudio API for addin support and other {rstudioapi} calls. Changes the option `vsc.rstudioapi` in R. Requires `#r.sessionWatcher#` to be set to `true`."
         },
+        "r.session.data.rowLimit": {
+          "type": "integer",
+          "default": 0,
+          "markdownDescription": "The maximum number of rows to be displayed in the data viewer. `0` means no limit. Changes the option `vsc.row_limit` in R. Requires `#r.sessionWatcher#` to be set to `true`."
+        },
         "r.session.viewers.viewColumn": {
           "type": "object",
           "markdownDescription": "Which view column should R-related webviews be displayed? Requires `#r.sessionWatcher#` to be set to `true`.",


### PR DESCRIPTION
# What problem did you solve?

close #944

Currently, when displaying a data frame in the data viewer, temporary files are written out and read in, which does not work well for huge data frames with more than a few million rows. (related to #619, #837)
I would like to add an option to limit the number of records loaded into the data viewer, as it is often enough to see some of the content without loading all the records into the data viewer.
I would also like to add support for the Apache Arrow Table, which is becoming a strong choice for data frame compatibility when dealing with large numbers of records.
By controlling the number of records to be displayed, a huge Arrow Table can be displayed in the data viewer without stress.

- [x] Add a setting to limit the number of rows when displaying data frames and matrices in the data viewer.
- [x] Support [Arrow Table and RecordBatch (`ArrowTabular`)](https://arrow.apache.org/docs/r/articles/arrow.html#data-objects).

## (If you have)Screenshot

![image](https://user-images.githubusercontent.com/50911393/149809556-41bf927a-57d0-4d1f-a2d8-84b3e297b935.png)

![image](https://user-images.githubusercontent.com/50911393/149934341-9ac7120d-9596-4958-9e04-72e749bd686c.png)

![image](https://user-images.githubusercontent.com/50911393/150101313-c6d1aacc-438b-4063-918d-2fecb9ec2bdb.png)

![image](https://user-images.githubusercontent.com/50911393/150108414-5ace711b-a29a-43b1-a747-2aa60ad8df31.png)

