### PR TITLE
R markdown templates

### DIFF
--- a/R/rmarkdown/templates.R
+++ b/R/rmarkdown/templates.R
@@ -1,0 +1,28 @@
+requireNamespace("jsonlite")
+requireNamespace("yaml")
+
+pkgs <- .packages(all.available = TRUE)
+templates <- new.env()
+template_dirs <- lapply(pkgs, function(pkg) {
+  dir <- system.file("rmarkdown/templates", package = pkg)
+  if (dir.exists(dir)) {
+    ids <- list.dirs(dir, full.names = FALSE, recursive = FALSE)
+    for (id in ids) {
+      file <- file.path(dir, id, "template.yaml")
+      if (file.exists(file)) {
+        data <- yaml::read_yaml(file)
+        data$id <- id
+        data$package <- pkg
+        templates[[paste0(pkg, "::", id)]] <- data
+      }
+    }
+  }
+})
+
+template_list <- unname(as.list(templates))
+
+lim <- "---vsc---"
+
+json <- jsonlite::toJSON(template_list, auto_unbox = TRUE)
+
+cat(lim, json, lim, "\n", sep = "")

--- a/R/rmarkdown/templates.R
+++ b/R/rmarkdown/templates.R
@@ -20,6 +20,6 @@ template_dirs <- lapply(pkgs, function(pkg) {
 })
 
 template_list <- unname(as.list(templates))
-file <- Sys.getenv("VSCR_FILE")
-
-jsonlite::write_json(template_list, file, auto_unbox = TRUE)
+lim <- Sys.getenv("VSCR_LIM")
+json <- jsonlite::toJSON(template_list, auto_unbox = TRUE)
+cat(lim, json, lim, sep = "\n", file = stdout())

--- a/R/rmarkdown/templates.R
+++ b/R/rmarkdown/templates.R
@@ -20,9 +20,6 @@ template_dirs <- lapply(pkgs, function(pkg) {
 })
 
 template_list <- unname(as.list(templates))
+file <- Sys.getenv("VSCR_FILE")
 
-lim <- "---vsc---"
-
-json <- jsonlite::toJSON(template_list, auto_unbox = TRUE)
-
-cat(lim, json, lim, "\n", sep = "")
+jsonlite::write_json(template_list, file, auto_unbox = TRUE)

--- a/package.json
+++ b/package.json
@@ -538,6 +538,11 @@
         "command": "r.goToNextChunk"
       },
       {
+        "title": "New Draft",
+        "category": "R Markdown",
+        "command": "r.rmarkdown.newDraft"
+      },
+      {
         "command": "r.rmarkdown.setKnitDirectory",
         "title": "R: Set Knit directory",
         "icon": "$(zap)",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,6 +93,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.goToNextChunk': rmarkdown.goToNextChunk,
         'r.runChunks': rTerminal.runChunksInTerm,
 
+        'r.rmarkdown.newDraft': () => rmarkdown.newDraft(),
         'r.rmarkdown.setKnitDirectory': () => rmdKnitManager.setKnitDir(),
         'r.rmarkdown.showPreviewToSide': () => rmdPreviewManager.previewRmd(vscode.ViewColumn.Beside),
         'r.rmarkdown.showPreview': (uri: vscode.Uri) => rmdPreviewManager.previewRmd(vscode.ViewColumn.Active, uri),

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -39,7 +39,7 @@ async function getTemplateItems(cwd: string): Promise<TemplateItem[]> {
     '--no-save',
     '--no-restore',
     '-f',
-    extensionContext.asAbsolutePath('R/rmarkdown/draft.R')
+    extensionContext.asAbsolutePath('R/rmarkdown/templates.R')
   ];
 
   try {

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -1,9 +1,6 @@
-/* eslint-disable @typescript-eslint/restrict-plus-operands */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import { QuickPickItem, QuickPickOptions, Uri, window, workspace } from 'vscode';

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -8,7 +8,7 @@
 
 import { QuickPickItem, QuickPickOptions, Uri, window, workspace } from 'vscode';
 import { extensionContext } from '../extension';
-import { executeRCommand, getCurrentWorkspaceFolder, getRpath } from '../util';
+import { executeRCommand, getCurrentWorkspaceFolder, getRpath, ToRStringLiteral } from '../util';
 import * as cp from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -93,7 +93,8 @@ async function launchTemplatePicker(cwd: string): Promise<TemplateItem> {
 }
 
 async function makeDraft(file: string, template: TemplateItem, cwd: string): Promise<string> {
-  const cmd = `cat(normalizePath(rmarkdown::draft(file='${file}', template='${template.id}', package='${template.package}', edit=FALSE)))`;
+  const fileString = ToRStringLiteral(file, '');
+  const cmd = `cat(normalizePath(rmarkdown::draft(file='${fileString}', template='${template.id}', package='${template.package}', edit=FALSE)))`;
   return await executeRCommand(cmd, cwd, (e: Error) => {
     void window.showErrorMessage(e.message);
     return '';

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -39,8 +39,6 @@ async function getTemplateItems(cwd: string): Promise<TemplateItem[]> {
         rScriptFile
     ];
 
-    let items: TemplateItem[] = [];
-
     try {
         const result = await spawnAsync(rPath, args, options);
         if (result.status !== 0) {
@@ -53,22 +51,21 @@ async function getTemplateItems(cwd: string): Promise<TemplateItem[]> {
         }
         const json = match[1];
         const templates = <TemplateInfo[]>JSON.parse(json) || [];
-        items = templates.map((x) => {
+        const items = templates.map((x) => {
             return {
                 alwaysShow: false,
                 description: `{${x.package}}`,
-                label: x.name,
+                label: x.name + (x.create_dir ? ' $(new-folder)' : ''),
                 detail: x.description,
                 picked: false,
                 info: x
             };
         });
+        return items;
     } catch (e) {
         console.log(e);
         void window.showErrorMessage((<{ message: string }>e).message);
     }
-
-    return items;
 }
 
 async function launchTemplatePicker(cwd: string): Promise<TemplateItem> {

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -1,141 +1,134 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-
 import { QuickPickItem, QuickPickOptions, Uri, window, workspace } from 'vscode';
 import { extensionContext } from '../extension';
-import { spawn, executeRCommand, getCurrentWorkspaceFolder, getRpath, ToRStringLiteral, spawnAsync } from '../util';
+import { executeRCommand, getCurrentWorkspaceFolder, getRpath, ToRStringLiteral, spawnAsync } from '../util';
 import * as cp from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { join } from 'path';
 
 interface TemplateInfo {
-  id: string;
-  package: string;
-  name: string;
-  description: string;
-  create_dir: boolean;
+    id: string;
+    package: string;
+    name: string;
+    description: string;
+    create_dir: boolean;
 }
 
 interface TemplateItem extends QuickPickItem {
-  info: TemplateInfo;
+    info: TemplateInfo;
 }
 
 async function getTemplateItems(cwd: string): Promise<TemplateItem[]> {
-  const lim = '---vsc---';
-  const rPath = await getRpath();
-  const options: cp.CommonOptions = {
-    cwd: cwd,
-    env: {
-      ...process.env,
-      VSCR_LIM: lim
+    const lim = '---vsc---';
+    const rPath = await getRpath();
+    const options: cp.CommonOptions = {
+        cwd: cwd,
+        env: {
+            ...process.env,
+            VSCR_LIM: lim
+        }
+    };
+
+    const rScriptFile = extensionContext.asAbsolutePath('R/rmarkdown/templates.R');
+    const args = [
+        '--silent',
+        '--slave',
+        '--no-save',
+        '--no-restore',
+        '-f',
+        rScriptFile
+    ];
+
+    let items: TemplateItem[] = [];
+
+    try {
+        const result = await spawnAsync(rPath, args, options);
+        if (result.status !== 0) {
+            throw result.error || new Error(result.stderr);
+        }
+        const re = new RegExp(`${lim}(.*)${lim}`, 'ms');
+        const match = re.exec(result.stdout);
+        if (match.length !== 2) {
+            throw new Error('Could not parse R output.');
+        }
+        const json = match[1];
+        const templates = <TemplateInfo[]>JSON.parse(json) || [];
+        items = templates.map((x) => {
+            return {
+                alwaysShow: false,
+                description: `{${x.package}}`,
+                label: x.name,
+                detail: x.description,
+                picked: false,
+                info: x
+            };
+        });
+    } catch (e) {
+        console.log(e);
+        void window.showErrorMessage((<{ message: string }>e).message);
     }
-  };
 
-  const rScriptFile = extensionContext.asAbsolutePath('R/rmarkdown/templates.R');
-  const args = [
-    '--silent',
-    '--slave',
-    '--no-save',
-    '--no-restore',
-    '-f',
-    rScriptFile
-  ];
-
-  let items: TemplateItem[] = [];
-
-  try {
-    const result = await spawnAsync(rPath, args, options);
-    if (result.status !== 0) {
-      throw result.error || new Error(result.stderr);
-    }
-    const re = new RegExp(`${lim}(.*)${lim}`, 'ms');
-    const match = re.exec(result.stdout);
-    if (match.length !== 2) {
-      throw new Error('Could not parse R output.');
-    }
-    const json = match[1];
-    const templates = <TemplateInfo[]>JSON.parse(json) || [];
-    items = templates.map((x) => {
-      return {
-        alwaysShow: false,
-        description: `{${x.package}}`,
-        label: x.name,
-        detail: x.description,
-        picked: false,
-        info: x
-      };
-    });
-  } catch (e) {
-    console.log(e);
-    void window.showErrorMessage((<{ message: string }>e).message);
-  }
-
-  return items;
+    return items;
 }
 
 async function launchTemplatePicker(cwd: string): Promise<TemplateItem> {
-  const options: QuickPickOptions = {
-    matchOnDescription: true,
-    matchOnDetail: true,
-    canPickMany: false,
-    ignoreFocusOut: false,
-    placeHolder: '',
-    onDidSelectItem: undefined
-  };
+    const options: QuickPickOptions = {
+        matchOnDescription: true,
+        matchOnDetail: true,
+        canPickMany: false,
+        ignoreFocusOut: false,
+        placeHolder: '',
+        onDidSelectItem: undefined
+    };
 
-  const items = await getTemplateItems(cwd);
+    const items = await getTemplateItems(cwd);
 
-  const selection: TemplateItem = await window.showQuickPick<TemplateItem>(items, options);
-  return selection;
+    const selection: TemplateItem = await window.showQuickPick<TemplateItem>(items, options);
+    return selection;
 }
 
 async function makeDraft(file: string, template: TemplateItem, cwd: string): Promise<string> {
-  const fileString = ToRStringLiteral(file, '');
-  const cmd = `cat(normalizePath(rmarkdown::draft(file='${fileString}', template='${template.info.id}', package='${template.info.package}', edit=FALSE)))`;
-  return await executeRCommand(cmd, cwd, (e: Error) => {
-    void window.showErrorMessage(e.message);
-    return '';
-  });
+    const fileString = ToRStringLiteral(file, '');
+    const cmd = `cat(normalizePath(rmarkdown::draft(file='${fileString}', template='${template.info.id}', package='${template.info.package}', edit=FALSE)))`;
+    return await executeRCommand(cmd, cwd, (e: Error) => {
+        void window.showErrorMessage(e.message);
+        return '';
+    });
 }
 
 export async function newDraft(): Promise<void> {
-  const cwd = getCurrentWorkspaceFolder()?.uri.fsPath ?? os.homedir();
-  const template = await launchTemplatePicker(cwd);
-  if (!template) {
-    return;
-  }
-
-  if (template.info.create_dir) {
-    const uri = await window.showSaveDialog({
-      defaultUri: Uri.file(join(cwd, 'draft')),
-      filters: {
-        'R Markdown': ['Rmd', 'rmd']
-      },
-      saveLabel: 'Create Folder',
-      title: 'R Markdown: New Draft'
-    });
-
-    if (uri) {
-      const draftPath = await makeDraft(uri.fsPath, template, cwd);
-      if (draftPath) {
-        await workspace.openTextDocument(draftPath)
-          .then(document => window.showTextDocument(document));
-      }
+    const cwd = getCurrentWorkspaceFolder()?.uri.fsPath ?? os.homedir();
+    const template = await launchTemplatePicker(cwd);
+    if (!template) {
+        return;
     }
-  } else {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-R-'));
-    const tempFile = path.join(tempDir, 'draft.Rmd');
-    const draftPath = await makeDraft(tempFile, template, cwd);
-    if (draftPath) {
-      const text = fs.readFileSync(draftPath, 'utf8');
-      await workspace.openTextDocument({ language: 'rmd', content: text })
-        .then(document => window.showTextDocument(document));
+
+    if (template.info.create_dir) {
+        const uri = await window.showSaveDialog({
+            defaultUri: Uri.file(path.join(cwd, 'draft')),
+            filters: {
+                'R Markdown': ['Rmd', 'rmd']
+            },
+            saveLabel: 'Create Folder',
+            title: 'R Markdown: New Draft'
+        });
+
+        if (uri) {
+            const draftPath = await makeDraft(uri.fsPath, template, cwd);
+            if (draftPath) {
+                await workspace.openTextDocument(draftPath)
+                    .then(document => window.showTextDocument(document));
+            }
+        }
+    } else {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-R-'));
+        const tempFile = path.join(tempDir, 'draft.Rmd');
+        const draftPath = await makeDraft(tempFile, template, cwd);
+        if (draftPath) {
+            const text = fs.readFileSync(draftPath, 'utf8');
+            await workspace.openTextDocument({ language: 'rmd', content: text })
+                .then(document => window.showTextDocument(document));
+        }
+        fs.rmdirSync(tempDir, { recursive: true });
     }
-    fs.rmdirSync(tempDir, { recursive: true });
-  }
 }

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -1,0 +1,144 @@
+/* eslint-disable @typescript-eslint/restrict-plus-operands */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { QuickPickItem, QuickPickOptions, window, workspace } from 'vscode';
+import { extensionContext } from '../extension';
+import { getCurrentWorkspaceFolder, getRpath } from '../util';
+import * as cp from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { readJSON } from 'fs-extra';
+
+interface TemplateItem extends QuickPickItem {
+  id: string;
+  package: string;
+}
+
+async function getTemplateItems(cwd: string): Promise<TemplateItem[]> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-R-'));
+  const tempFile = path.join(tempDir, 'templates.json');
+  const rPath = await getRpath();
+  const options: cp.ExecSyncOptionsWithStringEncoding = {
+    cwd: cwd,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      VSCR_FILE: tempFile
+    }
+  };
+
+  const args = [
+    '--silent',
+    '--slave',
+    '--no-save',
+    '--no-restore',
+    '-f',
+    extensionContext.asAbsolutePath('R/rmarkdown/draft.R')
+  ];
+
+  try {
+    const result = cp.spawnSync(rPath, args, options);
+    if (result.error) {
+      throw result.error;
+    }
+
+    const templates: any[] = await readJSON(tempFile).then(
+      (result) => result,
+      () => {
+        throw ('Failed to load templates from installed packages.');
+      }
+    );
+
+    const items = templates.map((x) => {
+      return {
+        alwaysShow: false,
+        description: `{${x.package}}`,
+        label: x.name,
+        detail: x.description,
+        picked: false,
+        package: x.package,
+        id: x.id,
+      };
+    });
+
+    return items;
+  } catch (e) {
+    void window.showErrorMessage((<{ message: string }>e).message);
+  } finally {
+    fs.rmdirSync(tempDir, { recursive: true });
+  }
+}
+
+async function launchTemplatePicker(cwd: string): Promise<TemplateItem> {
+  const options: QuickPickOptions = {
+    matchOnDescription: true,
+    matchOnDetail: true,
+    canPickMany: false,
+    ignoreFocusOut: false,
+    placeHolder: '',
+    onDidSelectItem: undefined
+  };
+
+  const items = await getTemplateItems(cwd);
+
+  const selection: TemplateItem = await window.showQuickPick<TemplateItem>(items, options);
+  return selection;
+}
+
+async function makeDraft(template: TemplateItem, cwd: string): Promise<string> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-R-'));
+  const tempFile = path.join(tempDir, 'draft.Rmd');
+  const rPath = await getRpath();
+  const options: cp.ExecSyncOptionsWithStringEncoding = {
+    cwd: cwd,
+    encoding: 'utf-8',
+  };
+
+  const args = [
+    '--silent',
+    '--slave',
+    '--no-save',
+    '--no-restore',
+    '-e',
+    `rmarkdown::draft(file='${tempFile}', template='${template.id}', package='${template.package}', edit=FALSE)`,
+  ];
+
+  try {
+    const result = cp.spawnSync(rPath, args, options);
+    if (result.error) {
+      throw result.error;
+    }
+
+    if (fs.existsSync(tempFile)) {
+      const text = fs.readFileSync(tempFile, 'utf-8');
+      return text;
+    } else {
+      throw new Error('Failed to create draft.');
+    }
+  } catch (e) {
+    void window.showErrorMessage((<{ message: string }>e).message);
+  } finally {
+    fs.rmdirSync(tempDir, { recursive: true });
+  }
+
+  return undefined;
+}
+
+export async function newDraft(): Promise<void> {
+  const cwd = getCurrentWorkspaceFolder()?.uri.fsPath ?? os.homedir();
+  const template = await launchTemplatePicker(cwd);
+  if (!template) {
+    return;
+  }
+
+  const text = await makeDraft(template, cwd);
+  if (text) {
+    void workspace.openTextDocument({ language: 'rmd', content: text });
+  }
+}

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -5,6 +5,7 @@ import { config } from '../util';
 // reexports
 export { knitDir, RMarkdownKnitManager } from './knit';
 export { RMarkdownPreviewManager } from './preview';
+export { newDraft } from './draft';
 
 function isRDocument(document: vscode.TextDocument) {
   return (document.languageId === 'r');

--- a/src/util.ts
+++ b/src/util.ts
@@ -286,7 +286,7 @@ export async function doWithProgress<T>(cb: (token?: vscode.CancellationToken, p
 export async function getCranUrl(path: string = '', cwd?: string): Promise<string> {
     const defaultCranUrl = 'https://cran.r-project.org/';
     // get cran URL from R. Returns empty string if option is not set.
-    const baseUrl = await executeRCommand('cat(getOption(\'repos\')[\'CRAN\'])', undefined, cwd);
+    const baseUrl = await executeRCommand('cat(getOption(\'repos\')[\'CRAN\'])', cwd);
     let url: string;
     try {
         url = new URL(path, baseUrl).toString();
@@ -301,12 +301,12 @@ export async function getCranUrl(path: string = '', cwd?: string): Promise<strin
 
 // executes an R command returns its output to stdout
 // uses a regex to filter out output generated e.g. by code in .Rprofile
-// returns the provided fallBack when the command failes
+// returns the provided fallback when the command failes
 //
 // WARNING: Cannot handle double quotes in the R command! (e.g. `print("hello world")`)
 // Single quotes are ok.
 //
-export async function executeRCommand(rCommand: string, fallBack?: string, cwd?: string): Promise<string | undefined> {
+export async function executeRCommand(rCommand: string, cwd?: string, fallback?: string | ((e: Error) => string)): Promise<string | undefined> {
     const lim = '---vsc---';
     const re = new RegExp(`${lim}(.*)${lim}`, 'ms');
 
@@ -334,6 +334,9 @@ export async function executeRCommand(rCommand: string, fallBack?: string, cwd?:
         if (result.error) {
             throw result.error;
         }
+        if (result.status !== 0) {
+            throw new Error(result.stderr);
+        }
         const match = re.exec(result.stdout);
         if (match.length === 2) {
             ret = match[1];
@@ -341,8 +344,8 @@ export async function executeRCommand(rCommand: string, fallBack?: string, cwd?:
             throw new Error('Could not parse R output.');
         }
     } catch (e) {
-        if (fallBack) {
-            ret = fallBack;
+        if (fallback) {
+            ret = (typeof fallback === 'function' ? fallback(e) : fallback);
         } else {
             console.warn(e);
         }
@@ -465,7 +468,7 @@ export function exec(command: string, args?: ReadonlyArray<string>, options?: cp
  */
 export async function isRPkgIntalled(name: string, cwd: string, promptToInstall: boolean = false, installMsg?: string, postInstallMsg?: string): Promise<boolean> {
     const cmd = `cat(requireNamespace('${name}', quietly=TRUE))`;
-    const rOut = await executeRCommand(cmd, 'FALSE', cwd);
+    const rOut = await executeRCommand(cmd, cwd, 'FALSE');
     const isInstalled = rOut === 'TRUE';
     if (promptToInstall && !isInstalled) {
         if (installMsg === undefined) {


### PR DESCRIPTION
# What problem did you solve?

Closes #839 

This PR implements choosing template and create draft rmd from template via `rmarkdown::draft()`.

The templates are obtained via scanning the R package folders so that the information of all templates are written to a temp JSON file. When user picks a template, saveFileDialog will show up and user needs to find a location to save the file.

Some templates have multiple files. If user specify e.g. `draft.Rmd`, multi-file templates will create a new folder `draft` and then put files in it.

## (If you have)Screenshot

https://user-images.githubusercontent.com/4662568/153199351-3838bdfb-a2a5-44c5-be7d-2dbf752e07b6.mp4

## (If you do not have screenshot) How can I check this pull request?

1. "R Markdown: New Draft" will let user choose template and choose a location to save file.
2. Then a rmd file or a folder will be created.
3. The rmd file will be open in editor.