### PR TITLE
Update `r.libPaths` behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1297,7 +1297,7 @@
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "Additional library paths to launch R background processes (R languageserver, help server, etc.). These paths will be appended to `.libPaths()` on process startup. It could be useful for projects with [renv](https://rstudio.github.io/renv/index.html) enabled. `${workspaceFolder}` and `${home}` could be used in the paths."
+          "markdownDescription": "Additional library paths to launch R background processes (R languageserver, help server, etc.). These paths will be appended to `.libPaths()` on process startup. It could be useful for projects with [renv](https://rstudio.github.io/renv/index.html) enabled."
         },
         "r.lsp.enabled": {
           "type": "boolean",

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -60,7 +60,7 @@ export class HelpProvider {
             cwd: this.cwd,
             env: {
                 ...process.env,
-                VSCR_LIB_PATHS: getRLibPaths(this.cwd),
+                VSCR_LIB_PATHS: getRLibPaths(),
                 VSCR_LIM: lim
             },
         };
@@ -276,7 +276,7 @@ export class AliasProvider {
             cwd: this.cwd,
             env: {
                 ...process.env,
-                VSCR_LIB_PATHS: getRLibPaths(this.cwd),
+                VSCR_LIB_PATHS: getRLibPaths(),
                 VSCR_LIM: lim
             }
         };

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -64,7 +64,7 @@ export class LanguageService implements Disposable {
     const use_stdio = config.get<boolean>('lsp.use_stdio');
     const env = Object.create(process.env);
     env.VSCR_LSP_DEBUG = debug ? 'TRUE' : 'FALSE';
-    env.VSCR_LIB_PATHS = getRLibPaths(workspaceFolder?.uri.fsPath || cwd);
+    env.VSCR_LIB_PATHS = getRLibPaths();
 
     const lang = config.get<string>('lsp.lang');
     if (lang !== '') {
@@ -190,7 +190,7 @@ export class LanguageService implements Disposable {
           const client = await self.createClient(config, documentSelector,
             path.dirname(document.uri.fsPath), folder, outputChannel);
           if (client) {
-            client.start();
+            extensionContext.subscriptions.push(client.start());
             self.clients.set(key, client);
           }
           self.initSet.delete(key);
@@ -211,7 +211,7 @@ export class LanguageService implements Disposable {
           ];
           const client = await self.createClient(config, documentSelector, folder.uri.fsPath, folder, outputChannel);
           if (client) {
-            client.start();
+            extensionContext.subscriptions.push(client.start());
             self.clients.set(key, client);
           }
           self.initSet.delete(key);
@@ -230,7 +230,7 @@ export class LanguageService implements Disposable {
             ];
             const client = await self.createClient(config, documentSelector, os.homedir(), undefined, outputChannel);
             if (client) {
-              client.start();
+              extensionContext.subscriptions.push(client.start());
               self.clients.set(key, client);
             }
             self.initSet.delete(key);
@@ -249,7 +249,7 @@ export class LanguageService implements Disposable {
             const client = await self.createClient(config, documentSelector,
               path.dirname(document.uri.fsPath), undefined, outputChannel);
             if (client) {
-              client.start();
+              extensionContext.subscriptions.push(client.start());
               self.clients.set(key, client);
             }
             self.initSet.delete(key);

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,6 @@
 
 import { existsSync, PathLike, readFile } from 'fs-extra';
 import * as fs from 'fs';
-import os = require('os');
 import winreg = require('winreg');
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -297,13 +296,8 @@ export async function getCranUrl(path: string = '', cwd?: string): Promise<strin
     return url;
 }
 
-export function getRLibPaths(cwd: string): string {
-    return config().get<string[]>('libPaths')
-        .map(dir => dir
-            .replace('${workspaceFolder}', cwd)
-            .replace('${home}', os.homedir())
-        )
-        .join('\n');
+export function getRLibPaths(): string {
+    return config().get<string[]>('libPaths').join('\n');
 }
 
 // executes an R command returns its output to stdout


### PR DESCRIPTION
This is a modification of #1097. `r.libPaths` no longer does substibute `${workspaceFolder}` (seems not useful) and `${home}` (not useful) since it could directly support a user library path such as `~/R/vscode-R/renv/library/R-4.2/x86_64-apple-darwin17.0` and avoid the confusion between os home path and R home path in Windows.
