### PR TITLE
add R package build task - build source and build binary like RStudio

### DIFF
--- a/package.json
+++ b/package.json
@@ -440,14 +440,14 @@
         "command": "r.loadAll"
       },
       {
-        "title": "Build Source",
+        "title": "Build",
         "category": "R Package",
-        "command": "r.buildsource"
+        "command": "r.build"
       },
       {
         "title": "Build Binary",
         "category": "R Package",
-        "command": "r.buildbinary"
+        "command": "r.buildBinary"
       },
       {
         "title": "Check",

--- a/package.json
+++ b/package.json
@@ -442,7 +442,12 @@
       {
         "title": "Build",
         "category": "R Package",
-        "command": "r.build"
+        "command": "r.buildsource"
+      },
+      {
+        "title": "Build",
+        "category": "R Package",
+        "command": "r.buildbinary"
       },
       {
         "title": "Check",

--- a/package.json
+++ b/package.json
@@ -440,12 +440,12 @@
         "command": "r.loadAll"
       },
       {
-        "title": "Build",
+        "title": "Build Source",
         "category": "R Package",
         "command": "r.buildsource"
       },
       {
-        "title": "Build",
+        "title": "Build Binary",
         "category": "R Package",
         "command": "r.buildbinary"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,8 +110,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
-        'r.buildsource': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: BuildSource'),
-        'r.buildbinary': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: BuildBinary'),
+        'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),
+        'r.buildBinary': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build Binary'),
         'r.check': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Check'),
         'r.document': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Document'),
         'r.install': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Install'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,7 +110,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
-        'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),
+        'r.buildsource': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: BuildSource'),
+        'r.buildbinary': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: BuildBinary'),
         'r.check': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Check'),
         'r.document': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Document'),
         'r.install': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Install'),

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -58,7 +58,7 @@ const rtasks: RTaskInfo[] = [
     {
         definition: {
             type: TYPE,
-            code: ['devtools::build(binary = TRUE, args = c("--preclean"))']
+            code: ['devtools::build(binary = TRUE, args = c(\'--preclean\'))']
         },
         name: 'BuildBinary',
         group: vscode.TaskGroup.Build,

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -50,7 +50,17 @@ const rtasks: RTaskInfo[] = [
             type: TYPE,
             code: ['devtools::build()']
         },
-        name: 'Build',
+        name: 'BuildSource',
+        group: vscode.TaskGroup.Build,
+        problemMatchers: []
+    },
+
+    {
+        definition: {
+            type: TYPE,
+            code: ['devtools::build(binary = TRUE, args = c("--preclean"))']
+        },
+        name: 'BuildBinary',
         group: vscode.TaskGroup.Build,
         problemMatchers: []
     },

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -50,7 +50,7 @@ const rtasks: RTaskInfo[] = [
             type: TYPE,
             code: ['devtools::build()']
         },
-        name: 'BuildSource',
+        name: 'Build',
         group: vscode.TaskGroup.Build,
         problemMatchers: []
     },
@@ -60,7 +60,7 @@ const rtasks: RTaskInfo[] = [
             type: TYPE,
             code: ['devtools::build(binary = TRUE, args = c(\'--preclean\'))']
         },
-        name: 'BuildBinary',
+        name: 'Build Binary',
         group: vscode.TaskGroup.Build,
         problemMatchers: []
     },


### PR DESCRIPTION
RStudio provides two build task with `devtools::build()` and `devtools::build(binary = TRUE, args = c('--preclean'))`, This PR provides `r.buildbinary` command to run `devtools::build(binary = TRUE, args = c('--preclean'))` as task and rename original `r.build` to `r.buildsource`.


