### PR TITLE
update dcf syntax and add support ".lintr" file

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,8 @@
           "R DCF"
         ],
         "filenames": [
-          "DESCRIPTION"
+          "DESCRIPTION",
+          ".lintr"
         ],
         "configuration": "./language/dcf-configuration.json"
       }

--- a/syntax/dcf.json
+++ b/syntax/dcf.json
@@ -22,7 +22,7 @@
             "patterns": [
                 {
                     "comment": "keyword",
-                    "match": "^(?!Authors@R:).*?:",
+                    "match": "^(?!(Authors@R:|linters:|exclusions:)).*?:",
                     "name": "keyword.control"
                 }
             ]
@@ -62,7 +62,7 @@
             ],
             "repository": {
                 "code-block-r": {
-                    "begin": "^(Authors@R:)",
+                    "begin": "^(Authors@R:|linters:|exclusions:)",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control"

--- a/syntax/dcf.json
+++ b/syntax/dcf.json
@@ -22,7 +22,7 @@
             "patterns": [
                 {
                     "comment": "keyword",
-                    "match": "^[A-Z][a-zA-Z-]+:",
+                    "match": "^(?!Authors@R:).*?:",
                     "name": "keyword.control"
                 }
             ]
@@ -68,7 +68,7 @@
                             "name": "keyword.control"
                         }
                     },
-                    "end": "(?<=\\))\\s*$",
+                    "end": "^(?!\\s)",
                     "contentName": "meta.embedded.block.r",
                     "patterns": [
                         {


### PR DESCRIPTION
# What problem did you solve?

Add syntax highlighting to the `.lintr` files, which are required to comfortably use this extension.

Also, improve the way to capture the end of the `Authors@R` field in the `DESCRIPTION` files.

## Screenshot

From https://github.com/r-lib/lintr/tree/6e0d15257496421266f4f87700be16c8dd3f090b

![image](https://user-images.githubusercontent.com/50911393/152633616-66082162-a0e7-4345-9c1b-4d420e8ecbcb.png)

![image](https://user-images.githubusercontent.com/50911393/152633620-02609f99-36f1-4a0a-9c3a-c5f4e2b52615.png)
