### PR TITLE
correcting typo on command argument (slient instead of silent)

### DIFF
--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -53,7 +53,7 @@ export class HelpProvider {
         const scriptPath = extensionContext.asAbsolutePath('R/help/helpServer.R');
         // const cmd = `${this.rPath} --silent --slave --no-save --no-restore -f "${scriptPath}"`;
         const args = [
-            '--slient',
+            '--silent',
             '--slave',
             '--no-save',
             '--no-restore',

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -67,7 +67,7 @@ export abstract class RMarkdownManager {
 				const fileName = args.fileName;
 				// const cmd = `${this.rPath} --silent --slave --no-save --no-restore -f "${scriptPath}"`;
 				const cpArgs = [
-					'--slient',
+					'--silent',
 					'--slave',
 					'--no-save',
 					'--no-restore',


### PR DESCRIPTION
# What problem did you solve?

A typo where silent had been misspelled slient

## (If you do not have screenshot) How can I check this pull request?

it is just a typo.