### PR TITLE
Add `Create .linr` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -426,7 +426,7 @@
         "command": "r.createGitignore"
       },
       {
-        "title": "Create .linr to the workspace",
+        "title": "Create .lintr to the workspace",
         "category": "R",
         "command": "r.createLintrConfig"
       },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "onCommand:r.goToPreviousChunk",
     "onCommand:r.goToNextChunk",
     "onCommand:r.createGitignore",
+    "onCommand:r.createLintrConfig",
     "onCommand:r.runCommandWithSelectionOrWord",
     "onCommand:r.runCommandWithEditorPath",
     "onCommand:r.runCommand",
@@ -423,6 +424,11 @@
         "title": "Create gitignore",
         "category": "R",
         "command": "r.createGitignore"
+      },
+      {
+        "title": "Create .linr to the workspace",
+        "category": "R",
+        "command": "r.createLintrConfig"
       },
       {
         "title": "Preview Dataframe",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import path = require('path');
 // functions etc. implemented in this extension
 import * as preview from './preview';
 import * as rGitignore from './rGitignore';
+import * as lintrConfig from './lintrConfig';
 import * as rTerminal from './rTerminal';
 import * as session from './session';
 import * as util from './util';
@@ -107,6 +108,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
         // editor independent commands
         'r.createGitignore': rGitignore.createGitignore,
+        'r.createLintrConfig': lintrConfig.createLintrConfig,
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758

--- a/src/lintrConfig.ts
+++ b/src/lintrConfig.ts
@@ -1,0 +1,27 @@
+'use strict';
+
+import { existsSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { window } from 'vscode';
+import { runTextInTerm } from './rTerminal';
+import { getCurrentWorkspaceFolder } from './util';
+
+export async function createLintrConfig(): Promise<void> {
+    const currentWorkspaceFolder = getCurrentWorkspaceFolder()?.uri.fsPath;
+    if (currentWorkspaceFolder === undefined) {
+        void window.showWarningMessage('Please open a workspace folder to create .lintr');
+        return;
+    }
+    const lintrFilePath = join(currentWorkspaceFolder, '.lintr');
+    if (existsSync(lintrFilePath)) {
+        const overwrite = await window.showWarningMessage(
+            '".lintr" file already exists. Do you want to overwrite?',
+            'Yes', 'No'
+        );
+        if (overwrite === 'No') {
+            return;
+        }
+        void unlinkSync(lintrFilePath);
+    }
+    void runTextInTerm('lintr::use_lintr()');
+}

--- a/src/lintrConfig.ts
+++ b/src/lintrConfig.ts
@@ -3,10 +3,9 @@
 import { existsSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { window } from 'vscode';
-import { runTextInTerm } from './rTerminal';
-import { getCurrentWorkspaceFolder } from './util';
+import { executeRCommand, getCurrentWorkspaceFolder } from './util';
 
-export async function createLintrConfig(): Promise<void> {
+export async function createLintrConfig(): Promise<string> {
     const currentWorkspaceFolder = getCurrentWorkspaceFolder()?.uri.fsPath;
     if (currentWorkspaceFolder === undefined) {
         void window.showWarningMessage('Please open a workspace folder to create .lintr');
@@ -23,5 +22,8 @@ export async function createLintrConfig(): Promise<void> {
         }
         void unlinkSync(lintrFilePath);
     }
-    void runTextInTerm('lintr::use_lintr()');
+    return await executeRCommand(`lintr::use_lintr()`, currentWorkspaceFolder, (e: Error) => {
+        void window.showErrorMessage(e.message);
+        return '';
+    });
 }


### PR DESCRIPTION
# What problem did you solve?

Close #712

Add a simple command that simply calls [the `lintr::use_lintr` function](https://lintr.r-lib.org/reference/use_lintr.html) that will be added in lintr 3.0.0.

## (If you have)Screenshot

## (If you do not have screenshot) How can I check this pull request?

Select "Create .linr to the workspace" from the command palette, with the development version of `lintr` package installed.