### PR TITLE
Add lsp settings to support disabling prompt and additional libPaths

### DIFF
--- a/R/languageServer.R
+++ b/R/languageServer.R
@@ -1,6 +1,6 @@
 add_lib_paths <- Sys.getenv("R_LSP_LIB_PATHS")
 if (nzchar(add_lib_paths)) {
-  add_lib_paths <- strsplit(add_lib_paths, "\n", fixed = TRUE)[[1]]
+  add_lib_paths <- strsplit(add_lib_paths, "\n", fixed = TRUE)[[1L]]
   .libPaths(c(.libPaths(), add_lib_paths))
 }
 
@@ -11,7 +11,7 @@ if (!requireNamespace("languageserver", quietly = TRUE)) {
 debug <- Sys.getenv("R_LSP_DEBUG")
 port <- Sys.getenv("R_LSP_PORT")
 
-debug <- if (nzchar(debug)) as.logical(debug)
+debug <- if (nzchar(debug)) as.logical(debug) else FALSE
 port <- if (nzchar(port)) as.integer(port) else NULL
 
 languageserver::run(port = port, debug = debug)

--- a/R/languageServer.R
+++ b/R/languageServer.R
@@ -1,0 +1,17 @@
+add_lib_paths <- Sys.getenv("R_LSP_LIB_PATHS")
+if (nzchar(add_lib_paths)) {
+  add_lib_paths <- strsplit(add_lib_paths, "\n", fixed = TRUE)[[1]]
+  .libPaths(c(.libPaths(), add_lib_paths))
+}
+
+if (!requireNamespace("languageserver", quietly = TRUE)) {
+  q(save = "no", status = 10)
+}
+
+debug <- Sys.getenv("R_LSP_DEBUG")
+port <- Sys.getenv("R_LSP_PORT")
+
+debug <- if (nzchar(debug)) as.logical(debug)
+port <- if (nzchar(port)) as.integer(port) else NULL
+
+languageserver::run(port = port, debug = debug)

--- a/package.json
+++ b/package.json
@@ -1310,7 +1310,7 @@
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "Additional library paths to launch R Language Server with. These paths will be appended to `.libPaths()`."
+          "markdownDescription": "Additional library paths to launch R Language Server with. These paths will be appended to `.libPaths()`. `${workspaceFolder}` and `${home}` could be used in the paths."
         },
         "r.lsp.promptToInstall": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1298,23 +1298,39 @@
         },
         "r.lsp.args": {
           "type": "array",
+          "items": {
+            "type": "string"
+          },
           "default": [],
-          "description": "The command line arguments to use when launching R Language Server"
+          "description": "The command line arguments to use when launching R Language Server."
+        },
+        "r.lsp.libPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Additional library paths to launch R Language Server with. These paths will be appended to `.libPaths()`."
+        },
+        "r.lsp.promptToInstall": {
+          "type": "boolean",
+          "default": true,
+          "description": "Prompt to install R Language Server if it is not installed."
         },
         "r.lsp.debug": {
           "type": "boolean",
           "default": false,
-          "description": "Debug R Language Server"
+          "description": "Debug R Language Server."
         },
         "r.lsp.diagnostics": {
           "type": "boolean",
           "default": true,
-          "description": "Enable Diagnostics"
+          "description": "Enable diagnostics."
         },
         "r.lsp.lang": {
           "type": "string",
           "default": "",
-          "description": "Override default LANG environment variable"
+          "markdownDescription": "Override default `LANG` environment variable."
         },
         "r.lsp.use_stdio": {
           "type": "boolean",

--- a/src/helpViewer/packages.ts
+++ b/src/helpViewer/packages.ts
@@ -196,7 +196,7 @@ export class PackageManager {
     // remove a specified package. The packagename is selected e.g. in the help tree-view
     public async removePackage(pkgName: string): Promise<boolean> {
         const rPath = await getRpath();
-        const args = ['--silent', '--slave', '-e', `remove.packages('${pkgName}')`];
+        const args = ['--silent', '--slave', '--no-save', '--no-restore', '-e', `remove.packages('${pkgName}')`];
         const cmd = `${rPath} ${args.join(' ')}`;
         const confirmation = 'Yes, remove package!';
         const prompt = `Are you sure you want to remove package ${pkgName}?`;
@@ -230,7 +230,7 @@ export class PackageManager {
     public async updatePackages(skipConfirmation: boolean = false): Promise<boolean> {
         const rPath = await getRpath();
         const cranUrl = await getCranUrl('', this.cwd);
-        const args = ['--silent', '--slave', '-e', `update.packages(ask=FALSE,repos='${cranUrl}')`];
+        const args = ['--silent', '--slave', '--no-save', '--no-restore', '-e', `update.packages(ask=FALSE,repos='${cranUrl}')`];
         const cmd = `${rPath} ${args.join(' ')}`;
         const confirmation = 'Yes, update all packages!';
         const prompt = 'Are you sure you want to update all installed packages? This might take some time!';

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -64,7 +64,12 @@ export class LanguageService implements Disposable {
     const use_stdio = config.get<boolean>('lsp.use_stdio');
     const env = Object.create(process.env);
     env.R_LSP_DEBUG = debug ? 'TRUE' : 'FALSE';
-    env.R_LSP_LIB_PATHS = config.get<string[]>('lsp.libPaths').join('\n');
+    env.R_LSP_LIB_PATHS = config.get<string[]>('lsp.libPaths')
+      .map(dir => dir
+        .replace('${workspaceFolder}', workspaceFolder?.uri.fsPath || cwd)
+        .replace('${home}', os.homedir())
+      )
+      .join('\n');
 
     const lang = config.get<string>('lsp.lang');
     if (lang !== '') {

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -84,7 +84,14 @@ export class LanguageService implements Disposable {
 
     const rScriptPath = extensionContext.asAbsolutePath('R/languageServer.R');
     const options = { cwd: cwd, env: env };
-    const args = config.get<string[]>('lsp.args').concat('--silent', '--slave', '-f', rScriptPath);
+    const args = config.get<string[]>('lsp.args').concat(
+      '--silent',
+      '--slave',
+      '--no-save',
+      '--no-restore',
+      '-f',
+      rScriptPath
+    );
 
     const tcpServerOptions = () => new Promise<DisposableProcess | StreamInfo>((resolve, reject) => {
       // Use a TCP socket because of problems with blocking STDIO

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -9,7 +9,9 @@ import net = require('net');
 import url = require('url');
 import { LanguageClient, LanguageClientOptions, StreamInfo, DocumentFilter, ErrorAction, CloseAction, RevealOutputChannelOn } from 'vscode-languageclient/node';
 import { Disposable, workspace, Uri, TextDocument, WorkspaceConfiguration, OutputChannel, window, WorkspaceFolder } from 'vscode';
-import { DisposableProcess, getRpath, spawn, isRPkgIntalled } from './util';
+import { DisposableProcess, getRpath, promptToInstallRPackage, spawn } from './util';
+import { extensionContext } from './extension';
+import { CommonOptions } from 'child_process';
 
 export class LanguageService implements Disposable {
   private readonly clients: Map<string, LanguageClient> = new Map();
@@ -23,17 +25,34 @@ export class LanguageService implements Disposable {
     return this.stopLanguageService();
   }
 
+  private spawnServer(client: LanguageClient, rPath: string, args: readonly string[], options: CommonOptions): DisposableProcess {
+    const childProcess = spawn(rPath, args, options);
+    client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) started`);
+    childProcess.stderr.on('data', (chunk: Buffer) => {
+      client.outputChannel.appendLine(chunk.toString());
+    });
+    childProcess.on('exit', (code, signal) => {
+      client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) exited ` +
+        (signal ? `from signal ${signal}` : `with exit code ${code}`));
+      if (code !== 0) {
+        if (code === 10) {
+          // languageserver is not installed.
+          void promptToInstallRPackage(
+            'languageserver', 'lsp.promptToInstall', options.cwd,
+            'R package {languageserver} is required to enable R language service features such as code completion, function signature, find references, etc. Do you want to install it?',
+            'You may need to reopen an R file to start the language service after the package is installed.'
+          );
+        } else {
+          client.outputChannel.show();
+        }
+      }
+      void client.stop();
+    });
+    return childProcess;
+  }
+
   private async createClient(config: WorkspaceConfiguration, selector: DocumentFilter[],
     cwd: string, workspaceFolder: WorkspaceFolder, outputChannel: OutputChannel): Promise<LanguageClient> {
-    const installed = await isRPkgIntalled(
-      'languageserver', cwd, true,
-      'R package {languageserver} is required to enable R language service features such as code completion, function signature, find references, etc. Do you want to install it?',
-      'You may need to reopen an R file to start the language service after the package is installed.'
-    );
-
-    if (!installed) {
-      return undefined;
-    }
 
     let client: LanguageClient;
 
@@ -44,18 +63,23 @@ export class LanguageService implements Disposable {
     }
     const use_stdio = config.get<boolean>('lsp.use_stdio');
     const env = Object.create(process.env);
+    env.R_LSP_DEBUG = debug ? 'TRUE' : 'FALSE';
+    env.R_LSP_LIB_PATHS = config.get<string[]>('lsp.libPaths').join('\n');
+
     const lang = config.get<string>('lsp.lang');
     if (lang !== '') {
       env.LANG = lang;
     } else if (env.LANG === undefined) {
       env.LANG = 'en_US.UTF-8';
     }
+
     if (debug) {
       console.log(`LANG: ${env.LANG}`);
     }
 
+    const rScriptPath = extensionContext.asAbsolutePath('R/languageServer.R');
     const options = { cwd: cwd, env: env };
-    const initArgs: string[] = config.get<string[]>('lsp.args').concat('--silent', '--slave');
+    const args = config.get<string[]>('lsp.args').concat('--silent', '--slave', '-f', rScriptPath);
 
     const tcpServerOptions = () => new Promise<DisposableProcess | StreamInfo>((resolve, reject) => {
       // Use a TCP socket because of problems with blocking STDIO
@@ -75,23 +99,8 @@ export class LanguageService implements Disposable {
       // Listen on random port
       server.listen(0, '127.0.0.1', () => {
         const port = (server.address() as net.AddressInfo).port;
-        const expr = debug ? `languageserver::run(port=${port},debug=TRUE)` : `languageserver::run(port=${port})`;
-        // const cmd = `${rPath} ${initArgs.join(' ')} -e "${expr}"`;
-        const args = initArgs.concat(['-e', expr]);
-        const childProcess = spawn(rPath, args, options);
-        client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) started`);
-        childProcess.stderr.on('data', (chunk: Buffer) => {
-          client.outputChannel.appendLine(chunk.toString());
-        });
-        childProcess.on('exit', (code, signal) => {
-          client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) exited ` +
-            (signal ? `from signal ${signal}` : `with exit code ${code}`));
-          if (code !== 0) {
-            client.outputChannel.show();
-          }
-          void client.stop();
-        });
-        return childProcess;
+        env.R_LSP_PORT = String(port);
+        return this.spawnServer(client, rPath, args, options);
       });
     });
 
@@ -121,12 +130,6 @@ export class LanguageService implements Disposable {
 
     // Create the language client and start the client.
     if (use_stdio && process.platform !== 'win32') {
-      let args: string[];
-      if (debug) {
-        args = initArgs.concat(['-e', `languageserver::run(debug=TRUE)`]);
-      } else {
-        args = initArgs.concat(['-e', `languageserver::run()`]);
-      }
       client = new LanguageClient('r', 'R Language Server', { command: rPath, args: args, options: options }, clientOptions);
     } else {
       client = new LanguageClient('r', 'R Language Server', tcpServerOptions, clientOptions);

--- a/src/util.ts
+++ b/src/util.ts
@@ -492,30 +492,30 @@ export async function spawnAsync(command: string, args?: ReadonlyArray<string>, 
 /**
  * Check if an R package is available or not
  *
- * @param name the R package name that need to be checked
+ * @param name the R package name to ask user to install
  * @returns a boolean Promise
  */
-export async function isRPkgIntalled(name: string, cwd: string, promptToInstall: boolean = false, installMsg?: string, postInstallMsg?: string): Promise<boolean> {
-    const cmd = `cat(requireNamespace('${name}', quietly=TRUE))`;
-    const rOut = await executeRCommand(cmd, cwd, 'FALSE');
-    const isInstalled = rOut === 'TRUE';
-    if (promptToInstall && !isInstalled) {
-        if (installMsg === undefined) {
-            installMsg = `R package {${name}} is not installed. Do you want to install it?`;
-        }
-        void vscode.window.showErrorMessage(installMsg, 'Yes', 'No')
-            .then(async function (select) {
-                if (select === 'Yes') {
-                    const repo = await getCranUrl('', cwd);
-                    const rPath = await getRpath();
-                    const args = ['--silent', '--slave', '-e', `install.packages('${name}', repos='${repo}')`];
-                    void executeAsTask('Install Package', rPath, args, true);
-                    if (postInstallMsg) {
-                        void vscode.window.showInformationMessage(postInstallMsg, 'OK');
-                    }
-                    return true;
-                }
-            });
+export async function promptToInstallRPackage(name: string, section: string, cwd: string, installMsg?: string, postInstallMsg?: string): Promise<void> {
+    const _config = config();
+    const prompt = _config.get<boolean>(section);
+    if (!prompt) {
+        return;
     }
-    return isInstalled;
+    if (installMsg === undefined) {
+        installMsg = `R package {${name}} is not installed. Do you want to install it?`;
+    }
+    await vscode.window.showErrorMessage(installMsg, 'Yes', 'No', 'Never ask again')
+        .then(async function (select) {
+            if (select === 'Yes') {
+                const repo = await getCranUrl('', cwd);
+                const rPath = await getRpath();
+                const args = ['--silent', '--slave', '-e', `install.packages('${name}', repos='${repo}')`];
+                void executeAsTask('Install Package', rPath, args, true);
+                if (postInstallMsg) {
+                    void vscode.window.showInformationMessage(postInstallMsg, 'OK');
+                }
+            } else if (select === 'Never ask again') {
+                void _config.update(section, false);
+            }
+        });
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -509,7 +509,7 @@ export async function promptToInstallRPackage(name: string, section: string, cwd
             if (select === 'Yes') {
                 const repo = await getCranUrl('', cwd);
                 const rPath = await getRpath();
-                const args = ['--silent', '--slave', '-e', `install.packages('${name}', repos='${repo}')`];
+                const args = ['--silent', '--slave', '--no-save', '--no-restore', '-e', `install.packages('${name}', repos='${repo}')`];
                 void executeAsTask('Install Package', rPath, args, true);
                 if (postInstallMsg) {
                     void vscode.window.showInformationMessage(postInstallMsg, 'OK');


### PR DESCRIPTION
# What problem did you solve?

Closes #1037
Closes #1021

This PR adds the following `r.lsp` settings:

* `r.lsp.promptToInstall` to prompt to install `languageserver` if the package is not installed.
* `r.lsp.libPaths` to add additional lib paths for the language server process to start with.

The check before starting languageserver is removed. Instead, a single R process runs a script. It first checks if languageserver is installed and if so it starts the language server with proper arguments. This resolves #1021 so that the startup arguments won't be inconsistent between the R process to check the package and to run the language server.

`r.lsp.libPaths` could be useful if project package manager like `renv` is used. In this case, user could add, for example, the following to the vscode settings to the workspace folder if renv is initialized in `.vscode` and languageserver is installed here.

```json
{
  "r.lsp.libPaths": [
    "${workspaceFolder}/.vscode/renv/library/R-4.1/x86_64-apple-darwin17.0"
  ]
}
```

The path could be any location that contains a valid installation of languageserver so that the  path is appended to `.libPaths()` before the language server is run.

## (If you do not have screenshot) How can I check this pull request?
