### PR TITLE
Add file creation to file/newFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -560,6 +560,18 @@
         "command": "r.rmarkdown.newDraft"
       },
       {
+        "title": "R Markdown (rmd)",
+        "category": "R Markdown",
+        "when": false,
+        "command": "r.rmarkdown.newFileDraft"
+      },
+      {
+        "title": "R Document (r)",
+        "category": "R",
+        "when": false,
+        "command": "r.newFileDocument"
+      },
+      {
         "command": "r.rmarkdown.setKnitDirectory",
         "title": "Set Knit directory",
         "icon": "$(zap)",
@@ -1236,6 +1248,16 @@
         },
         {
           "command": "r.knitRmdToAll"
+        }
+      ],
+      "file/newFile": [
+        {
+          "group": "R",
+          "command": "r.rmarkdown.newFileDraft"
+        },
+        {
+          "group": "R",
+          "command": "r.newFileDocument"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,6 +105,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.rmarkdown.preview.enableAutoRefresh': () => rmdPreviewManager.enableAutoRefresh(),
         'r.rmarkdown.preview.disableAutoRefresh': () => rmdPreviewManager.disableAutoRefresh(),
 
+        // file creation (under file submenu)
+        'r.rmarkdown.newFileDraft': () => rmarkdown.newDraft(),
+        'r.newFileDocument': () => vscode.workspace.openTextDocument({language: 'r'}).then((v) => vscode.window.showTextDocument(v)),
+
         // editor independent commands
         'r.createGitignore': rGitignore.createGitignore,
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -132,7 +132,7 @@ export async function newDraft(): Promise<void> {
             const parsedPath = path.parse(uri.fsPath);
             const dir = path.join(parsedPath.dir, parsedPath.name);
             if (fs.existsSync(dir)) {
-                if (await getConfirmation(`Folder already exists. Are you sure to replace the folder?`)) {
+                if (await getConfirmation(`Folder already exists. Are you sure you want to replace the folder?`)) {
                     fs.rmdirSync(dir, { recursive: true });
                 } else {
                     return;


### PR DESCRIPTION
# What problem did you solve?

VSCode-R currently doesn't have any menu items contributed to VSCode's native file dialog `Create: new file`. This adds RMD files and R files to the dialog box.

## (If you have)Screenshot

![image](https://user-images.githubusercontent.com/60372411/171584847-b68ea73f-335d-44ba-a133-a46e82fb492c.png)

## (If you do not have screenshot) How can I check this pull request?
Access the file dialog via `Create: new file dialog`