### PR TITLE
Avoid rpath quoting

### DIFF
--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -29,7 +29,7 @@ export async function initializeHelp(
     void vscode.commands.executeCommand('setContext', 'r.helpViewer.show', true);
 
     // get the "vanilla" R path from config
-    const rPath = await getRpath(false);
+    const rPath = await getRpath();
 
     // get the current working directory from vscode
     const cwd = vscode.workspace.workspaceFolders?.length

--- a/src/helpViewer/packages.ts
+++ b/src/helpViewer/packages.ts
@@ -195,7 +195,7 @@ export class PackageManager {
 
     // remove a specified package. The packagename is selected e.g. in the help tree-view
     public async removePackage(pkgName: string): Promise<boolean> {
-        const rPath = await getRpath(false);
+        const rPath = await getRpath();
         const args = ['--silent', '--slave', '-e', `remove.packages('${pkgName}')`];
         const cmd = `${rPath} ${args.join(' ')}`;
         const confirmation = 'Yes, remove package!';
@@ -212,7 +212,7 @@ export class PackageManager {
     // actually install packages
     // confirmation can be skipped (e.g. if the user has confimred before)
     public async installPackages(pkgNames: string[], skipConfirmation: boolean = false): Promise<boolean> {
-        const rPath = await getRpath(false);
+        const rPath = await getRpath();
         const cranUrl = await getCranUrl('', this.cwd);
         const args = [`--silent`, '--slave', `-e`, `install.packages(c(${pkgNames.map(v => `'${v}'`).join(',')}),repos='${cranUrl}')`];
         const cmd = `${rPath} ${args.join(' ')}`;
@@ -228,7 +228,7 @@ export class PackageManager {
     }
     
     public async updatePackages(skipConfirmation: boolean = false): Promise<boolean> {
-        const rPath = await getRpath(false);
+        const rPath = await getRpath();
         const cranUrl = await getCranUrl('', this.cwd);
         const args = ['--silent', '--slave', '-e', `update.packages(ask=FALSE,repos='${cranUrl}')`];
         const cmd = `${rPath} ${args.join(' ')}`;

--- a/src/util.ts
+++ b/src/util.ts
@@ -310,7 +310,7 @@ export async function executeRCommand(rCommand: string, fallBack?: string, cwd?:
     const lim = '---vsc---';
     const re = new RegExp(`${lim}(.*)${lim}`, 'ms');
 
-    const rPath = await getRpath(true);
+    const rPath = await getRpath();
 
     const options: cp.ExecSyncOptionsWithStringEncoding = {
         cwd: cwd,
@@ -475,7 +475,7 @@ export async function isRPkgIntalled(name: string, cwd: string, promptToInstall:
             .then(async function (select) {
                 if (select === 'Yes') {
                     const repo = await getCranUrl('', cwd);
-                    const rPath = await getRpath(false);
+                    const rPath = await getRpath();
                     const args = ['--silent', '--slave', '-e', `install.packages('${name}', repos='${repo}')`];
                     void executeAsTask('Install Package', rPath, args, true);
                     if (postInstallMsg) {


### PR DESCRIPTION
# What problem did you solve?

Closes #980 

Now we use `spawn` and `spawnSync` to start child processes, there's no need to quote rpath anywhere.

