### PR TITLE
prompt to install languageserver is not available

### DIFF
--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -26,7 +26,7 @@ export class LanguageService implements Disposable {
   private async createClient(config: WorkspaceConfiguration, selector: DocumentFilter[],
     cwd: string, workspaceFolder: WorkspaceFolder, outputChannel: OutputChannel): Promise<LanguageClient> {
     const installed = await isRPkgIntalled(
-      'languageserver', true,
+      'languageserver', cwd, true,
       'R package {languageserver} is required to enable R language service features such as code completion, function signature, find references, etc. Do you want to install it?',
       'You may need to reopen an R file to start the language service after the package is installed.'
     );

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -25,6 +25,16 @@ export class LanguageService implements Disposable {
 
   private async createClient(config: WorkspaceConfiguration, selector: DocumentFilter[],
     cwd: string, workspaceFolder: WorkspaceFolder, outputChannel: OutputChannel): Promise<LanguageClient> {
+    const installed = await isRPkgIntalled(
+      'languageserver', true,
+      'R package {languageserver} is required to enable R language service features such as code completion, function signature, find references, etc. Do you want to install it?',
+      'You may need to reopen an R file to start the language service after the package is installed.'
+    );
+
+    if (!installed) {
+      return undefined;
+    }
+
     let client: LanguageClient;
 
     const debug = config.get<boolean>('lsp.debug');
@@ -145,10 +155,6 @@ export class LanguageService implements Disposable {
   }
 
   private startLanguageService(self: LanguageService): void {
-    void isRPkgIntalled(
-      'languageserver',
-      'You need the R package `languageserver` to enjoy R language service features like code completion and function documentation.'
-    );
     const config = workspace.getConfiguration('r');
     const outputChannel: OutputChannel = window.createOutputChannel('R Language Server');
 
@@ -173,8 +179,10 @@ export class LanguageService implements Disposable {
           ];
           const client = await self.createClient(config, documentSelector,
             path.dirname(document.uri.fsPath), folder, outputChannel);
-          client.start();
-          self.clients.set(key, client);
+          if (client) {
+            client.start();
+            self.clients.set(key, client);
+          }
           self.initSet.delete(key);
         }
         return;
@@ -192,8 +200,10 @@ export class LanguageService implements Disposable {
             { scheme: 'file', language: 'rmd', pattern: pattern },
           ];
           const client = await self.createClient(config, documentSelector, folder.uri.fsPath, folder, outputChannel);
-          client.start();
-          self.clients.set(key, client);
+          if (client) {
+            client.start();
+            self.clients.set(key, client);
+          }
           self.initSet.delete(key);
         }
 
@@ -209,8 +219,10 @@ export class LanguageService implements Disposable {
               { scheme: 'untitled', language: 'rmd' },
             ];
             const client = await self.createClient(config, documentSelector, os.homedir(), undefined, outputChannel);
-            client.start();
-            self.clients.set(key, client);
+            if (client) {
+              client.start();
+              self.clients.set(key, client);
+            }
             self.initSet.delete(key);
           }
           return;
@@ -226,8 +238,10 @@ export class LanguageService implements Disposable {
             ];
             const client = await self.createClient(config, documentSelector,
               path.dirname(document.uri.fsPath), undefined, outputChannel);
-            client.start();
-            self.clients.set(key, client);
+            if (client) {
+              client.start();
+              self.clients.set(key, client);
+            }
             self.initSet.delete(key);
           }
           return;

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -9,7 +9,7 @@ import net = require('net');
 import url = require('url');
 import { LanguageClient, LanguageClientOptions, StreamInfo, DocumentFilter, ErrorAction, CloseAction, RevealOutputChannelOn } from 'vscode-languageclient/node';
 import { Disposable, workspace, Uri, TextDocument, WorkspaceConfiguration, OutputChannel, window, WorkspaceFolder } from 'vscode';
-import { DisposableProcess, getRpath, exec } from './util';
+import { DisposableProcess, getRpath, exec, isRPkgIntalled } from './util';
 
 export class LanguageService implements Disposable {
   private readonly clients: Map<string, LanguageClient> = new Map();
@@ -145,6 +145,10 @@ export class LanguageService implements Disposable {
   }
 
   private startLanguageService(self: LanguageService): void {
+    void isRPkgIntalled(
+      'languageserver',
+      'You need the R package `languageserver` to enjoy R language service features like code completion and function documentation.'
+    );
     const config = workspace.getConfiguration('r');
     const outputChannel: OutputChannel = window.createOutputChannel('R Language Server');
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -464,7 +464,6 @@ export function exec(command: string, args?: ReadonlyArray<string>, options?: cp
  * @returns a boolean Promise
  */
 export async function isRPkgIntalled(name: string, cwd: string, promptToInstall: boolean = false, installMsg?: string, postInstallMsg?: string): Promise<boolean> {
-    // users may write stdout in .Rprofile at the begining or the end of the session. so we need some strings to surround the output
     const cmd = `cat(requireNamespace('${name}', quietly=TRUE))`;
     const rOut = await executeRCommand(cmd, 'FALSE', cwd);
     const isInstalled = rOut === 'TRUE';

--- a/src/util.ts
+++ b/src/util.ts
@@ -334,7 +334,12 @@ export async function executeRCommand(rCommand: string, fallBack?: string, cwd?:
         if (result.error) {
             throw result.error;
         }
-        ret = result.stdout.replace(re, '$1');
+        const match = re.exec(result.stdout);
+        if (match.length === 2) {
+            ret = match[1];
+        } else {
+            throw new Error('Could not parse R output.');
+        }
     } catch (e) {
         if (fallBack) {
             ret = fallBack;

--- a/src/util.ts
+++ b/src/util.ts
@@ -475,7 +475,7 @@ export async function isRPkgIntalled(name: string, cwd: string, promptToInstall:
         void vscode.window.showErrorMessage(installMsg, 'Yes', 'No')
             .then(async function (select) {
                 if (select === 'Yes') {
-                    const repo = await getCranUrl(undefined, cwd);
+                    const repo = await getCranUrl('', cwd);
                     const rPath = await getRpath(false);
                     const args = ['--silent', '--slave', '-e', `install.packages('${name}', repos='${repo}')`];
                     void executeAsTask('Install Package', rPath, args, true);

--- a/src/util.ts
+++ b/src/util.ts
@@ -471,7 +471,7 @@ export async function isRPkgIntalled(name: string, msg?: string): Promise<boolea
         void vscode.window.showErrorMessage(msg, 'Click to install', 'Not sure')
         .then(function(select) {
             if (select === 'Click to install') {
-                const args = [`--silent`, '--slave', `-e`, `install.packages('${name}', repos='${repo}')`];
+                const args = ['--silent', '--slave', '-e', `install.packages('${name}', repos='${repo}')`];
                 void executeAsTask('Install Package', rPath, args, true);
                 void vscode.window.showInformationMessage('You may need to reload VSCode to take effect after the R package gets installed', 'OK');
                 return true;

--- a/src/util.ts
+++ b/src/util.ts
@@ -473,7 +473,7 @@ export async function isRPkgIntalled(name: string, msg?: string): Promise<boolea
             if (select === 'Click to install') {
                 const args = [`--silent`, '--slave', `-e`, `install.packages('${name}', repos='${repo}')`];
                 void executeAsTask('Install Package', rPath, args, true);
-                void vscode.window.showInformationMessage('You may need to reload VSCode to take effect after the R package being installed', 'OK');
+                void vscode.window.showInformationMessage('You may need to reload VSCode to take effect after the R package gets installed', 'OK');
                 return true;
             }
         });

--- a/src/util.ts
+++ b/src/util.ts
@@ -463,10 +463,10 @@ export function exec(command: string, args?: ReadonlyArray<string>, options?: cp
  * @param name the R package name that need to be checked
  * @returns a boolean Promise
  */
-export async function isRPkgIntalled(name: string, promptToInstall: boolean = false, installMsg?: string, postInstallMsg?: string): Promise<boolean> {
+export async function isRPkgIntalled(name: string, cwd: string, promptToInstall: boolean = false, installMsg?: string, postInstallMsg?: string): Promise<boolean> {
     // users may write stdout in .Rprofile at the begining or the end of the session. so we need some strings to surround the output
     const cmd = `cat(requireNamespace('${name}', quietly=TRUE))`;
-    const rOut = await executeRCommand(cmd);
+    const rOut = await executeRCommand(cmd, 'FALSE', cwd);
     const isInstalled = rOut === 'TRUE';
     if (promptToInstall && !isInstalled) {
         if (installMsg === undefined) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -472,11 +472,11 @@ export async function isRPkgIntalled(name: string, cwd: string, promptToInstall:
         if (installMsg === undefined) {
             installMsg = `R package {${name}} is not installed. Do you want to install it?`;
         }
-        const repo = await getCranUrl();
-        const rPath = await getRpath(false);
         void vscode.window.showErrorMessage(installMsg, 'Yes', 'No')
-            .then(function (select) {
+            .then(async function (select) {
                 if (select === 'Yes') {
+                    const repo = await getCranUrl(undefined, cwd);
+                    const rPath = await getRpath(false);
                     const args = ['--silent', '--slave', '-e', `install.packages('${name}', repos='${repo}')`];
                     void executeAsTask('Install Package', rPath, args, true);
                     if (postInstallMsg) {


### PR DESCRIPTION
# What problem did you solve?

Fixes #754 

Newbies may find it confusing when the R package `languageserver` is not installed. This PR enables a prompt to instruct the user to install `languageserver` if missing.

(We can use the added function to check other required R packages as well)
(I've also verified that it works on Windows)

## How can I check this pull request?

1. (R) remove the package via `remove.packages("languageserver")`
2. Open VSCode with any R project
3. A prompt will show up. Click "Not sure" the message vanishes. Click "Click to install" will launch a task to install the package with a notice that the user may need to reload to take effect.

## Screenshot

<img width="511" alt="image" src="https://user-images.githubusercontent.com/8368933/152396617-9fdab604-28b1-4e36-96cd-3b50f9b527bc.png">

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/8368933/152396675-c24aee8d-d231-49dd-ab9a-41b3c3d00fff.png">
