### PR TITLE
Fix console err

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -31,7 +31,7 @@ const roxygenTagCompletionItems = [
 
 export class HoverProvider implements vscode.HoverProvider {
     provideHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover {
-        if(!session.workspaceData.globalenv){
+        if(!session.workspaceData?.globalenv){
             return null;
         }
 
@@ -115,7 +115,7 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
         completionContext: vscode.CompletionContext
     ): vscode.CompletionItem[] {
         const items = [];
-        if (token.isCancellationRequested) {
+        if (token.isCancellationRequested || !session.workspaceData?.globalenv) {
             return items;
         }
 

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -423,6 +423,7 @@ export class RHelp
     private async getAllAliases(): Promise<Alias[] | undefined> {
         const aliases = await doWithProgress(() =>
             this.aliasProvider.getAllAliases(),
+            vscode.ProgressLocation.Window
         );
         if (!aliases) {
             void vscode.window.showErrorMessage(

--- a/src/helpViewer/packages.ts
+++ b/src/helpViewer/packages.ts
@@ -178,7 +178,7 @@ export class PackageManager {
 
     // let the user pick and install a package from CRAN 
     public async pickAndInstallPackages(pickMany: boolean = false): Promise<boolean> {
-        const packages = await doWithProgress(() => this.getPackages(true));
+        const packages = await doWithProgress(() => this.getPackages(true), this.rHelp.treeViewWrapper.viewId);
         if(!packages?.length){
             return false;
         }

--- a/src/helpViewer/treeView.ts
+++ b/src/helpViewer/treeView.ts
@@ -45,6 +45,7 @@ type cmdName = keyof typeof nodeCommands;
 // necessary to implement Node.refresh(),
 // which is used to signal from a node that its contents/children have changed
 export class HelpTreeWrapper {
+    public readonly viewId = 'rHelpPages';
     public rHelp: RHelp;
     public helpView: vscode.TreeView<Node>;
     public helpViewProvider: HelpViewProvider;
@@ -53,7 +54,7 @@ export class HelpTreeWrapper {
         this.rHelp = rHelp;
         this.helpViewProvider = new HelpViewProvider(this);
         this.helpView = vscode.window.createTreeView(
-            'rHelpPages',
+            this.viewId,
             {
                 treeDataProvider: this.helpViewProvider,
                 showCollapseAll: true
@@ -587,7 +588,7 @@ class RefreshNode extends MetaNode {
     iconPath = new vscode.ThemeIcon('refresh');
 
     async callBack(){
-        await doWithProgress(() => this.rHelp.refresh());
+        await doWithProgress(() => this.rHelp.refresh(), this.wrapper.viewId);
         this.parent.pkgRootNode.refresh();
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -261,7 +261,7 @@ export async function executeAsTask(name: string, cmdOrProcess: string, args?: s
 // executes a callback and shows a 'busy' progress bar during the execution
 // synchronous callbacks are converted to async to properly render the progress bar
 // default location is in the help pages tree view
-export async function doWithProgress<T>(cb: (token?: vscode.CancellationToken, progress?: vscode.Progress<T>) => T | Promise<T>, location: string | vscode.ProgressLocation = 'rHelpPages', title?: string, cancellable?: boolean): Promise<T> {
+export async function doWithProgress<T>(cb: (token?: vscode.CancellationToken, progress?: vscode.Progress<T>) => T | Promise<T>, location: (string | vscode.ProgressLocation) = vscode.ProgressLocation.Window, title?: string, cancellable?: boolean): Promise<T> {
     const location2 = (typeof location === 'string' ? { viewId: location } : location);
     const options: vscode.ProgressOptions = {
         location: location2,


### PR DESCRIPTION
# What problem did you solve?

Closes #1033 

## (If you do not have screenshot) How can I check this pull request?

When no terminal is created, hover on a symbol in editor should no longer cause undefined `globalenv`.
When the R Help pages viewer is not open, hover on a symbol should no longer cause bad location to `rHelpPages`.