### PR TITLE
Update data viewer column resizing

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -507,8 +507,10 @@ export async function getTableHtml(webview: Webview, file: string): Promise<stri
             sortable: true,
             resizable: true,
             filter: true,
+            width: 100,
+            minWidth: 50,
             filterParams: {
-            buttons: ['reset', 'apply']
+                buttons: ['reset', 'apply']
             }
         },
         columnDefs: data.columns,
@@ -519,11 +521,11 @@ export async function getTableHtml(webview: Webview, file: string): Promise<stri
         enableCellTextSelection: true,
         ensureDomOrder: true,
         tooltipShowDelay: 100,
-        onGridReady: function (params) {
-            gridOptions.api.sizeColumnsToFit();
-            autoSizeAll(false);
-        }
+        onFirstDataRendered: onFirstDataRendered
     };
+    function onFirstDataRendered(params) {
+        gridOptions.columnApi.autoSizeAllColumns(false);
+    }
     function updateTheme() {
         const gridDiv = document.querySelector('#myGrid');
         if (document.body.classList.contains('vscode-light')) {
@@ -531,13 +533,6 @@ export async function getTableHtml(webview: Webview, file: string): Promise<stri
         } else {
             gridDiv.className = 'ag-theme-balham-dark';
         }
-    }
-    function autoSizeAll(skipHeader) {
-        var allColumnIds = [];
-        gridOptions.columnApi.getAllColumns().forEach(function (column) {
-            allColumnIds.push(column.colId);
-        });
-        gridOptions.columnApi.autoSizeColumns(allColumnIds, skipHeader);
     }
     document.addEventListener('DOMContentLoaded', () => {
         gridOptions.columnDefs.forEach(function(column) {


### PR DESCRIPTION
# What problem did you solve?

Closes #1120

`suppressColumnVirtualisation: true` does not look like a good idea mainly for performance reasons. Setting `minWidth` and `width` seems to be enough for most purposes.

## (If you do not have screenshot) How can I check this pull request?

```r
n <- 1000
df <- data.frame(id = 1:n)
for (i in 1:100) {
  df[[paste0("abcdef", i)]] <- rnorm(n)
}

View(df)
```