### PR TITLE
Fix incorrect syntax highlighting for variables starting with "function"

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,7 +43,10 @@
       "outFiles": [
         "${workspaceFolder}/out/test/**/*.js"
       ],
-      "preLaunchTask": "npm: pretest"
+      "preLaunchTask": "npm: pretest",
+      "env": {
+        "EXTENSION_ROOT": "${workspaceRoot}"
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,10 +43,7 @@
       "outFiles": [
         "${workspaceFolder}/out/test/**/*.js"
       ],
-      "preLaunchTask": "npm: pretest",
-      "env": {
-        "EXTENSION_ROOT": "${workspaceRoot}"
-      }
+      "preLaunchTask": "npm: pretest"
     }
   ]
 }

--- a/src/test/suite/syntax.test.ts
+++ b/src/test/suite/syntax.test.ts
@@ -19,7 +19,8 @@ interface syntaxFile {
 
 /**
  * Converts a POSIX regular expression string into a format
- * that JavaScript can use
+ * that JavaScript can use. This is because vscode parses 
+ * syntax files using POSIX but JavaScript can't support it.
  * @param {string} s - A string to be used as a regular expression
  */
 const regex_from_posix = function (s: string): string {
@@ -35,9 +36,12 @@ const regex_from_posix = function (s: string): string {
 };
 
 
-const extension_root: string = process.env.EXTENSION_ROOT;
-const rawdata = readFileSync(join(extension_root, 'syntax', 'r.json')) as unknown;
-const rsyntax: syntaxFile = JSON.parse(rawdata as string) as syntaxFile;
+const extension_root: string = join(__dirname, '..', '..', '..');
+
+const r_syntax_file: string = join(extension_root, 'syntax', 'r.json');
+console.log(r_syntax_file);
+const rsyntax_raw = readFileSync(r_syntax_file) as unknown;
+const rsyntax: syntaxFile = JSON.parse(rsyntax_raw as string) as syntaxFile;
 
 const function_pattern: string = rsyntax.repository['function-declarations'].patterns[0].match;
 const function_pattern_fixed: string = regex_from_posix(function_pattern);

--- a/src/test/suite/syntax.test.ts
+++ b/src/test/suite/syntax.test.ts
@@ -1,0 +1,69 @@
+'use strict';
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import * as assert from 'assert';
+
+interface syntaxFile {
+    'repository': {
+        'function-declarations': {
+            'patterns': [
+                {
+                    'match':string
+                }
+            ]
+        }
+    }
+}
+
+
+/**
+ * Converts a POSIX regular expression string into a format
+ * that JavaScript can use
+ * @param {string} s - A string to be used as a regular expression
+ */
+const regex_from_posix = function (s: string): string {
+    const mappings = [
+        ['[:alnum:]', 'a-zA-Z0-9'],
+        ['[:alpha:]', 'a-zA-Z']
+    ];
+    let s2 = s;
+    mappings.forEach((el) => {
+        s2 = s2.replace(el[0], el[1]);
+    });
+    return s2;
+};
+
+
+const extension_root: string = process.env.EXTENSION_ROOT;
+const rawdata = readFileSync(join(extension_root, 'syntax', 'r.json')) as unknown;
+const rsyntax: syntaxFile = JSON.parse(rawdata as string) as syntaxFile;
+
+const function_pattern: string = rsyntax.repository['function-declarations'].patterns[0].match;
+const function_pattern_fixed: string = regex_from_posix(function_pattern);
+
+
+suite('Syntax Highlighting', () => {
+
+    test('function-declarations - basic match', () => {
+        const re = new RegExp(function_pattern_fixed);
+        const line = 'x <- function(x) {';
+        const match = re.exec(line);
+        assert.strictEqual(match[3], 'function');
+    });
+    
+    test('function-declarations - extra spacing', () => {
+        const re = new RegExp(function_pattern_fixed);
+        const line = 'x <- function  (x) {';
+        const match = re.exec(line);
+        assert.strictEqual(match[3], 'function');
+    });
+    
+    test('function-declarations - false function', () => {
+        const re = new RegExp(function_pattern_fixed);
+        const line = 'x <- functions';
+        const match = re.exec(line);
+        assert.strictEqual(match, null);
+    });
+
+});

--- a/syntax/r.json
+++ b/syntax/r.json
@@ -440,7 +440,7 @@
         "function-declarations": {
             "patterns": [
                 {
-                    "match": "((?:`[^`\\\\]*(?:\\\\.[^`\\\\]*)*`)|(?:[[:alpha:].][[:alnum:]._]*))\\s*(<?<-|=(?!=))\\s*(function)",
+                    "match": "((?:`[^`\\\\]*(?:\\\\.[^`\\\\]*)*`)|(?:[[:alpha:].][[:alnum:]._]*))\\s*(<?<-|=(?!=))\\s*(function)(?!\\w)",
                     "captures": {
                         "1": {
                             "name": "entity.name.function.r"


### PR DESCRIPTION
# What problem did you solve?

Closes #982  -  incorrect syntax highlighting for variables starting with the word `function`

- Resolved by adding a negative lookahead to the `function-declarations` file to make sure there are no additional word characters following the `function` keyword
- Added unit tests to show my code is working in the most basic settings
    - Unit tests work by reading in the regex pattern from the syntax file and then running them again pre-made strings.
    - Note that apparently vscode parses regex as POSIX but javascript doesn't so had to add a translation function.


Please let me know if there's a better way to test this or if you need me to refactor the code (am still learning node/ts/js/vscode).

## (If you have)Screenshot

![image](https://user-images.githubusercontent.com/8447209/153758821-6d6bd5c3-d20e-46c7-bc67-0cbb6748b01d.png)

