### PR TITLE
Share httpgd url for LiveShare

### DIFF
--- a/src/liveShare/index.ts
+++ b/src/liveShare/index.ts
@@ -279,8 +279,8 @@ export class GuestService {
             void liveShareRequest(Callback.RequestAttachGuest);
             // focus guest term if it exists
             const rTermNameOptions = ['R [Shared]', 'R Interactive [Shared]'];
-            const activeTerminalName = vscode.window.activeTerminal.name;
-            if (!rTermNameOptions.includes(activeTerminalName)) {
+            const activeTerminalName = vscode.window.activeTerminal?.name;
+            if (activeTerminalName && !rTermNameOptions.includes(activeTerminalName)) {
                 for (const [i] of vscode.window.terminals.entries()) {
                     const terminal = vscode.window.terminals[i];
                     const terminalName = terminal.name;

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -225,6 +225,14 @@ function getGuestImageHtml(content: string) {
 `;
 }
 
+export async function shareServer(url: URL, name: string): Promise<vscode.Disposable> {
+    return liveSession.shareServer({
+        port: parseInt(url.port),
+        displayName: `${name} (${url.host})`,
+        browseUrl: url.toString()
+    });
+}
+
 // Share and close browser are called from the
 // host session
 // Automates sharing browser sessions through the
@@ -232,12 +240,7 @@ function getGuestImageHtml(content: string) {
 export async function shareBrowser(url: string, name: string, force: boolean = false): Promise<void> {
     if (autoShareBrowser || force) {
         const _url = new URL(url);
-        const server: vsls.Server = {
-            port: parseInt(_url.port),
-            displayName: name,
-            browseUrl: url,
-        };
-        const disposable = await liveSession.shareServer(server);
+        const disposable = await shareServer(_url, name);
         console.log(`[HostService] shared ${name} at ${url}`);
         browserDisposables.push({ Disposable: disposable, url, name });
     }

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -2,7 +2,7 @@ import path = require('path');
 import * as vscode from 'vscode';
 import * as vsls from 'vsls';
 
-import { extensionContext, globalRHelp, rWorkspace } from '../extension';
+import { extensionContext, globalHttpgdManager, globalRHelp, rWorkspace } from '../extension';
 import { config, readContent } from '../util';
 import { showBrowser, showDataView, showWebView } from '../session';
 import { liveSession, UUID, rGuestService, _sessionStatusBarItem as sessionStatusBarItem } from '.';
@@ -98,13 +98,19 @@ export async function updateGuestRequest(file: string, force: boolean = false): 
                         break;
                     }
                     case 'httpgd': {
+                        if (request.url) {
+                            globalHttpgdManager?.showViewer(request.url);
+                        }
                         break;
                     }
                     case 'attach': {
                         guestPid = String(request.pid);
+                        rVer = String(request.version);
+                        info = request.info;
                         console.info(`[updateGuestRequest] attach PID: ${guestPid}`);
                         sessionStatusBarItem.text = `Guest R ${rVer}: ${guestPid}`;
                         sessionStatusBarItem.tooltip = `${info.version}\nProcess ID: ${guestPid}\nCommand: ${info.command}\nStart time: ${info.start_time}\nClick to attach to host terminal.`;
+                        sessionStatusBarItem.show();
                         break;
                     }
                     case 'browser': {
@@ -131,13 +137,13 @@ export async function updateGuestRequest(file: string, force: boolean = false): 
             }
         } else {
             guestPid = String(request.pid);
-            rVer = String(request.version);
-            info = request.info;
+            // rVer = String(request.version);
+            // info = request.info;
 
-            console.info(`[updateGuestRequest] attach PID: ${guestPid}`);
-            sessionStatusBarItem.text = `Guest R ${rVer}: ${guestPid}`;
-            sessionStatusBarItem.tooltip = `${info.version}\nProcess ID: ${guestPid}\nCommand: ${info.command}\nStart time: ${info.start_time}\nClick to attach to host terminal.`;
-            sessionStatusBarItem.show();
+            // console.info(`[updateGuestRequest] attach PID: ${guestPid}`);
+            // sessionStatusBarItem.text = `Guest R ${rVer}: ${guestPid}`;
+            // sessionStatusBarItem.tooltip = `${info.version}\nProcess ID: ${guestPid}\nCommand: ${info.command}\nStart time: ${info.start_time}\nClick to attach to host terminal.`;
+            // sessionStatusBarItem.show();
         }
     }
 }

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -1,6 +1,5 @@
 import path = require('path');
 import * as vscode from 'vscode';
-import * as vsls from 'vsls';
 
 import { extensionContext, globalHttpgdManager, globalRHelp, rWorkspace } from '../extension';
 import { config, readContent } from '../util';
@@ -85,66 +84,70 @@ export function attachActiveGuest(): void {
 export async function updateGuestRequest(file: string, force: boolean = false): Promise<void> {
     const requestContent: string = await readContent(file, 'utf8');
     console.info(`[updateGuestRequest] request: ${requestContent}`);
-    if (typeof (requestContent) === 'string') {
-        const request: IRequest = JSON.parse(requestContent) as IRequest;
-        if (request && !force) {
-            if (request.uuid === null || request.uuid === undefined || request.uuid === UUID) {
-                switch (request.command) {
-                    case 'help': {
-                        if (globalRHelp) {
-                            console.log(request.requestPath);
-                            void globalRHelp.showHelpForPath(request.requestPath, request.viewer);
-                        }
-                        break;
-                    }
-                    case 'httpgd': {
-                        if (request.url) {
-                            globalHttpgdManager?.showViewer(request.url);
-                        }
-                        break;
-                    }
-                    case 'attach': {
-                        guestPid = String(request.pid);
-                        rVer = String(request.version);
-                        info = request.info;
-                        console.info(`[updateGuestRequest] attach PID: ${guestPid}`);
-                        sessionStatusBarItem.text = `Guest R ${rVer}: ${guestPid}`;
-                        sessionStatusBarItem.tooltip = `${info.version}\nProcess ID: ${guestPid}\nCommand: ${info.command}\nStart time: ${info.start_time}\nClick to attach to host terminal.`;
-                        sessionStatusBarItem.show();
-                        break;
-                    }
-                    case 'browser': {
-                        await showBrowser(request.url, request.title, request.viewer);
-                        break;
-                    }
-                    case 'webview': {
-                        void showWebView(request.file, request.title, request.viewer);
-                        break;
-                    }
-                    case 'dataview': {
-                        void showDataView(request.source,
-                            request.type, request.title, request.file, request.viewer);
-                        break;
-                    }
-                    case 'rstudioapi': {
-                        console.error(`[GuestService] ${request.command} not supported`);
-                        break;
-                    }
-                    default:
-                        console.error(`[updateRequest] Unsupported command: ${request.command}`);
+    if (typeof (requestContent) !== 'string') {
+        return;
+    }
+
+    const request: IRequest = JSON.parse(requestContent) as IRequest;
+    if (!request) {
+        return;
+    }
+
+    if (force) {
+        // The last request is not necessarily an attach request.
+        guestPid = String(request.pid);
+        console.info(`[updateGuestRequest] attach PID: ${guestPid}`);
+        sessionStatusBarItem.text = `Guest R: ${guestPid}`;
+        sessionStatusBarItem.tooltip = 'Click to attach to host terminal.';
+        sessionStatusBarItem.show();
+    }
+
+    if (request.uuid === null || request.uuid === undefined || request.uuid === UUID) {
+        switch (request.command) {
+            case 'help': {
+                if (globalRHelp) {
+                    console.log(request.requestPath);
+                    await globalRHelp.showHelpForPath(request.requestPath, request.viewer);
                 }
-
+                break;
             }
-        } else {
-            guestPid = String(request.pid);
-            // rVer = String(request.version);
-            // info = request.info;
-
-            // console.info(`[updateGuestRequest] attach PID: ${guestPid}`);
-            // sessionStatusBarItem.text = `Guest R ${rVer}: ${guestPid}`;
-            // sessionStatusBarItem.tooltip = `${info.version}\nProcess ID: ${guestPid}\nCommand: ${info.command}\nStart time: ${info.start_time}\nClick to attach to host terminal.`;
-            // sessionStatusBarItem.show();
+            case 'httpgd': {
+                if (request.url) {
+                    await globalHttpgdManager?.showViewer(request.url);
+                }
+                break;
+            }
+            case 'attach': {
+                guestPid = String(request.pid);
+                rVer = String(request.version);
+                info = request.info;
+                console.info(`[updateGuestRequest] attach PID: ${guestPid}`);
+                sessionStatusBarItem.text = `Guest R ${rVer}: ${guestPid}`;
+                sessionStatusBarItem.tooltip = `${info.version}\nProcess ID: ${guestPid}\nCommand: ${info.command}\nStart time: ${info.start_time}\nClick to attach to host terminal.`;
+                sessionStatusBarItem.show();
+                break;
+            }
+            case 'browser': {
+                await showBrowser(request.url, request.title, request.viewer);
+                break;
+            }
+            case 'webview': {
+                await showWebView(request.file, request.title, request.viewer);
+                break;
+            }
+            case 'dataview': {
+                await showDataView(request.source,
+                    request.type, request.title, request.file, request.viewer);
+                break;
+            }
+            case 'rstudioapi': {
+                console.error(`[GuestService] ${request.command} not supported`);
+                break;
+            }
+            default:
+                console.error(`[updateRequest] Unsupported command: ${request.command}`);
         }
+
     }
 }
 

--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -16,6 +16,7 @@ import { extensionContext } from '../extension';
 import { FocusPlotMessage, InMessage, OutMessage, ToggleStyleMessage, UpdatePlotMessage, HidePlotMessage, AddPlotMessage, PreviewPlotLayout, PreviewPlotLayoutMessage, ToggleFullWindowMessage } from './webviewMessages';
 import { HttpgdIdResponse, HttpgdPlotId, HttpgdRendererId } from 'httpgd/lib/types';
 import { Response } from 'node-fetch';
+import { isHost, shareServer } from '../liveShare';
 
 const commands = [
     'showViewers',
@@ -65,7 +66,7 @@ export class HttpgdManager {
         };
     }
 
-    public showViewer(urlString: string): void {
+    public async showViewer(urlString: string): Promise<void> {
         const url = new URL(urlString);
         const host = url.host;
         const token = url.searchParams.get('token') || undefined;
@@ -86,6 +87,10 @@ export class HttpgdManager {
             this.viewerOptions.fullWindow = conf.get('plot.defaults.fullWindowMode', false);
             this.viewerOptions.token = token;
             const viewer = new HttpgdViewer(host, this.viewerOptions);
+            if (isHost()) {
+                const disposable = await shareServer(url, 'httpgd');
+                viewer.webviewPanel?.onDidDispose(() => void disposable.dispose());
+            }
             this.viewers.unshift(viewer);
         }
     }
@@ -121,7 +126,7 @@ export class HttpgdManager {
         };
         const urlString = await vscode.window.showInputBox(options);
         if (urlString) {
-            this.showViewer(urlString);
+            await this.showViewer(urlString);
         }
     }
 

--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -16,7 +16,7 @@ import { extensionContext } from '../extension';
 import { FocusPlotMessage, InMessage, OutMessage, ToggleStyleMessage, UpdatePlotMessage, HidePlotMessage, AddPlotMessage, PreviewPlotLayout, PreviewPlotLayoutMessage, ToggleFullWindowMessage } from './webviewMessages';
 import { HttpgdIdResponse, HttpgdPlotId, HttpgdRendererId } from 'httpgd/lib/types';
 import { Response } from 'node-fetch';
-import { isHost, shareServer } from '../liveShare';
+import { autoShareBrowser, isHost, shareServer } from '../liveShare';
 
 const commands = [
     'showViewers',
@@ -87,7 +87,7 @@ export class HttpgdManager {
             this.viewerOptions.fullWindow = conf.get('plot.defaults.fullWindowMode', false);
             this.viewerOptions.token = token;
             const viewer = new HttpgdViewer(host, this.viewerOptions);
-            if (isHost()) {
+            if (isHost() && autoShareBrowser) {
                 const disposable = await shareServer(url, 'httpgd');
                 viewer.webviewPanel?.onDidDispose(() => void disposable.dispose());
             }

--- a/src/session.ts
+++ b/src/session.ts
@@ -730,7 +730,7 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                     }
                     case 'httpgd': {
                         if (request.url) {
-                            globalHttpgdManager?.showViewer(request.url);
+                            void globalHttpgdManager?.showViewer(request.url);
                         }
                         break;
                     }
@@ -781,7 +781,7 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                 await liveSession.shareServer({
                     port: Number(url.port),
                     browseUrl: request.url,
-                    displayName: request.command
+                    displayName: `${request.command} (${url.host}:${url.port})`
                 });
             }
             void rHostService.notifyRequest(requestFile);

--- a/src/session.ts
+++ b/src/session.ts
@@ -781,7 +781,7 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                 await liveSession.shareServer({
                     port: Number(url.port),
                     browseUrl: request.url,
-                    displayName: `${request.command} (${url.host}:${url.port})`
+                    displayName: `${request.command} (${url.host})`
                 });
             }
             void rHostService.notifyRequest(requestFile);

--- a/src/session.ts
+++ b/src/session.ts
@@ -724,7 +724,7 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                     case 'help': {
                         if (globalRHelp) {
                             console.log(request.requestPath);
-                            void globalRHelp.showHelpForPath(request.requestPath, request.viewer);
+                            await globalRHelp.showHelpForPath(request.requestPath, request.viewer);
                         }
                         break;
                     }
@@ -756,11 +756,11 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                         break;
                     }
                     case 'webview': {
-                        void showWebView(request.file, request.title, request.viewer);
+                        await showWebView(request.file, request.title, request.viewer);
                         break;
                     }
                     case 'dataview': {
-                        void showDataView(request.source,
+                        await showDataView(request.source,
                             request.type, request.title, request.file, request.viewer);
                         break;
                     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -15,7 +15,7 @@ import { config, readContent, UriIcon } from './util';
 import { purgeAddinPickerItems, dispatchRStudioAPICall } from './rstudioapi';
 
 import { homeExtDir, rWorkspace, globalRHelp, globalHttpgdManager, extensionContext } from './extension';
-import { UUID, rHostService, rGuestService, isLiveShare, isHost, isGuestSession, closeBrowser, guestResDir, shareBrowser, openVirtualDoc, shareWorkspace } from './liveShare';
+import { UUID, rHostService, rGuestService, isLiveShare, isHost, isGuestSession, closeBrowser, guestResDir, shareBrowser, openVirtualDoc, shareWorkspace, liveSession } from './liveShare';
 
 export let globalenv: any;
 let resDir: string;
@@ -776,6 +776,14 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
             console.info(`[updateRequest] Ignored request outside workspace`);
         }
         if (isLiveShare()) {
+            if (request.url) {
+                const url = new URL(request.url);
+                await liveSession.shareServer({
+                    port: Number(url.port),
+                    browseUrl: request.url,
+                    displayName: request.command
+                });
+            }
             void rHostService.notifyRequest(requestFile);
         }
     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -15,7 +15,7 @@ import { config, readContent, UriIcon } from './util';
 import { purgeAddinPickerItems, dispatchRStudioAPICall } from './rstudioapi';
 
 import { homeExtDir, rWorkspace, globalRHelp, globalHttpgdManager, extensionContext } from './extension';
-import { UUID, rHostService, rGuestService, isLiveShare, isHost, isGuestSession, closeBrowser, guestResDir, shareBrowser, openVirtualDoc, shareWorkspace, liveSession } from './liveShare';
+import { UUID, rHostService, rGuestService, isLiveShare, isHost, isGuestSession, closeBrowser, guestResDir, shareBrowser, openVirtualDoc, shareWorkspace } from './liveShare';
 
 export let globalenv: any;
 let resDir: string;
@@ -730,7 +730,7 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                     }
                     case 'httpgd': {
                         if (request.url) {
-                            void globalHttpgdManager?.showViewer(request.url);
+                            await globalHttpgdManager?.showViewer(request.url);
                         }
                         break;
                     }
@@ -747,7 +747,7 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                         updateSessionWatcher();
                         purgeAddinPickerItems();
                         if (request.plot_url) {
-                            globalHttpgdManager?.showViewer(request.plot_url);
+                            await globalHttpgdManager?.showViewer(request.plot_url);
                         }
                         break;
                     }
@@ -776,14 +776,6 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
             console.info(`[updateRequest] Ignored request outside workspace`);
         }
         if (isLiveShare()) {
-            if (request.url) {
-                const url = new URL(request.url);
-                await liveSession.shareServer({
-                    port: Number(url.port),
-                    browseUrl: request.url,
-                    displayName: `${request.command} (${url.host})`
-                });
-            }
             void rHostService.notifyRequest(requestFile);
         }
     }


### PR DESCRIPTION
# What problem did you solve?

Closes #1023 

When a new httpgd viewer is created, the httpgd url is shared if auto forward ports is enabled.

I tested on a Windows host and a Ubuntu client, it works as expected.

## (If you do not have screenshot) How can I check this pull request?

1. Start live share session on host
2. join live share session on a client on separate server
3. Enable auto forward ports, use httpgd
4. Create an R session
5. `plot(1)`.
6. An item of `httpgd (127.0.0.1:port)` will show up in the shared servers of live share side view.
7. Both host and client will open the httpgd plot viewer and the plot could be properly displayed.