### PR TITLE
Take out http from `Insert image` Rmd snippet

### DIFF
--- a/snippets/rmarkdown.json
+++ b/snippets/rmarkdown.json
@@ -110,7 +110,7 @@
 	},
 	"Insert image": {
 		"prefix": "image",
-		"body": "![${1:alt}](http://${2:link})$0",
+		"body": "![${1:alt}](${2:link})$0",
 		"description": "Insert image"
 	},
 	"Insert code chunk": {


### PR DESCRIPTION
# What problem did you solve?

Currently, `Insert image` Rmd snippet assumes that the image link should be a remote URL. However, this is overgeneralization because local image can b also used. Thus, I've taken out the http from the snippet.

## (If you have)Screenshot


## (If you do not have screenshot) How can I check this pull request?

Try using `Insert image` snippet in any Rmd file.
