### PR TITLE
[data frame viewer] Add type of column to headerTooltip

### DIFF
--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -321,6 +321,7 @@ show_view <- !identical(getOption("vsc.view", "Two"), FALSE)
 if (show_view) {
   get_column_def <- function(name, field, value) {
     filter <- TRUE
+    tooltip <- typeof(value)
     if (is.numeric(value)) {
       type <- "numericColumn"
       if (is.null(attr(value, "class"))) {
@@ -335,6 +336,7 @@ if (show_view) {
     }
     list(
       headerName = name,
+      headerTooltip = tooltip,
       field = field,
       type = type,
       filter = filter

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -348,11 +348,11 @@ if (show_view) {
 
     if (is.data.frame(data)) {
       .nrow <- nrow(data)
-      colnames <- colnames(data)
-      if (is.null(colnames)) {
-        colnames <- sprintf("V%d", seq_len(ncol(data)))
+      .colnames <- colnames(data)
+      if (is.null(.colnames)) {
+        .colnames <- sprintf("V%d", seq_len(ncol(data)))
       } else {
-        colnames <- trimws(colnames)
+        .colnames <- trimws(.colnames)
       }
       if (.row_names_info(data) > 0L) {
         rownames <- rownames(data)
@@ -360,14 +360,14 @@ if (show_view) {
       } else {
         rownames <- seq_len(.nrow)
       }
-      colnames <- c("(row)", colnames)
-      fields <- sprintf("x%d", seq_along(colnames))
+      .colnames <- c("(row)", .colnames)
+      fields <- sprintf("x%d", seq_along(.colnames))
       data <- c(list(" " = rownames), .subset(data))
       names(data) <- fields
       class(data) <- "data.frame"
       attr(data, "row.names") <- .set_row_names(.nrow)
       columns <- .mapply(get_column_def,
-        list(colnames, fields, data),
+        list(.colnames, fields, data),
         NULL
       )
       list(

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -321,7 +321,11 @@ show_view <- !identical(getOption("vsc.view", "Two"), FALSE)
 if (show_view) {
   get_column_def <- function(name, field, value) {
     filter <- TRUE
-    tooltip <- typeof(value)
+    tooltip <- sprintf(
+      "class: [%s], type: %s",
+      toString(class(value)),
+      typeof(value)
+    )
     if (is.numeric(value)) {
       type <- "numericColumn"
       if (is.null(attr(value, "class"))) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -497,6 +497,7 @@ export async function getTableHtml(webview: Webview, file: string): Promise<stri
         pagination: true,
         enableCellTextSelection: true,
         ensureDomOrder: true,
+        tooltipShowDelay: 100,
         onGridReady: function (params) {
             gridOptions.api.sizeColumnsToFit();
             autoSizeAll(false);


### PR DESCRIPTION
# What problem did you solve?

I was wondering if it was possible to display the column types in the data viewer.
I think it would be easier to implement and not spoil the look of the viewer if the type is displayed in the tooltip that appears when you mouse over the header.
https://www.ag-grid.com/javascript-data-grid/column-headers/#header-tooltips

## Screenshot

![headertooltip](https://user-images.githubusercontent.com/50911393/152677752-24a7f9b9-3f70-468a-8132-4e28d98e479b.gif)

It may be a little unresponsive in some cases.