### PR TITLE
Add delay before refreshing plots

### DIFF
--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -288,10 +288,10 @@ export class HttpgdViewer implements IHttpgdViewer {
     readonly zoom0: number = 1;
     zoom: number = this.zoom0;
 
-    resizeTimeout?: NodeJS.Timeout;
+    protected resizeTimeout?: NodeJS.Timeout;
     readonly resizeTimeoutLength: number = 1300;
 
-    refreshTimeout?: NodeJS.Timeout;
+    protected refreshTimeout?: NodeJS.Timeout;
     readonly refreshTimeoutLength: number = 10;
     
     private lastExportUri?: vscode.Uri;
@@ -570,12 +570,9 @@ export class HttpgdViewer implements IHttpgdViewer {
     
     protected async refreshPlotsDelayed(plotsIdResponse: HttpgdIdResponse[], redraw: boolean = false, force: boolean = false): Promise<void> {
         if(this.refreshTimeoutLength === 0){
-            if(this.refreshTimeout){
-                clearTimeout(this.refreshTimeout);
-            }
-            this.refreshTimeout = undefined;
             await this.refreshPlots(plotsIdResponse, redraw, force);
-        } if(!this.refreshTimeout){
+        } else{
+            clearTimeout(this.refreshTimeout);
             this.refreshTimeout = setTimeout(() => {
                 void this.refreshPlots(plotsIdResponse, redraw, force).then(() => 
                     this.refreshTimeout = undefined


### PR DESCRIPTION
Adds a delay before refreshing plots to avoid redrawing too often. See https://github.com/REditorSupport/vscode-R/discussions/950.