### PR TITLE
Hide preview env values to prevent accidental deletion

### DIFF
--- a/R/rmarkdown/knit.R
+++ b/R/rmarkdown/knit.R
@@ -29,5 +29,6 @@ cat(
     .vsc.knit_lim,
     eval(parse(text = .vsc.knit_command)),
     .vsc.knit_lim,
-    sep = ""
+    sep = "",
+    file = stdout()
 )

--- a/R/rmarkdown/preview.R
+++ b/R/rmarkdown/preview.R
@@ -4,44 +4,54 @@ if (!requireNamespace("rmarkdown", quietly = TRUE)) {
 }
 
 # get values from extension-set env values
-knit_dir <- Sys.getenv("VSCR_KNIT_DIR")
-lim <- Sys.getenv("VSCR_LIM")
-file_path <- Sys.getenv("VSCR_FILE_PATH")
-output_file_loc <- Sys.getenv("VSCR_OUTPUT_FILE")
-tmp_dir <- Sys.getenv("VSCR_TMP_DIR")
+# Hiding values is necessary to prevent their accidental removal
+# See: https://github.com/REditorSupport/vscode-R/issues/860
+attach(
+    local({
+        .vsc.knit_dir <- Sys.getenv("VSCR_KNIT_DIR")
+        .vsc.knit_lim <- Sys.getenv("VSCR_LIM")
+        .vsc.file_path <- Sys.getenv("VSCR_FILE_PATH")
+        .vsc.output_file_loc <- Sys.getenv("VSCR_OUTPUT_FILE")
+        .vsc.tmp_dir <- Sys.getenv("VSCR_TMP_DIR")
 
-# if an output format ends up as html, we should not overwrite
-# the format with rmarkdown::html_document()
-set_html <- tryCatch(
-    expr = {
-        lines <- suppressWarnings(readLines(file_path, encoding = "UTF-8"))
-        out <- rmarkdown:::output_format_from_yaml_front_matter(lines)
-        output_format <- rmarkdown:::create_output_format(out$name, out$options)
-        if (!output_format$pandoc$to == "html") {
-            rmarkdown::html_document()
-        } else {
-            NULL
-        }
-    }, error = function(e) {
-        rmarkdown::html_document()
-    }
+        # if an output format ends up as html, we should not overwrite
+        # the format with rmarkdown::html_document()
+        .vsc.set_html <- tryCatch(
+            expr = {
+                lines <- suppressWarnings(readLines(.vsc.file_path, encoding = "UTF-8"))
+                out <- rmarkdown:::output_format_from_yaml_front_matter(lines)
+                output_format <- rmarkdown:::create_output_format(out$name, out$options)
+                if (!output_format$pandoc$to == "html") {
+                    rmarkdown::html_document()
+                } else {
+                    NULL
+                }
+            }, error = function(e) {
+                rmarkdown::html_document()
+            }
+        )
+        environment()
+    }),
+    name = "tools:vscode",
+    warn.conflicts = FALSE
 )
 
 # set the knitr chunk eval directory
 # mainly affects source calls
-if (nzchar(knit_dir)) {
-    knitr::opts_knit[["set"]](root.dir = knit_dir)
+if (nzchar(.vsc.knit_dir)) {
+    knitr::opts_knit[["set"]](root.dir = .vsc.knit_dir)
 }
 
 # render and get file output location for use in extension
 cat(
-    lim,
+    .vsc.knit_lim,
     rmarkdown::render(
-        file_path,
-        output_format = set_html,
-        output_file = output_file_loc,
-        intermediates_dir = tmp_dir
+        .vsc.file_path,
+        output_format = .vsc.set_html,
+        output_file = .vsc.output_file_loc,
+        intermediates_dir = .vsc.tmp_dir
     ),
-    lim,
-    sep = ""
+    .vsc.knit_lim,
+    sep = "",
+    file = stdout()
 )


### PR DESCRIPTION
# What problem did you solve?

Follows #1060 to address the same problem (#860) with previewing rmd.

## (If you do not have screenshot) How can I check this pull request?

````
---
title: new document
author: test
---

This is a test document.

```{r}
rm(list = ls(all.names = TRUE))
x <- 1
y <- 2
```

Following is a test plot:

```{r}
plot(rnorm(100))
```
```