### PR TITLE
Add note about required httpgd package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1613,7 +1613,7 @@
         "r.plot.useHttpgd": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Use the httpgd-based plot viewer instead of the base VSCode-R plot viewer. Changes the option `vsc.use_httpgd` in R."
+          "markdownDescription": "Use the httpgd-based plot viewer instead of the base VSCode-R plot viewer. Changes the option `vsc.use_httpgd` in R.\n\nRequires the `httpgd` R package version 1.2.0 or later."
         },
         "r.plot.defaults.colorTheme": {
           "type": "string",


### PR DESCRIPTION
# What problem did you solve?

After vscode-R v2.3.4, when #823 was merged, some issues were created (#916, #923, #947, #971) because users were not informed that the minimum version of the `httpgd` package was 1.2.0.
Add a note about the `httpgd` version in the settings.

## Screenshot

![image](https://user-images.githubusercontent.com/50911393/152640799-e8bdfad6-c120-43fb-9670-580460bafc30.png)
