### PR TITLE
set the LANG env when rendering rmarkdown

### DIFF
--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -74,9 +74,16 @@ export abstract class RMarkdownManager {
 					'-f',
 					scriptPath
 				];
+				// When there's no LANG variable, we should try to set to a UTF-8 compatible one, as R relies
+				// on locale setting (based on LANG) to render certain characters.
+				// See https://github.com/REditorSupport/vscode-R/issues/933
+				let env = process.env;
+				if (env.LANG === undefined) {
+					env.LANG = 'en_US.UTF-8';
+				}
 				const processOptions: cp.SpawnOptions = {
 					env: {
-						...process.env,
+						...env,
 						...scriptArgs
 					},
 					cwd: args.workingDirectory,

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -77,7 +77,7 @@ export abstract class RMarkdownManager {
 				// When there's no LANG variable, we should try to set to a UTF-8 compatible one, as R relies
 				// on locale setting (based on LANG) to render certain characters.
 				// See https://github.com/REditorSupport/vscode-R/issues/933
-				let env = process.env;
+				const env = process.env;
 				if (env.LANG === undefined) {
 					env.LANG = 'en_US.UTF-8';
 				}


### PR DESCRIPTION
# What problem did you solve?

Closes #933 

The `process.env` doesn't contain the LANG environment variable. Thus, when the child process calls R, R will set the locale to "C". This causes an issue that UTF-8 strings can't be corrected handled.

## (If you have)Screenshot

<img width="1201" alt="image" src="https://user-images.githubusercontent.com/8368933/152299207-13079bfd-8dd1-43f0-b02e-cef5b5c192f1.png">


## (If you do not have screenshot) How can I check this pull request?

Open the below Rmd file in VSCode. Click the knit button to render the file. View the generated HTML file you will see:

(I only verified this on macOS)

1. Before: The locale is "C" and there's no string or garbaged string in the left-bottom corner.
2. After: The locale is "xxx_UTF-8" and the left-bottom displays "科比", as expected.


``````rmd
---
title: "minimal example"
author: "Kobe Bryant"
output: html_document
---

```{r setup, include=FALSE}
knitr::opts_chunk$set(echo = F, warning = F, message = F, eval = T)
```

Chinese character in the main article can be rendered normally.
(正文区的中文可以正确的渲染)

Figure legends cannot be rendered normally.

```{r, fig.cap = "科比"}
print(Sys.getlocale())
plot(1:5, 1:5)
```
``````