### PR TITLE
WIP: Add problemMatching to task

### DIFF
--- a/package.json
+++ b/package.json
@@ -1670,6 +1670,27 @@
       {
         "type": "R"
       }
+    ],
+    "problemMatchers": [
+      {
+        "name": "testthat",
+        "owner": "R",
+        "severity": "error",
+        "fileLocation": ["relative", "${workspaceFolder}/tests/testthat"],
+        "pattern": [
+          {
+              "regexp": "^(Failure|Error)\\s\\((.*\\.[Rr]):(\\d+):(\\d+)\\):\\s(.*)",
+              "file": 2,
+              "line": 3,
+              "column": 4,
+              "message": 5
+          },
+          {
+              "regexp": "^(.*)$",
+              "message": 1
+          }
+        ]
+      }
     ]
   },
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import * as completions from './completions';
 import * as rShare from './liveShare';
 import * as httpgdViewer from './plotViewer';
 import * as languageService from './languageService';
+import { rtasks } from './tasks';
 
 
 // global objects used in other files
@@ -201,27 +202,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
     // deploy liveshare listener
     await rShare.initLiveShare(context);
-
+    
     // register task provider
-    const type = 'R';
-    vscode.tasks.registerTaskProvider(type, {
+    vscode.tasks.registerTaskProvider('R', {
         provideTasks() {
-            // `vscode.ShellQuoting.Strong` will treat the "value" as pure string and quote them based on the shell used
-            // this can ensure it works for different shells, e.g., zsh, PowerShell or cmd
-            return [
-                new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Build', 'R',
-                    new vscode.ShellExecution('Rscript', ['-e', {value: 'devtools::build()', quoting: vscode.ShellQuoting.Strong}])),
-                new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Check', 'R',
-                    new vscode.ShellExecution('Rscript', ['-e', {value: 'devtools::check()', quoting: vscode.ShellQuoting.Strong}])),
-                new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Document', 'R',
-                    new vscode.ShellExecution('Rscript', ['-e', {value: 'devtools::document()', quoting: vscode.ShellQuoting.Strong}])),
-                new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Install', 'R',
-                    new vscode.ShellExecution('Rscript', ['-e', {value: 'devtools::install()', quoting: vscode.ShellQuoting.Strong}])),
-                new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Test', 'R',
-                    new vscode.ShellExecution('Rscript', ['-e', {value: 'devtools::test()', quoting: vscode.ShellQuoting.Strong}]))
-            ];
+            console.log('From provide Task');
+            return rtasks;
         },
         resolveTask(task: vscode.Task) {
+            console.log('From resolve Task');
             return task;
         }
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,15 +202,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
     // deploy liveshare listener
     await rShare.initLiveShare(context);
-    
+
     // register task provider
     vscode.tasks.registerTaskProvider('R', {
         provideTasks() {
-            console.log('From provide Task');
             return rtasks;
         },
         resolveTask(task: vscode.Task) {
-            console.log('From resolve Task');
             return task;
         }
     });

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -30,20 +30,6 @@ export const rtasks = [
     new vscode.Task(
         { type: type },
         vscode.TaskScope.Workspace,
-        'ttest',
-        'R',
-        new vscode.ShellExecution(
-            'echo',
-            [
-                'hello',
-                'world'
-            ]
-        )
-    ),
-    
-    new vscode.Task(
-        { type: type },
-        vscode.TaskScope.Workspace,
         'Check',
         'R',
         new vscode.ShellExecution(

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,0 +1,112 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+const type = 'R';
+
+// `vscode.ShellQuoting.Strong` will treat the "value" as pure string
+// and quote them based on the shell used this can ensure it works for
+// different shells, e.g., zsh, PowerShell or cmd
+
+export const rtasks = [
+
+    new vscode.Task(
+        { type: type },
+        vscode.TaskScope.Workspace,
+        'Build',
+        'R',
+        new vscode.ShellExecution(
+            'Rscript',
+            [
+                '-e',
+                {
+                    value: 'devtools::build()',
+                    quoting: vscode.ShellQuoting.Strong
+                }
+            ]
+        )
+    ),
+    
+    new vscode.Task(
+        { type: type },
+        vscode.TaskScope.Workspace,
+        'ttest',
+        'R',
+        new vscode.ShellExecution(
+            'echo',
+            [
+                'hello',
+                'world'
+            ]
+        )
+    ),
+    
+    new vscode.Task(
+        { type: type },
+        vscode.TaskScope.Workspace,
+        'Check',
+        'R',
+        new vscode.ShellExecution(
+            'Rscript',
+            [
+                '-e',
+                {
+                    value: 'devtools::check()',
+                    quoting: vscode.ShellQuoting.Strong
+                }
+            ]
+        )
+    ),
+    
+    new vscode.Task(
+        { type: type },
+        vscode.TaskScope.Workspace,
+        'Document',
+        'R',
+        new vscode.ShellExecution(
+            'Rscript',
+            [
+                '-e',
+                {
+                    value: 'devtools::document()',
+                    quoting: vscode.ShellQuoting.Strong
+                }
+            ]
+        )
+    ),
+    
+    new vscode.Task(
+        { type: type },
+        vscode.TaskScope.Workspace,
+        'Install',
+        'R',
+        new vscode.ShellExecution(
+            'Rscript',
+            [
+                '-e',
+                {
+                    value: 'devtools::install()',
+                    quoting: vscode.ShellQuoting.Strong
+                }
+            ]
+        )
+    ),
+    
+    new vscode.Task(
+        { type: type },
+        vscode.TaskScope.Workspace,
+        'Test',
+        'R',
+        new vscode.ShellExecution(
+            'Rscript',
+            [
+                '-e',
+                {
+                    value: 'devtools::test()',
+                    quoting: vscode.ShellQuoting.Strong
+                }
+            ]
+        ),
+        '$testthat'
+    )
+];


### PR DESCRIPTION
# What problem did you solve?

Wanted to try and incorporate problemMatching into the default `R: test` task to make it easier to find test failures when testing a R package.  The change so far seems to be working (see screenshot below). That being said I'm not sure how to test this. I was thinking about setting up a dummy repo and running the task inside of it but I can't quite work out how to do that... I had tried

```
    test('workbench actions', async () => {
        const action = await vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Test');
        .....
    });
```
But that doesn't seem to work. My next idea was to try and extract the regex patterns and see if they work aginst pre-defined error messages but I couldn't figure out the api for getting access to them. Any advice here would be appreciated !

![image](https://user-images.githubusercontent.com/8447209/153722478-2faa3cc4-84ed-45d1-a4e4-eaa5062e5120.png)
