### PR TITLE
Use `loadNamespace`

### DIFF
--- a/R/help/getAliases.R
+++ b/R/help/getAliases.R
@@ -1,4 +1,4 @@
-requireNamespace("jsonlite")
+loadNamespace("jsonlite")
 
 ip <- installed.packages()
 

--- a/R/rmarkdown/templates.R
+++ b/R/rmarkdown/templates.R
@@ -1,5 +1,5 @@
-requireNamespace("jsonlite")
-requireNamespace("yaml")
+loadNamespace("jsonlite")
+loadNamespace("yaml")
 
 pkgs <- .packages(all.available = TRUE)
 templates <- new.env()

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -65,6 +65,7 @@ async function getTemplateItems(cwd: string): Promise<TemplateItem[]> {
     } catch (e) {
         console.log(e);
         void window.showErrorMessage((<{ message: string }>e).message);
+        return undefined;
     }
 }
 
@@ -80,8 +81,16 @@ async function launchTemplatePicker(cwd: string): Promise<TemplateItem> {
 
     const items = await getTemplateItems(cwd);
 
-    const selection: TemplateItem = await window.showQuickPick<TemplateItem>(items, options);
-    return selection;
+    if (items) {
+        if (items.length > 0) {
+            const selection = await window.showQuickPick<TemplateItem>(items, options);
+            return selection;
+        } else {
+            void window.showInformationMessage('No templates found.');
+        }
+    } else {
+        return undefined;
+    }
 }
 
 async function makeDraft(file: string, template: TemplateItem, cwd: string): Promise<string> {

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -88,9 +88,8 @@ async function launchTemplatePicker(cwd: string): Promise<TemplateItem> {
         } else {
             void window.showInformationMessage('No templates found.');
         }
-    } else {
-        return undefined;
     }
+    return undefined;
 }
 
 async function makeDraft(file: string, template: TemplateItem, cwd: string): Promise<string> {


### PR DESCRIPTION
# What problem did you solve?

* `requireNamespace()` does not stop. Use `loadNamespace()` instead so it could fail early if the required packages are not available.
* Improved the error handling of `R Markdown: Create new draft`.
