### PR TITLE
R language server and help supports additional libPaths

### DIFF
--- a/R/help/getAliases.R
+++ b/R/help/getAliases.R
@@ -1,3 +1,9 @@
+add_lib_paths <- Sys.getenv("VSCR_LIB_PATHS")
+if (nzchar(add_lib_paths)) {
+  add_lib_paths <- strsplit(add_lib_paths, "\n", fixed = TRUE)[[1L]]
+  .libPaths(c(.libPaths(), add_lib_paths))
+}
+
 loadNamespace("jsonlite")
 
 ip <- installed.packages()

--- a/R/help/helpServer.R
+++ b/R/help/helpServer.R
@@ -1,4 +1,9 @@
-# get values from extension-set env values
+add_lib_paths <- Sys.getenv("VSCR_LIB_PATHS")
+if (nzchar(add_lib_paths)) {
+  add_lib_paths <- strsplit(add_lib_paths, "\n", fixed = TRUE)[[1L]]
+  .libPaths(c(.libPaths(), add_lib_paths))
+}
+
 lim <- Sys.getenv("VSCR_LIM")
 
 NEW_PACKAGE_STRING <- "NEW_PACKAGES"

--- a/R/languageServer.R
+++ b/R/languageServer.R
@@ -1,4 +1,4 @@
-add_lib_paths <- Sys.getenv("R_LSP_LIB_PATHS")
+add_lib_paths <- Sys.getenv("VSCR_LIB_PATHS")
 if (nzchar(add_lib_paths)) {
   add_lib_paths <- strsplit(add_lib_paths, "\n", fixed = TRUE)[[1L]]
   .libPaths(c(.libPaths(), add_lib_paths))
@@ -8,8 +8,8 @@ if (!requireNamespace("languageserver", quietly = TRUE)) {
   q(save = "no", status = 10)
 }
 
-debug <- Sys.getenv("R_LSP_DEBUG")
-port <- Sys.getenv("R_LSP_PORT")
+debug <- Sys.getenv("VSCR_LSP_DEBUG")
+port <- Sys.getenv("VSCR_LSP_PORT")
 
 debug <- if (nzchar(debug)) as.logical(debug) else FALSE
 port <- if (nzchar(port)) as.integer(port) else NULL

--- a/package.json
+++ b/package.json
@@ -1304,13 +1304,13 @@
           "default": [],
           "description": "The command line arguments to use when launching R Language Server."
         },
-        "r.lsp.libPaths": {
+        "r.libPaths": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "Additional library paths to launch R Language Server with. These paths will be appended to `.libPaths()`. `${workspaceFolder}` and `${home}` could be used in the paths."
+          "markdownDescription": "Additional library paths to launch R background processes (R languageserver, help server, etc.). These paths will be appended to `.libPaths()` on process startup. It could be useful for projects with [renv](https://rstudio.github.io/renv/index.html) enabled. `${workspaceFolder}` and `${home}` could be used in the paths."
         },
         "r.lsp.promptToInstall": {
           "type": "boolean",

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -4,7 +4,7 @@ import * as cp from 'child_process';
 
 import * as rHelp from '.';
 import { extensionContext } from '../extension';
-import { DisposableProcess, spawn, spawnAsync } from '../util';
+import { DisposableProcess, getRLibPaths, spawn, spawnAsync } from '../util';
 
 export interface RHelpProviderOptions {
 	// path of the R executable
@@ -58,7 +58,11 @@ export class HelpProvider {
         ];
         const cpOptions = {
             cwd: this.cwd,
-            env: { ...process.env, 'VSCR_LIM': lim },
+            env: {
+                ...process.env,
+                VSCR_LIB_PATHS: getRLibPaths(this.cwd),
+                VSCR_LIM: lim
+            },
         };
 
         const childProcess: ChildProcessWithPort = spawn(this.rPath, args, cpOptions);
@@ -272,6 +276,7 @@ export class AliasProvider {
             cwd: this.cwd,
             env: {
                 ...process.env,
+                VSCR_LIB_PATHS: getRLibPaths(this.cwd),
                 VSCR_LIM: lim
             }
         };

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,7 @@
 
 import { existsSync, PathLike, readFile } from 'fs-extra';
 import * as fs from 'fs';
+import os = require('os');
 import winreg = require('winreg');
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -296,8 +297,14 @@ export async function getCranUrl(path: string = '', cwd?: string): Promise<strin
     return url;
 }
 
-
-
+export function getRLibPaths(cwd: string): string {
+    return config().get<string[]>('libPaths')
+        .map(dir => dir
+            .replace('${workspaceFolder}', cwd)
+            .replace('${home}', os.homedir())
+        )
+        .join('\n');
+}
 
 // executes an R command returns its output to stdout
 // uses a regex to filter out output generated e.g. by code in .Rprofile


### PR DESCRIPTION
Follows #1071.

`r.lsp.libPaths` is renamed to `r.libPaths` to support additional lib paths when R language server, helpServer, and getAliases are executed. In this way, user will not have to install language server in renv-enabled projects.

```json
{
  "r.libPaths": [
    "${home}/R/renv/library/R-4.1/x86_64-apple-darwin17.0"
  ]
}
```