### PR TITLE
Provide optional 'code' argument to r.runSelection command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.thead': () => rTerminal.runSelectionOrWord(['t', 'head']),
         'r.names': () => rTerminal.runSelectionOrWord(['names']),
         'r.runSource': () => { void rTerminal.runSource(false); },
-        'r.runSelection':  (code?: string) => { code ? rTerminal.runTextInTerm(code) : rTerminal.runSelection() },
+        'r.runSelection':  (code?: string) => { code ? void rTerminal.runTextInTerm(code) : void rTerminal.runSelection(); },
         'r.runFromLineToEnd': rTerminal.runFromLineToEnd,
         'r.runFromBeginningToLine': rTerminal.runFromBeginningToLine,
         'r.runSelectionRetainCursor': rTerminal.runSelectionRetainCursor,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.thead': () => rTerminal.runSelectionOrWord(['t', 'head']),
         'r.names': () => rTerminal.runSelectionOrWord(['names']),
         'r.runSource': () => { void rTerminal.runSource(false); },
-        'r.runSelection': rTerminal.runSelection,
+        'r.runSelection':  (code?: string) => { code ? rTerminal.runTextInTerm(code) : rTerminal.runSelection() },
         'r.runFromLineToEnd': rTerminal.runFromLineToEnd,
         'r.runFromBeginningToLine': rTerminal.runFromBeginningToLine,
         'r.runSelectionRetainCursor': rTerminal.runSelectionRetainCursor,


### PR DESCRIPTION
Intended to allow other extensions to execute code using the vscode-R interactive terminal (similar to the `jupyter.execSelectionInteractive` command recently added to the Python extension for the same purpose).

# What problem did you solve?

Enable the Quarto VS Code extension to execute R code using vscode-R.

![Screen Shot 2022-02-28 at 12 36 16 PM](https://user-images.githubusercontent.com/104391/156031067-3676d12e-a903-46d3-b875-0603a75cf017.png)

