### PR TITLE
should use Strong quote for shell commands

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -206,17 +206,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     const type = 'R';
     vscode.tasks.registerTaskProvider(type, {
         provideTasks() {
+            // `vscode.ShellQuoting.Strong` will treat the "value" as pure string and quote them based on the shell used
+            // this can ensure it works for different shells, e.g., zsh, PowerShell or cmd
             return [
                 new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Build', 'R',
-                    new vscode.ShellExecution('Rscript -e "devtools::build()"')),
+                    new vscode.ShellExecution('Rscript', ['-e', {value: 'devtools::build()', quoting: vscode.ShellQuoting.Strong}])),
                 new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Check', 'R',
-                    new vscode.ShellExecution('Rscript -e "devtools::check()"')),
+                    new vscode.ShellExecution('Rscript', ['-e', {value: 'devtools::check()', quoting: vscode.ShellQuoting.Strong}])),
                 new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Document', 'R',
-                    new vscode.ShellExecution('Rscript -e "devtools::document()"')),
+                    new vscode.ShellExecution('Rscript', ['-e', {value: 'devtools::document()', quoting: vscode.ShellQuoting.Strong}])),
                 new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Install', 'R',
-                    new vscode.ShellExecution('Rscript -e "devtools::install()"')),
+                    new vscode.ShellExecution('Rscript', ['-e', {value: 'devtools::install()', quoting: vscode.ShellQuoting.Strong}])),
                 new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Test', 'R',
-                    new vscode.ShellExecution('Rscript -e "devtools::test()"')),
+                    new vscode.ShellExecution('Rscript', ['-e', {value: 'devtools::test()', quoting: vscode.ShellQuoting.Strong}]))
             ];
         },
         resolveTask(task: vscode.Task) {


### PR DESCRIPTION
# What problem did you solve?

Fixes #932 

The cause of this issue is that different shell uses different quote style. The reliable way of doing that in VSCode is to use the [`vscode.ShellQuotedString`](https://code.visualstudio.com/api/references/vscode-api#ShellQuotingOptions).

## (If you do not have screenshot) How can I check this pull request?

1. Open any R package project.
2. Cmd + Shift + P and choose any "R Package - xxx" command, e.g., "R Package - Document".
3. You'll find the command executes as expected.
4. Probably, you can switch to another Shell and test it again. For example, on Windows you can choose CMD or PowerShell, as the two use different quote for strings `"` for CMD and `'` for PowerShell. Now the command generated will quote the string uses correct style.


## (If you have)Screenshot

(Note that the commands in the two shells use different quote identifiers)

### Windows, Powershell
<img width="703" alt="截屏2022-02-03 21 48 19" src="https://user-images.githubusercontent.com/8368933/152356019-06623fc4-38a5-4e27-b212-80ba1e8f77fc.png">


### Windows, CMD


<img width="700" alt="image" src="https://user-images.githubusercontent.com/8368933/152355226-9eced3a6-b6b6-4200-a306-f346e07bef1b.png">



