### PR TITLE
Take out http from link snippet

### DIFF
--- a/snippets/rmarkdown.json
+++ b/snippets/rmarkdown.json
@@ -105,7 +105,7 @@
 	},
 	"Insert link": {
 		"prefix": "link",
-		"body": "[${1:text}](http://${2:link})$0",
+		"body": "[${1:text}](${2:link})$0",
 		"description": "Insert link"
 	},
 	"Insert image": {


### PR DESCRIPTION
# What problem did you solve?

similar to #1084: link could be a relative path or even local path. Also `https` could be used. Thus, do not fix it as `http://`.

## (If you have)Screenshot

## (If you do not have screenshot) How can I check this pull request?

In Rmd file, try `Insert link` snippet.