### PR TITLE
Enhance workspace viewer

### DIFF
--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -208,7 +208,7 @@ inspect_env <- function(env, cache) {
         info$slots <- slotNames(obj)
       }
 
-      if (is.list(obj) && !is.null(dim(obj))) {
+      if (!is.null(dim(obj))) {
         info$dim <- dim(obj)
       }
     }

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -221,25 +221,26 @@ inspect_env <- function(env, cache) {
 dir_session <- file.path(tempdir, "vscode-R")
 dir.create(dir_session, showWarnings = FALSE, recursive = TRUE)
 
-removeTaskCallback("vsc.globalenv")
+removeTaskCallback("vsc.workspace")
 show_globalenv <- isTRUE(getOption("vsc.globalenv", TRUE))
-if (show_globalenv) {
-  globalenv_file <- file.path(dir_session, "globalenv.json")
-  globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
-  file.create(globalenv_lock_file, showWarnings = FALSE)
+workspace_file <- file.path(dir_session, "workspace.json")
+workspace_lock_file <- file.path(dir_session, "workspace.lock")
+file.create(workspace_lock_file, showWarnings = FALSE)
 
-  update_globalenv <- function(...) {
-    tryCatch({
-      objs <- inspect_env(.GlobalEnv, globalenv_cache)
-      jsonlite::write_json(objs, globalenv_file, force = TRUE, pretty = FALSE)
-      cat(get_timestamp(), file = globalenv_lock_file)
-    }, error = message)
-    TRUE
-  }
-
-  update_globalenv()
-  addTaskCallback(update_globalenv, name = "vsc.globalenv")
+update_workspace <- function(...) {
+  tryCatch({
+    data <- list(
+      search = search(),
+      loaded_namespaces = loadedNamespaces(),
+      globalenv = if (show_globalenv) inspect_env(.GlobalEnv, globalenv_cache) else NULL
+    )
+    jsonlite::write_json(data, workspace_file, force = TRUE, pretty = FALSE)
+    cat(get_timestamp(), file = workspace_lock_file)
+  }, error = message)
+  TRUE
 }
+update_workspace()
+addTaskCallback(update_workspace, name = "vsc.workspace")
 
 removeTaskCallback("vsc.plot")
 use_httpgd <- identical(getOption("vsc.use_httpgd", FALSE), TRUE)

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -230,7 +230,7 @@ file.create(workspace_lock_file, showWarnings = FALSE)
 update_workspace <- function(...) {
   tryCatch({
     data <- list(
-      search = search(),
+      search = search()[-1],
       loaded_namespaces = loadedNamespaces(),
       globalenv = if (show_globalenv) inspect_env(.GlobalEnv, globalenv_cache) else NULL
     )

--- a/package.json
+++ b/package.json
@@ -291,32 +291,43 @@
       {
         "command": "r.workspaceViewer.refreshEntry",
         "title": "Manual Refresh",
-        "icon": "$(refresh)"
+        "icon": "$(refresh)",
+        "category": "R Workspace Viewer"
       },
       {
         "command": "r.workspaceViewer.view",
         "title": "View",
-        "icon": "$(open-preview)"
+        "icon": "$(open-preview)",
+        "category": "R Workspace Viewer"
       },
       {
         "command": "r.workspaceViewer.clear",
         "title": "Clear environment",
-        "icon": "$(clear-all)"
+        "icon": "$(clear-all)",
+        "category": "R Workspace Viewer"
       },
       {
         "command": "r.workspaceViewer.remove",
         "title": "Remove",
-        "icon": "$(close)"
+        "icon": "$(close)",
+        "category": "R Workspace Viewer"
       },
       {
         "command": "r.workspaceViewer.save",
         "title": "Save workspace",
-        "icon": "$(save)"
+        "icon": "$(save)",
+        "category": "R Workspace Viewer"
       },
       {
         "command": "r.workspaceViewer.load",
         "title": "Load workspace",
-        "icon": "$(folder-opened)"
+        "icon": "$(folder-opened)",
+        "category": "R Workspace Viewer"
+      },
+      {
+        "command": "r.workspaceViewer.namespace.showQuickPick",
+        "title": "Show QuickPick",
+        "category": "R Workspace Viewer"
       },
       {
         "command": "r.browser.refresh",
@@ -332,7 +343,8 @@
       },
       {
         "command": "r.showHelp",
-        "title": "R: Show help"
+        "title": "Show help",
+        "category": "R"
       },
       {
         "command": "editor.action.webvieweditor.showFind",
@@ -544,7 +556,7 @@
       },
       {
         "command": "r.rmarkdown.setKnitDirectory",
-        "title": "R: Set Knit directory",
+        "title": "Set Knit directory",
         "icon": "$(zap)",
         "category": "R Markdown"
       },

--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
         "category": "R Workspace Viewer"
       },
       {
-        "command": "r.workspaceViewer.namespace.showQuickPick",
+        "command": "r.workspaceViewer.package.showQuickPick",
         "title": "Show QuickPick",
         "category": "R Workspace Viewer"
       },

--- a/package.json
+++ b/package.json
@@ -603,113 +603,133 @@
       },
       {
         "command": "r.helpPanel.back",
-        "title": "R Help Panel: Go Back",
+        "title": "Go Back",
+        "category": "R Help Panel",
         "enablement": "r.helpPanel.canGoBack",
         "icon": "$(arrow-left)"
       },
       {
         "command": "r.helpPanel.forward",
-        "title": "R Help Panel: Go Forward",
+        "title": "Go Forward",
+        "category": "R Help Panel",
         "enablement": "r.helpPanel.canGoForward",
         "icon": "$(arrow-right)"
       },
       {
         "command": "r.helpPanel.openExternal",
-        "title": "R Help Panel: Open in external browser",
+        "title": "Open in external browser",
+        "category": "R Help Panel",
         "icon": "$(link-external)"
       },
       {
         "title": "Search Package Topics",
+        "category": "R Help Panel",
         "command": "r.helpPanel.searchPackage",
         "icon": "$(search)"
       },
       {
         "title": "Open Topic in new Panel",
+        "category": "R Help Panel",
         "command": "r.helpPanel.openInNewPanel",
         "icon": "$(add)"
       },
       {
         "title": "Clear Cached Files",
+        "category": "R Help Panel",
         "command": "r.helpPanel.clearCache",
         "icon": "$(refresh)"
       },
       {
         "title": "Filter Packages",
+        "category": "R Help Panel",
         "command": "r.helpPanel.filterPackages",
         "icon": "$(filter)"
       },
       {
         "title": "Remove from favorites",
+        "category": "R Help Panel",
         "command": "r.helpPanel.removeFromFavorites",
         "icon": "$(star-full)"
       },
       {
         "title": "Add to favorites",
+        "category": "R Help Panel",
         "command": "r.helpPanel.addToFavorites",
         "icon": "$(star-empty)"
       },
       {
         "title": "Show all packages",
+        "category": "R Help Panel",
         "command": "r.helpPanel.showAllPackages",
         "icon": "$(star-full)"
       },
       {
         "title": "Show only favorites",
+        "category": "R Help Panel",
         "command": "r.helpPanel.showOnlyFavorites",
         "icon": "$(star-empty)"
       },
       {
         "title": "Remove Package",
+        "category": "R Help Panel",
         "command": "r.helpPanel.removePackage",
         "icon": "$(trash)"
       },
       {
         "title": "Update Installed Packages",
+        "category": "R Help Panel",
         "command": "r.helpPanel.updateInstalledPackages",
         "icon": "$(clone)"
       },
       {
         "title": "Update/reinstall Package",
+        "category": "R Help Panel",
         "command": "r.helpPanel.updatePackage",
         "icon": "$(cloud-download)"
       },
       {
         "title": "Install multiple packages",
+        "category": "R Help Panel",
         "command": "r.helpPanel.installPackages",
         "icon": "$(expand-all)"
       },
       {
         "title": "Show QuickPick",
+        "category": "R Help Panel",
         "command": "r.helpPanel.showQuickPick",
         "icon": "$(zap)"
       },
       {
         "title": "Summarize Identical Topics",
+        "category": "R Help Panel",
         "command": "r.helpPanel.summarizeTopics",
         "icon": "$(fold)"
       },
       {
         "title": "Don't Summarize Identical Topics",
+        "category": "R Help Panel",
         "command": "r.helpPanel.unsummarizeTopics",
         "icon": "$(unfold)"
       },
       {
         "title": "Open help for selection",
-        "category": "R",
+        "category": "R Help Panel",
         "command": "r.helpPanel.openForSelection"
       },
       {
         "title": "Open help for path",
-        "category": "R",
+        "category": "R Help Panel",
         "command": "r.helpPanel.openForPath"
       },
       {
         "command": "r.liveShare.toggle",
+        "category": "R Live Share",
         "title": "Toggle"
       },
       {
         "command": "r.liveShare.retry",
         "title": "Retry connection to Live Share service",
+        "category": "R Live Share",
         "icon": "$(refresh)"
       },
       {

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -31,7 +31,7 @@ const roxygenTagCompletionItems = [
 
 export class HoverProvider implements vscode.HoverProvider {
     provideHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover {
-        if(!session.globalenv){
+        if(!session.workspaceData){
             return null;
         }
 
@@ -48,10 +48,10 @@ export class HoverProvider implements vscode.HoverProvider {
         // use juggling check here for both
         // null and undefined
         // eslint-disable-next-line eqeqeq
-        if (session.globalenv[text]?.str == null) {
+        if (session.workspaceData[text]?.str == null) {
             return null;
         }
-        return new vscode.Hover(`\`\`\`\n${session.globalenv[text]?.str}\n\`\`\``);
+        return new vscode.Hover(`\`\`\`\n${session.workspaceData[text]?.str}\n\`\`\``);
     }
 }
 
@@ -131,8 +131,8 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
         const trigger = completionContext.triggerCharacter;
 
         if (trigger === undefined) {
-            Object.keys(session.globalenv).forEach((key) => {
-                const obj = session.globalenv[key];
+            Object.keys(session.workspaceData).forEach((key) => {
+                const obj = session.workspaceData[key];
                 const item = new vscode.CompletionItem(
                     key,
                     obj.type === 'closure' || obj.type === 'builtin'
@@ -148,7 +148,7 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
             const symbolRange = document.getWordRangeAtPosition(symbolPosition);
             const symbol = document.getText(symbolRange);
             const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
-            const obj = session.globalenv[symbol];
+            const obj = session.workspaceData[symbol];
             let names: string[];
             if (obj !== undefined) {
                 if (completionContext.triggerCharacter === '$') {
@@ -221,7 +221,7 @@ function getBracketCompletionItems(document: vscode.TextDocument, position: vsco
     }
 
     if (!token.isCancellationRequested && symbol !== undefined) {
-        const obj = session.globalenv[symbol];
+        const obj = session.workspaceData[symbol];
         if (obj !== undefined && obj.names !== undefined) {
             const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
             items.push(...getCompletionItems(obj.names, vscode.CompletionItemKind.Field, '[session]', doc));
@@ -266,7 +266,7 @@ function getPipelineCompletionItems(document: vscode.TextDocument, position: vsc
     }
 
     if (!token.isCancellationRequested && symbol !== undefined) {
-        const obj = session.globalenv[symbol];
+        const obj = session.workspaceData[symbol];
         if (obj !== undefined && obj.names !== undefined) {
             const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
             items.push(...getCompletionItems(obj.names, vscode.CompletionItemKind.Field, '[session]', doc));

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -98,8 +98,7 @@ export class StaticCompletionItemProvider implements vscode.CompletionItemProvid
             }
         }
 
-        if (document.lineAt(position).text
-                    .substr(0, 2) === '#\'') {
+        if (document.lineAt(position).text.startsWith('#\'')) {
             return roxygenTagCompletionItems;
         }
 
@@ -159,7 +158,7 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
             }
 
             if (names) {
-                items.push(...getCompletionItems(names, vscode.CompletionItemKind.Field, '[session]', doc));
+                items.push(...getCompletionItems(names, vscode.CompletionItemKind.Variable, '[session]', doc));
             }
         }
 

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -31,7 +31,7 @@ const roxygenTagCompletionItems = [
 
 export class HoverProvider implements vscode.HoverProvider {
     provideHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover {
-        if(!session.workspaceData){
+        if(!session.workspaceData.globalenv){
             return null;
         }
 
@@ -48,10 +48,10 @@ export class HoverProvider implements vscode.HoverProvider {
         // use juggling check here for both
         // null and undefined
         // eslint-disable-next-line eqeqeq
-        if (session.workspaceData[text]?.str == null) {
+        if (session.workspaceData.globalenv[text]?.str == null) {
             return null;
         }
-        return new vscode.Hover(`\`\`\`\n${session.workspaceData[text]?.str}\n\`\`\``);
+        return new vscode.Hover(`\`\`\`\n${session.workspaceData.globalenv[text]?.str}\n\`\`\``);
     }
 }
 
@@ -131,8 +131,8 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
         const trigger = completionContext.triggerCharacter;
 
         if (trigger === undefined) {
-            Object.keys(session.workspaceData).forEach((key) => {
-                const obj = session.workspaceData[key];
+            Object.keys(session.workspaceData.globalenv).forEach((key) => {
+                const obj = session.workspaceData.globalenv[key];
                 const item = new vscode.CompletionItem(
                     key,
                     obj.type === 'closure' || obj.type === 'builtin'
@@ -148,7 +148,7 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
             const symbolRange = document.getWordRangeAtPosition(symbolPosition);
             const symbol = document.getText(symbolRange);
             const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
-            const obj = session.workspaceData[symbol];
+            const obj = session.workspaceData.globalenv[symbol];
             let names: string[];
             if (obj !== undefined) {
                 if (completionContext.triggerCharacter === '$') {
@@ -221,7 +221,7 @@ function getBracketCompletionItems(document: vscode.TextDocument, position: vsco
     }
 
     if (!token.isCancellationRequested && symbol !== undefined) {
-        const obj = session.workspaceData[symbol];
+        const obj = session.workspaceData.globalenv[symbol];
         if (obj !== undefined && obj.names !== undefined) {
             const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
             items.push(...getCompletionItems(obj.names, vscode.CompletionItemKind.Field, '[session]', doc));
@@ -266,7 +266,7 @@ function getPipelineCompletionItems(document: vscode.TextDocument, position: vsc
     }
 
     if (!token.isCancellationRequested && symbol !== undefined) {
-        const obj = session.workspaceData[symbol];
+        const obj = session.workspaceData.globalenv[symbol];
         if (obj !== undefined && obj.names !== undefined) {
             const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
             items.push(...getCompletionItems(obj.names, vscode.CompletionItemKind.Field, '[session]', doc));

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -223,7 +223,7 @@ function getBracketCompletionItems(document: vscode.TextDocument, position: vsco
         const obj = session.workspaceData.globalenv[symbol];
         if (obj !== undefined && obj.names !== undefined) {
             const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
-            items.push(...getCompletionItems(obj.names, vscode.CompletionItemKind.Field, '[session]', doc));
+            items.push(...getCompletionItems(obj.names, vscode.CompletionItemKind.Variable, '[session]', doc));
         }
     }
     return items;
@@ -268,7 +268,7 @@ function getPipelineCompletionItems(document: vscode.TextDocument, position: vsc
         const obj = session.workspaceData.globalenv[symbol];
         if (obj !== undefined && obj.names !== undefined) {
             const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
-            items.push(...getCompletionItems(obj.names, vscode.CompletionItemKind.Field, '[session]', doc));
+            items.push(...getCompletionItems(obj.names, vscode.CompletionItemKind.Variable, '[session]', doc));
         }
     }
     return items;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,8 +124,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
         // workspace viewer
         'r.workspaceViewer.refreshEntry': () => rWorkspace?.refresh(),
-        'r.workspaceViewer.view': (node: workspaceViewer.WorkspaceItem) => workspaceViewer.viewItem(node.label),
-        'r.workspaceViewer.remove': (node: workspaceViewer.WorkspaceItem) => workspaceViewer.removeItem(node.label),
+        'r.workspaceViewer.view': (node: workspaceViewer.GlobalEnvItem) => workspaceViewer.viewItem(node.label),
+        'r.workspaceViewer.remove': (node: workspaceViewer.GlobalEnvItem) => workspaceViewer.removeItem(node.label),
         'r.workspaceViewer.clear': workspaceViewer.clearWorkspace,
         'r.workspaceViewer.load': workspaceViewer.loadWorkspace,
         'r.workspaceViewer.save': workspaceViewer.saveWorkspace,

--- a/src/helpViewer/treeView.ts
+++ b/src/helpViewer/treeView.ts
@@ -428,7 +428,7 @@ class PkgRootNode extends MetaNode {
 
 
 // contains the topics belonging to an individual package
-class PackageNode extends Node {
+export class PackageNode extends Node {
     // TreeItem
     public command = undefined;
     public collapsibleState = CollapsibleState.Collapsed;
@@ -459,7 +459,7 @@ class PackageNode extends Node {
         }
     }
 
-    public async _handleCommand(cmd: cmdName){
+    public async _handleCommand(cmd: cmdName): Promise<void> {
         if(cmd === 'clearCache'){
             // useful e.g. when working on a package
             this.rHelp.clearCachedFiles(new RegExp(`^/library/${this.pkg.name}/`));
@@ -487,7 +487,7 @@ class PackageNode extends Node {
         }
     }
 
-    async makeChildren(forQuickPick: boolean = false) {
+    async makeChildren(forQuickPick: boolean = false): Promise<TopicNode[]> {
         const summarizeTopics = (
             forQuickPick ? false : (this.parent.summarizeTopics ?? true)
         );

--- a/src/helpViewer/treeView.ts
+++ b/src/helpViewer/treeView.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { RHelp } from '.';
+import { extensionContext } from '../extension';
 import { doWithProgress } from '../util';
 import { Package, Topic, TopicType } from './packages';
 
@@ -61,12 +62,12 @@ export class HelpTreeWrapper {
 
         // register the commands defiend in `nodeCommands`
         // they still need to be defined in package.json (apart from CALLBACK)
-        for(const cmd in nodeCommands){
-            vscode.commands.registerCommand(nodeCommands[cmd], (node: Node | undefined) => {
+        for (const cmd in nodeCommands) {
+            extensionContext.subscriptions.push(vscode.commands.registerCommand(nodeCommands[cmd], (node: Node | undefined) => {
                 // treeview-root is represented by `undefined`
                 node ||= this.helpViewProvider.rootItem;
                 node.handleCommand(<cmdName>cmd);
-            });
+            }));
         }
     }
 

--- a/src/liveShare/index.ts
+++ b/src/liveShare/index.ts
@@ -14,7 +14,7 @@ import { initTreeView, rLiveShareProvider, shareWorkspace, ToggleNode } from './
 import { Commands, Callback, liveShareOnRequest, liveShareRequest } from './shareCommands';
 
 import { HelpFile } from '../helpViewer';
-import { globalenv } from '../session';
+import { WorkspaceData, workspaceData } from '../session';
 import { config } from '../util';
 
 /// LiveShare
@@ -222,15 +222,15 @@ export class HostService {
     // This way, we don't have to re-create a guest version of the session
     // watcher, and can rely on the host to tell when something needs to be
     // updated
-    public notifyGlobalenv(hostEnv: string): void {
+    public notifyWorkspace(hostWorkspace: WorkspaceData): void {
         if (this._isStarted && shareWorkspace) {
-            void liveShareRequest(Callback.NotifyEnvUpdate, hostEnv);
+            void liveShareRequest(Callback.NotifyWorkspaceUpdate, hostWorkspace);
         }
     }
     public notifyRequest(file: string, force: boolean = false): void {
         if (this._isStarted && shareWorkspace) {
             void liveShareRequest(Callback.NotifyRequestUpdate, file, force);
-            void this.notifyGlobalenv(globalenv);
+            void this.notifyWorkspace(workspaceData);
         }
     }
     public notifyPlot(file: string): void {

--- a/src/liveShare/shareCommands.ts
+++ b/src/liveShare/shareCommands.ts
@@ -3,11 +3,11 @@ import * as vscode from 'vscode';
 import * as fs from 'fs-extra';
 
 import { rHostService, isGuest, service } from '.';
-import { updateGuestRequest, updateGuestGlobalenv, updateGuestPlot, detachGuest } from './shareSession';
+import { updateGuestRequest, updateGuestWorkspace, updateGuestPlot, detachGuest } from './shareSession';
 import { forwardCommands, shareWorkspace } from './shareTree';
 
 import { runTextInTerm } from '../rTerminal';
-import { requestFile } from '../session';
+import { requestFile, WorkspaceData } from '../session';
 import { HelpFile } from '../helpViewer';
 import { globalHttpgdManager, globalRHelp } from '../extension';
 
@@ -31,7 +31,7 @@ interface ICommands {
 // used for notify & request events
 // (mainly to prevent typos)
 export const enum Callback {
-    NotifyEnvUpdate = 'NotifyEnvUpdate',
+    NotifyWorkspaceUpdate = 'NotifyWorkspaceUpdate',
     NotifyPlotUpdate = 'NotifyPlotUpdate',
     NotifyRequestUpdate = 'NotifyRequestUpdate',
     NotifyMessage = 'NotifyMessage',
@@ -92,8 +92,8 @@ export const Commands: ICommands = {
         [Callback.NotifyRequestUpdate]: (args: [file: string, force: boolean]): void => {
             void updateGuestRequest(args[0], args[1]);
         },
-        [Callback.NotifyEnvUpdate]: (args: [hostEnv: string]): void => {
-            void updateGuestGlobalenv(args[0]);
+        [Callback.NotifyWorkspaceUpdate]: (args: [hostWorkspace: WorkspaceData]): void => {
+            void updateGuestWorkspace(args[0]);
         },
         [Callback.NotifyPlotUpdate]: (args: [file: string]): void => {
             void updateGuestPlot(args[0]);

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -4,14 +4,14 @@ import * as vsls from 'vsls';
 
 import { extensionContext, globalRHelp, rWorkspace } from '../extension';
 import { config, readContent } from '../util';
-import { showBrowser, showDataView, showWebView } from '../session';
+import { showBrowser, showDataView, showWebView, WorkspaceData } from '../session';
 import { liveSession, UUID, rGuestService, _sessionStatusBarItem as sessionStatusBarItem } from '.';
 import { autoShareBrowser } from './shareTree';
 import { docProvider, docScheme } from './virtualDocs';
 
 // Workspace Vars
 let guestPid: string;
-export let guestGlobalenv: unknown;
+export let guestWorkspace: WorkspaceData;
 export let guestResDir: string;
 let rVer: string;
 let info: IRequest['info'];
@@ -66,7 +66,7 @@ export function detachGuest(): void {
     console.info('[Guest Service] detach guest from workspace');
     sessionStatusBarItem.text = 'Guest R: (not attached)';
     sessionStatusBarItem.tooltip = 'Click to attach to host terminal';
-    guestGlobalenv = undefined;
+    guestWorkspace = undefined;
     rWorkspace?.refresh();
 }
 
@@ -142,12 +142,12 @@ export async function updateGuestRequest(file: string, force: boolean = false): 
     }
 }
 
-// Call from host, pass parsed globalenvfile
-export function updateGuestGlobalenv(hostEnv: string): void {
-    if (hostEnv) {
-        guestGlobalenv = hostEnv;
+// Call from host, pass parsed workspace file
+export function updateGuestWorkspace(hostWorkspace: WorkspaceData): void {
+    if (hostWorkspace) {
+        guestWorkspace = hostWorkspace;
         void rWorkspace?.refresh();
-        console.info('[updateGuestGlobalenv] Done');
+        console.info('[updateGuestWorkspace] Done');
     }
 }
 

--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -44,7 +44,9 @@ export function initializeHttpgd(): HttpgdManager {
     for (const cmd of commands) {
         const fullCommand = `r.plot.${cmd}`;
         const cb = httpgdManager.getCommandHandler(cmd);
-        vscode.commands.registerCommand(fullCommand, cb);
+        extensionContext.subscriptions.push(
+            vscode.commands.registerCommand(fullCommand, cb)
+        );
     }
     return httpgdManager;
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -17,10 +17,23 @@ import { purgeAddinPickerItems, dispatchRStudioAPICall } from './rstudioapi';
 import { homeExtDir, rWorkspace, globalRHelp, globalHttpgdManager, extensionContext } from './extension';
 import { UUID, rHostService, rGuestService, isLiveShare, isHost, isGuestSession, closeBrowser, guestResDir, shareBrowser, openVirtualDoc, shareWorkspace } from './liveShare';
 
+export interface GlobalEnv {
+    [key: string]: {
+        class: string[];
+        type: string;
+        length: number;
+        str: string;
+        size?: number;
+        dim?: number[],
+        names?: string[],
+        slots?: string[]
+    }
+}
+
 export interface WorkspaceData {
     search: string[];
     loaded_namespaces: string[];
-    globalenv: any;
+    globalenv: GlobalEnv;
 }
 
 export let workspaceData: WorkspaceData;

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -23,22 +23,22 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 
 	data: WorkspaceData;
 
-	private readonly treeItems: TreeItem[] = [];
+	private readonly attachedNamespacesItem: TreeItem;
+	private readonly loadedNamespacesItem: TreeItem;
+	private readonly globalEnvItem: TreeItem;
 
 	constructor() {
-		const attachedNamespacesItem = new TreeItem('Attached Namespaces', TreeItemCollapsibleState.Collapsed);
-		attachedNamespacesItem.id = 'attached-namespaces';
-		attachedNamespacesItem.iconPath = new ThemeIcon('library');
+		this.attachedNamespacesItem = new TreeItem('Attached Namespaces', TreeItemCollapsibleState.Collapsed);
+		this.attachedNamespacesItem.id = 'attached-namespaces';
+		this.attachedNamespacesItem.iconPath = new ThemeIcon('library');
 
-		const loadedNamespacesItem = new TreeItem('Loaded Namespaces', TreeItemCollapsibleState.Collapsed);
-		loadedNamespacesItem.id = 'loaded-namespaces';
-		loadedNamespacesItem.iconPath = new ThemeIcon('package');
+		this.loadedNamespacesItem = new TreeItem('Loaded Namespaces', TreeItemCollapsibleState.Collapsed);
+		this.loadedNamespacesItem.id = 'loaded-namespaces';
+		this.loadedNamespacesItem.iconPath = new ThemeIcon('package');
 
-		const globalEnvItem = new TreeItem('Global Environment', TreeItemCollapsibleState.Expanded);
-		globalEnvItem.id = 'globalenv';
-		globalEnvItem.iconPath = new ThemeIcon('menu');
-
-		this.treeItems.push(attachedNamespacesItem, loadedNamespacesItem, globalEnvItem);
+		this.globalEnvItem = new TreeItem('Global Environment', TreeItemCollapsibleState.Expanded);
+		this.globalEnvItem.id = 'globalenv';
+		this.globalEnvItem.iconPath = new ThemeIcon('menu');
 
 		extensionContext.subscriptions.push(
 			vscode.commands.registerCommand(PackageItem.command, async (name: string) => {
@@ -108,7 +108,11 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 					);
 			}
 		} else {
-			return this.treeItems;
+			const treeItems = [this.attachedNamespacesItem, this.loadedNamespacesItem];
+			if (config().get<boolean>('session.watchGlobalEnvironment')) {
+				treeItems.push(this.globalEnvItem);
+			}
+			return treeItems;
 		}
 	}
 

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -1,9 +1,9 @@
 import * as path from 'path';
 import { TreeDataProvider, EventEmitter, TreeItemCollapsibleState, TreeItem, Event, Uri, window } from 'vscode';
 import { runTextInTerm } from './rTerminal';
-import { globalenv, workingDir } from './session';
+import { workspaceData, workingDir } from './session';
 import { config } from './util';
-import { isGuestSession, isLiveShare, UUID, guestGlobalenv } from './liveShare';
+import { isGuestSession, isLiveShare, UUID, guestWorkspace } from './liveShare';
 
 interface WorkspaceAttr {
 	[key: string]: {
@@ -26,9 +26,9 @@ export class WorkspaceDataProvider implements TreeDataProvider<WorkspaceItem> {
 
 	refresh(): void {
 		if (isGuestSession) {
-			this.data = guestGlobalenv as WorkspaceAttr;
+			this.data = guestWorkspace.globalenv as WorkspaceAttr;
 		} else {
-			this.data = globalenv as WorkspaceAttr;
+			this.data = workspaceData.globalenv as WorkspaceAttr;
 		}
 		this._onDidChangeTreeData.fire();
 	}
@@ -179,7 +179,7 @@ export function clearWorkspace(): void {
 	const removeHiddenItems: boolean = config().get('workspaceViewer.removeHiddenItems');
 	const promptUser: boolean = config().get('workspaceViewer.clearPrompt');
 
-	if ((isGuestSession ? guestGlobalenv : globalenv) !== undefined) {
+	if ((isGuestSession ? guestWorkspace : workspaceData) !== undefined) {
 		if (promptUser) {
 			void window.showInformationMessage(
 				'Are you sure you want to clear the workspace? This cannot be reversed.',
@@ -207,7 +207,7 @@ export function clearWorkspace(): void {
 }
 
 export function saveWorkspace(): void {
-	if (globalenv !== undefined) {
+	if (workspaceData !== undefined) {
 		void window.showSaveDialog({
 			defaultUri: Uri.file(`${workingDir}${path.sep}workspace.RData`),
 			filters: {
@@ -226,7 +226,7 @@ export function saveWorkspace(): void {
 }
 
 export function loadWorkspace(): void {
-	if (globalenv !== undefined) {
+	if (workspaceData !== undefined) {
 		void window.showOpenDialog({
 			defaultUri: Uri.file(workingDir),
 			filters: {

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -110,9 +110,9 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 			)) : [];
 
 		function sortItems(a: GlobalEnvItem, b: GlobalEnvItem) {
-			if (priorityAttr.includes(a.contextValue) > priorityAttr.includes(b.contextValue)) {
+			if (priorityAttr.includes(a.type) > priorityAttr.includes(b.type)) {
 				return -1;
-			} else if (priorityAttr.includes(b.contextValue) > priorityAttr.includes(a.contextValue)) {
+			} else if (priorityAttr.includes(b.type) > priorityAttr.includes(a.type)) {
 				return 1;
 			} else {
 				return 0 || a.label.localeCompare(b.label);
@@ -127,6 +127,7 @@ export class GlobalEnvItem extends TreeItem {
 	label: string;
 	desc: string;
 	str: string;
+	type: string;
 	treeLevel: number;
 	contextValue: string;
 
@@ -140,16 +141,17 @@ export class GlobalEnvItem extends TreeItem {
 		dim?: number[],
 	) {
 		super(label, GlobalEnvItem.setCollapsibleState(treeLevel, type, str));
-		this.description = this.getDescription(dim, str, rClass);
+		this.description = this.getDescription(dim, str, rClass, type);
 		this.tooltip = this.getTooltip(label, rClass, size, treeLevel);
-		this.contextValue = type;
+		this.iconPath = this.getIconPath(type, dim);
+		this.type = type;
 		this.str = str;
 		this.treeLevel = treeLevel;
 		this.contextValue = treeLevel === 0 ? 'rootNode' : `childNode${treeLevel}`;
 	}
 
-	private getDescription(dim: number[], str: string, rClass: string): string {
-		if (dim !== undefined) {
+	private getDescription(dim: number[], str: string, rClass: string, type: string): string {
+		if (dim && type === 'list') {
 			if (dim[1] === 1) {
 				return `${rClass}: ${dim[0]} obs. of ${dim[1]} variable`;
 			} else {
@@ -178,6 +180,36 @@ export class GlobalEnvItem extends TreeItem {
 		} else {
 			return `${label} (${rClass})`;
 		}
+	}
+
+	private getIconPath(type: string, dim?: number[]) {
+		let name: string;
+		if (dim) {
+			if (type === 'list') {
+				name = 'symbol-constant';
+			} else {
+				name = 'symbol-array';
+			}
+		} else if (type === 'closure' || type === 'builtin') {
+			name = 'symbol-function';
+		} else if (type === 'double' || type === 'integer') {
+			name = 'symbol-numeric';
+		} else if (type === 'logical') {
+			name = 'symbol-boolean';
+		} else if (type === 'character') {
+			name = 'symbol-string';
+		} else if (type === 'NULL') {
+			name = 'symbol-null';
+		} else if (type === 'list') {
+			name = 'symbol-struct';
+		} else if (type === 'environment') {
+			name = 'symbol-object';
+		} else if (type === '') {
+			name = 'symbol-variable';
+		} else {
+			name = 'symbol-field';
+		}
+		return new ThemeIcon(name);
 	}
 
 	/* This logic has to be implemented this way to allow it to be called

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -42,15 +42,17 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 
 		extensionContext.subscriptions.push(
 			vscode.commands.registerCommand(PackageItem.command, async (name: string) => {
-				const rootNode = globalRHelp.treeViewWrapper.helpViewProvider.rootItem;
-				// ensure the pkgRootNode is populated.
-				await rootNode.getChildren();
-				const pkgRootNode = rootNode.pkgRootNode;
-				if (pkgRootNode) {
-					const packages = await pkgRootNode.getChildren();
-					const node = packages.find(node => node.label === name);
-					if (node) {
-						await node.showQuickPick();
+				const rootNode = globalRHelp?.treeViewWrapper.helpViewProvider.rootItem;
+				if (rootNode) {
+					// ensure the pkgRootNode is populated.
+					await rootNode.getChildren();
+					const pkgRootNode = rootNode.pkgRootNode;
+					if (pkgRootNode) {
+						const packages = await pkgRootNode.getChildren();
+						const node = packages.find(node => node.label === name);
+						if (node) {
+							await node.showQuickPick();
+						}
 					}
 				}
 			})

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -68,10 +68,11 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 			if (this.data === undefined) {
 				return [];
 			}
+			const pkgPrefix = 'package:';
 			if (element.id === 'attached-namespaces') {
 				return this.data.search.map(name => {
-					if (name.startsWith('package:')) {
-						return new PackageItem(name, name.substring(8));
+					if (name.startsWith(pkgPrefix)) {
+						return new PackageItem(name, name.substring(pkgPrefix.length));
 					} else {
 						const item = new TreeItem(name, TreeItemCollapsibleState.None);
 						item.iconPath = new ThemeIcon('symbol-array');
@@ -79,8 +80,14 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 					}
 				});
 			} else if (element.id === 'loaded-namespaces') {
+				const attached_packages = this.data.search
+					.filter(name => name.startsWith(pkgPrefix))
+					.map(name => name.substring(pkgPrefix.length));
 				return this.data.loaded_namespaces.map(name => {
 					const item = new PackageItem(name, name);
+					if (attached_packages.includes(name)) {
+						item.description = 'attached';
+					}
 					return item;
 				});
 			} else if (element.id === 'globalenv') {
@@ -150,13 +157,13 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 }
 
 class PackageItem extends TreeItem {
-	static command : string = 'r.workspaceViewer.namespace.showQuickPick';
+	static command : string = 'r.workspaceViewer.package.showQuickPick';
 	label: string;
 	name: string;
 	constructor(label: string, name: string) {
 		super(label, TreeItemCollapsibleState.None);
-		this.iconPath = new ThemeIcon('symbol-namespace');
 		this.name = name;
+		this.iconPath = new ThemeIcon('symbol-package');
 		this.command = {
 			command: PackageItem.command,
 			title: 'Show help topics',

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -44,7 +44,10 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 	}
 
 	getChildren(element?: TreeItem): TreeItem[] {
-		if (element && this.data) {
+		if (element) {
+			if (this.data === undefined) {
+				return [];
+			}
 			if (element.id === 'attached-namespaces') {
 				return this.data.search.map(name => {
 					const item = new TreeItem(name, TreeItemCollapsibleState.None);
@@ -143,7 +146,7 @@ export class GlobalEnvItem extends TreeItem {
 		super(label, GlobalEnvItem.setCollapsibleState(treeLevel, type, str));
 		this.description = this.getDescription(dim, str, rClass, type);
 		this.tooltip = this.getTooltip(label, rClass, size, treeLevel);
-		this.iconPath = this.getIconPath(type, dim);
+		this.iconPath = this.getIcon(type, dim);
 		this.type = type;
 		this.str = str;
 		this.treeLevel = treeLevel;
@@ -182,28 +185,12 @@ export class GlobalEnvItem extends TreeItem {
 		}
 	}
 
-	private getIconPath(type: string, dim?: number[]) {
+	private getIcon(type: string, dim?: number[]) {
 		let name: string;
 		if (dim) {
-			if (type === 'list') {
-				name = 'symbol-constant';
-			} else {
-				name = 'symbol-array';
-			}
+			name = 'symbol-array';
 		} else if (type === 'closure' || type === 'builtin') {
 			name = 'symbol-function';
-		} else if (type === 'double' || type === 'integer') {
-			name = 'symbol-numeric';
-		} else if (type === 'logical') {
-			name = 'symbol-boolean';
-		} else if (type === 'character') {
-			name = 'symbol-string';
-		} else if (type === 'NULL') {
-			name = 'symbol-null';
-		} else if (type === 'list') {
-			name = 'symbol-struct';
-		} else if (type === 'environment') {
-			name = 'symbol-object';
 		} else if (type === '') {
 			name = 'symbol-variable';
 		} else {

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -44,7 +44,7 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 	}
 
 	getChildren(element?: TreeItem): TreeItem[] {
-		if (element) {
+		if (element && this.data) {
 			if (element.id === 'attached-namespaces') {
 				return this.data.search.map(name => {
 					const item = new TreeItem(name, TreeItemCollapsibleState.None);

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -247,11 +247,11 @@ export function clearWorkspace(): void {
 export function saveWorkspace(): void {
 	if (workspaceData !== undefined) {
 		void window.showSaveDialog({
-			defaultUri: Uri.file(`${workingDir}${path.sep}workspace.RData`),
+			defaultUri: Uri.file(path.join(workingDir, 'workspace.RData')),
 			filters: {
-				'Data': ['RData']
+				'RData': ['RData']
 			},
-			title: 'Save workspace'
+			title: 'Save Workspace'
 		}
 		).then(async (uri: Uri | undefined) => {
 			if (uri) {

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -23,22 +23,22 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 
 	data: WorkspaceData;
 
-	private readonly attachedNamespacesItem: TreeItem;
-	private readonly loadedNamespacesItem: TreeItem;
-	private readonly globalEnvItem: TreeItem;
+	private readonly attachedNamespacesRootItem: TreeItem;
+	private readonly loadedNamespacesRootItem: TreeItem;
+	private readonly globalEnvRootItem: TreeItem;
 
 	constructor() {
-		this.attachedNamespacesItem = new TreeItem('Attached Namespaces', TreeItemCollapsibleState.Collapsed);
-		this.attachedNamespacesItem.id = 'attached-namespaces';
-		this.attachedNamespacesItem.iconPath = new ThemeIcon('library');
+		this.attachedNamespacesRootItem = new TreeItem('Attached Namespaces', TreeItemCollapsibleState.Collapsed);
+		this.attachedNamespacesRootItem.id = 'attached-namespaces';
+		this.attachedNamespacesRootItem.iconPath = new ThemeIcon('library');
 
-		this.loadedNamespacesItem = new TreeItem('Loaded Namespaces', TreeItemCollapsibleState.Collapsed);
-		this.loadedNamespacesItem.id = 'loaded-namespaces';
-		this.loadedNamespacesItem.iconPath = new ThemeIcon('package');
+		this.loadedNamespacesRootItem = new TreeItem('Loaded Namespaces', TreeItemCollapsibleState.Collapsed);
+		this.loadedNamespacesRootItem.id = 'loaded-namespaces';
+		this.loadedNamespacesRootItem.iconPath = new ThemeIcon('package');
 
-		this.globalEnvItem = new TreeItem('Global Environment', TreeItemCollapsibleState.Expanded);
-		this.globalEnvItem.id = 'globalenv';
-		this.globalEnvItem.iconPath = new ThemeIcon('menu');
+		this.globalEnvRootItem = new TreeItem('Global Environment', TreeItemCollapsibleState.Expanded);
+		this.globalEnvRootItem.id = 'globalenv';
+		this.globalEnvRootItem.iconPath = new ThemeIcon('menu');
 
 		extensionContext.subscriptions.push(
 			vscode.commands.registerCommand(PackageItem.command, async (name: string) => {
@@ -108,9 +108,9 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 					);
 			}
 		} else {
-			const treeItems = [this.attachedNamespacesItem, this.loadedNamespacesItem];
+			const treeItems = [this.attachedNamespacesRootItem, this.loadedNamespacesRootItem];
 			if (config().get<boolean>('session.watchGlobalEnvironment')) {
-				treeItems.push(this.globalEnvItem);
+				treeItems.push(this.globalEnvRootItem);
 			}
 			return treeItems;
 		}

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -1,19 +1,9 @@
 import * as path from 'path';
 import { TreeDataProvider, EventEmitter, TreeItemCollapsibleState, TreeItem, Event, Uri, window } from 'vscode';
 import { runTextInTerm } from './rTerminal';
-import { workspaceData, workingDir } from './session';
+import { GlobalEnv, workspaceData, workingDir } from './session';
 import { config } from './util';
 import { isGuestSession, isLiveShare, UUID, guestWorkspace } from './liveShare';
-
-interface WorkspaceAttr {
-	[key: string]: {
-		class: string[];
-		type: string;
-		str: string;
-		size?: number;
-		dim?: number[]
-	}
-}
 
 const priorityAttr: string[] = [
 	'list',
@@ -26,14 +16,14 @@ export class WorkspaceDataProvider implements TreeDataProvider<WorkspaceItem> {
 
 	refresh(): void {
 		if (isGuestSession) {
-			this.data = guestWorkspace.globalenv as WorkspaceAttr;
+			this.data = guestWorkspace.globalenv;
 		} else {
-			this.data = workspaceData.globalenv as WorkspaceAttr;
+			this.data = workspaceData.globalenv;
 		}
 		this._onDidChangeTreeData.fire();
 	}
 
-	data: WorkspaceAttr;
+	data: GlobalEnv;
 
 	getTreeItem(element: WorkspaceItem): TreeItem {
 		return element;
@@ -60,7 +50,7 @@ export class WorkspaceDataProvider implements TreeDataProvider<WorkspaceItem> {
 
 	}
 
-	private getWorkspaceItems(data: WorkspaceAttr): WorkspaceItem[] {
+	private getWorkspaceItems(data: GlobalEnv): WorkspaceItem[] {
 		const toItem = (
 			key: string,
 			rClass: string,


### PR DESCRIPTION
# What problem did you solve?

Closes #1018

This PR renames the global environment watcher to workspace watcher and includes `search()` and `loadedNamespaces()` in the writing of `workspace.json` instead of the previous `globalenv.json`. The following are improved:

* The workspace viewer contains more information of the R workspace: attached namespaces, loaded namespaces, and global environment symbols.
* The global environment symbols now get proper icons consistent with their completion item icons.
* Clicking the `package:foo` items in Attached Namespaces or items in Loaded Namespaces will show quick pick of help topics of that package.

## (If you have)Screenshot

https://user-images.githubusercontent.com/4662568/156767723-aad57c1a-b02b-4c21-90bd-a4c662111f81.mp4


## (If you do not have screenshot) How can I check this pull request?
