### PR TITLE
Click code in help views

### DIFF
--- a/R/session/rstudioapi_util.R
+++ b/R/session/rstudioapi_util.R
@@ -180,8 +180,7 @@ normalise_pos_or_range_arg <- function(location) {
 normalise_text_arg <- function(text, location_length) {
     if (length(text) == location_length) {
         text
-    }
-    else if (length(text) == 1 && location_length > 1) {
+    } else if (length(text) == 1 && location_length > 1) {
         rep(text, location_length)
     } else {
         stop(

--- a/html/help/script.js
+++ b/html/help/script.js
@@ -73,16 +73,18 @@ window.document.body.onload = () => {
         }
     }
     // notify vscode when code is clicked:
-    const codeElements = document.getElementsByTagName('pre');
-    console.log(codeElements);
-    for (let i = 0; i < codeElements.length; i++) {
-        const el = codeElements[i];
-        el.onclick = () => {
-            const code = el.textContent;
-            vscode.postMessage({
-                message: 'codeClicked',
-                code: code || ''
-            });
-        };
+    if (document.body.classList.contains('preClickable')) {
+        const codeElements = document.getElementsByTagName('pre');
+        console.log(codeElements);
+        for (let i = 0; i < codeElements.length; i++) {
+            const el = codeElements[i];
+            el.onclick = () => {
+                const code = el.textContent;
+                vscode.postMessage({
+                    message: 'codeClicked',
+                    code: code || ''
+                });
+            };
+        }
     }
 };

--- a/html/help/script.js
+++ b/html/help/script.js
@@ -78,11 +78,16 @@ window.document.body.onload = () => {
         console.log(codeElements);
         for (let i = 0; i < codeElements.length; i++) {
             const el = codeElements[i];
-            el.onclick = () => {
-                const code = el.textContent;
+            el.onclick = (me) => {
                 vscode.postMessage({
                     message: 'codeClicked',
-                    code: code || ''
+                    code: el.textContent || '',
+                    modifiers: {
+                        altKey: me.altKey,
+                        ctrlKey: me.ctrlKey,
+                        shiftKey: me.shiftKey,
+                        metaKey: me.metaKey,
+                    }
                 });
             };
         }

--- a/html/help/script.js
+++ b/html/help/script.js
@@ -72,4 +72,17 @@ window.document.body.onload = () => {
             };
         }
     }
+    // notify vscode when code is clicked:
+    const codeElements = document.getElementsByTagName('pre');
+    console.log(codeElements);
+    for (let i = 0; i < codeElements.length; i++) {
+        const el = codeElements[i];
+        el.onclick = () => {
+            const code = el.textContent;
+            vscode.postMessage({
+                message: 'codeClicked',
+                code: code || ''
+            });
+        };
+    }
 };

--- a/html/help/script.ts
+++ b/html/help/script.ts
@@ -85,5 +85,19 @@ window.document.body.onload = () => {
             };
         }
     }
+    
+    // notify vscode when code is clicked:
+    const codeElements = document.getElementsByTagName('pre');
+    console.log(codeElements);
+    for(let i=0; i<codeElements.length; i++){
+        const el = codeElements[i];
+        el.onclick = () => {
+            const code = el.textContent;
+            vscode.postMessage({
+                message: 'codeClicked',
+                code: code || ''
+            });
+        };
+    }
 };
 

--- a/html/help/script.ts
+++ b/html/help/script.ts
@@ -87,17 +87,19 @@ window.document.body.onload = () => {
     }
     
     // notify vscode when code is clicked:
-    const codeElements = document.getElementsByTagName('pre');
-    console.log(codeElements);
-    for(let i=0; i<codeElements.length; i++){
-        const el = codeElements[i];
-        el.onclick = () => {
-            const code = el.textContent;
-            vscode.postMessage({
-                message: 'codeClicked',
-                code: code || ''
-            });
-        };
+    if(document.body.classList.contains('preClickable')){
+        const codeElements = document.getElementsByTagName('pre');
+        console.log(codeElements);
+        for(let i=0; i<codeElements.length; i++){
+            const el = codeElements[i];
+            el.onclick = () => {
+                const code = el.textContent;
+                vscode.postMessage({
+                    message: 'codeClicked',
+                    code: code || ''
+                });
+            };
+        }
     }
 };
 

--- a/html/help/script.ts
+++ b/html/help/script.ts
@@ -92,11 +92,16 @@ window.document.body.onload = () => {
         console.log(codeElements);
         for(let i=0; i<codeElements.length; i++){
             const el = codeElements[i];
-            el.onclick = () => {
-                const code = el.textContent;
+            el.onclick = (me: MouseEvent) => {
                 vscode.postMessage({
                     message: 'codeClicked',
-                    code: code || ''
+                    code: el.textContent || '',
+                    modifiers: {
+                        altKey: me.altKey,
+                        ctrlKey: me.ctrlKey,
+                        shiftKey: me.shiftKey,
+                        metaKey: me.metaKey,
+                    }
                 });
             };
         }

--- a/html/help/theme.css
+++ b/html/help/theme.css
@@ -34,12 +34,12 @@ a ~ div.header {
 }
 
 .vscode-light {
-    --rhelp-number: #cb4b16;
-    --rhelp-string: #647400;
-    --rhelp-symbol: #cb4b16;
-    --rhelp-keyword: #2074b1;
-    --rhelp-comment: #727e7e;
-    --rhelp-function: #2074b1;
+  --rhelp-number: #cb4b16;
+  --rhelp-string: #647400;
+  --rhelp-symbol: #cb4b16;
+  --rhelp-keyword: #2074b1;
+  --rhelp-comment: #727e7e;
+  --rhelp-function: #2074b1;
 }
 
 .vscode-dark, 
@@ -50,6 +50,12 @@ a ~ div.header {
     --rhelp-keyword: #569cd6;
     --rhelp-comment: #6A9955;
     --rhelp-function: #DCDCAA;
+}
+
+pre:hover,
+pre:hover span {
+  color: red;
+  cursor: pointer;
 }
 
 .hljs-number {

--- a/html/help/theme.css
+++ b/html/help/theme.css
@@ -52,10 +52,9 @@ a ~ div.header {
     --rhelp-function: #DCDCAA;
 }
 
-pre:hover,
-pre:hover span {
-  color: red;
+pre:hover {
   cursor: pointer;
+  background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 .hljs-number {

--- a/html/help/theme.css
+++ b/html/help/theme.css
@@ -1,15 +1,7 @@
+
+/* General styling */
 body {
   font-size: var(--vscode-editor-font-size);
-}
-
-pre, code {
-  font-family: var(--vscode-editor-font-family);
-  font-size: var(--vscode-editor-font-size);
-}
-
-.preClickable pre:hover {
-  cursor: pointer;
-  background-color: var(--vscode-list-hoverBackground);
 }
 
 body table:nth-child(1)[width="100%"] td:nth-child(2){
@@ -19,7 +11,6 @@ body table:nth-child(1)[width="100%"] td:nth-child(2){
 body table:nth-child(1)[width="100%"] td:nth-child(1){
   text-align: right;
 }
-
 
 h1, h2 {
   text-align: center;
@@ -34,6 +25,26 @@ a ~ div.header {
   display: none;
 }
 
+/* Styling for clickable code sections */
+pre, code {
+  font-family: var(--vscode-editor-font-family);
+  font-size: var(--vscode-editor-font-size);
+}
+
+.preClickable pre {
+  margin: 0px;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+}
+
+.preClickable .preDiv:hover {
+  cursor: pointer;
+}
+.preClickable pre:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+/* Syntax highlighting in code sections */
 .hljs-link {
   color: var(--vscode-textLink-foreground)
 }

--- a/html/help/theme.css
+++ b/html/help/theme.css
@@ -7,6 +7,11 @@ pre, code {
   font-size: var(--vscode-editor-font-size);
 }
 
+.preClickable pre:hover {
+  cursor: pointer;
+  background-color: var(--vscode-list-hoverBackground);
+}
+
 body table:nth-child(1)[width="100%"] td:nth-child(2){
   display: none;
 }
@@ -44,46 +49,41 @@ a ~ div.header {
 
 .vscode-dark, 
 .vscode-high-contrast {
-    --rhelp-number: #b5cea8;
-    --rhelp-string: #CE9178;
-    --rhelp-symbol: #4EC9B0;
-    --rhelp-keyword: #569cd6;
-    --rhelp-comment: #6A9955;
-    --rhelp-function: #DCDCAA;
-}
-
-pre:hover {
-  cursor: pointer;
-  background-color: var(--vscode-list-hoverBackground);
+  --rhelp-number: #b5cea8;
+  --rhelp-string: #CE9178;
+  --rhelp-symbol: #4EC9B0;
+  --rhelp-keyword: #569cd6;
+  --rhelp-comment: #6A9955;
+  --rhelp-function: #DCDCAA;
 }
 
 .hljs-number {
-    color: var(--rhelp-number)
+  color: var(--rhelp-number)
 }
 
 .hljs-regexp,
 .hljs-bullet,
 .hljs-string {
-    color: var(--rhelp-string)
+  color: var(--rhelp-string)
 }
 
 .hljs-symbol,
 .hljs-class {
-    color: var(--rhelp-symbol)
+  color: var(--rhelp-symbol)
 }
 
 .hljs-literal,
 .hljs-keyword {
-    color: var(--rhelp-keyword)
+  color: var(--rhelp-keyword)
 }
 
 .hljs-built_in,
 .hljs-function {
-    color: var(--rhelp-function)
+  color: var(--rhelp-function)
 }
 
 .hljs-quote,
 .hljs-comment {
-    color: var(--rhelp-comment)
+  color: var(--rhelp-comment)
 }
 

--- a/html/help/theme.css
+++ b/html/help/theme.css
@@ -37,7 +37,7 @@ pre, code {
   padding-bottom: 0.5em;
 }
 
-.preClickable .preDiv:hover {
+.preHoverPointer .preDiv:hover {
   cursor: pointer;
 }
 .preClickable pre:hover {

--- a/html/help/theme.css
+++ b/html/help/theme.css
@@ -54,7 +54,7 @@ a ~ div.header {
 
 pre:hover {
   cursor: pointer;
-  background-color: var(--vscode-toolbar-hoverBackground);
+  background-color: var(--vscode-list-hoverBackground);
 }
 
 .hljs-number {

--- a/html/help/webviewMessages.d.ts
+++ b/html/help/webviewMessages.d.ts
@@ -25,7 +25,13 @@ interface LinkClickedMessage extends IOutMessage {
 }
 interface CodeClickedMessage extends IOutMessage {
   message: 'codeClicked',
-  code: string
+  code: string,
+  modifiers: {
+    altKey: boolean,
+    ctrlKey: boolean,
+    shiftKey: boolean,
+    metaKey: boolean,
+  }
 }
 
 type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage | CodeClickedMessage;

--- a/html/help/webviewMessages.d.ts
+++ b/html/help/webviewMessages.d.ts
@@ -23,6 +23,10 @@ interface LinkClickedMessage extends IOutMessage {
   href: string,
   scrollY: number
 }
+interface CodeClickedMessage extends IOutMessage {
+  message: 'codeClicked',
+  code: string
+}
 
-type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage;
+type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage | CodeClickedMessage;
 

--- a/package.json
+++ b/package.json
@@ -1464,6 +1464,16 @@
           "default": true,
           "markdownDescription": "Show links to matching help pages in hover"
         },
+        "r.helpPanel.clickCodeExamples": {
+          "type": "string",
+          "default": "Copy",
+          "markdownDescription": "What happens when clicking code examples on help pages.",
+          "enum": [
+            "Disabled",
+            "Copy",
+            "Run"
+          ]
+        },
         "r.source.encoding": {
           "type": "string",
           "default": "UTF-8",

--- a/package.json
+++ b/package.json
@@ -1825,6 +1825,7 @@
     "vscode:prepublish": "tsc -p . && tsc -p ./html/help && tsc -p ./html/httpgd",
     "compile": "tsc -p . && tsc -p ./html/help && tsc -p ./html/httpgd",
     "watch": "tsc -p . --watch",
+    "watchHelp": "tsc -p ./html/help --watch",
     "pretest": "tsc -p ./",
     "test": "node ./out/test/runTest.js",
     "lint": "eslint src --ext ts"

--- a/package.json
+++ b/package.json
@@ -1472,6 +1472,11 @@
             "Disabled",
             "Copy",
             "Run"
+          ],
+          "markdownEnumDescriptions": [
+            "Do not make code examples clickable.",
+            "Copy the code to the clipboard.",
+            "Run the code in the terminal."
           ]
         },
         "r.source.encoding": {

--- a/package.json
+++ b/package.json
@@ -1465,19 +1465,58 @@
           "markdownDescription": "Show links to matching help pages in hover"
         },
         "r.helpPanel.clickCodeExamples": {
-          "type": "string",
-          "default": "Copy",
-          "markdownDescription": "What happens when clicking code examples on help pages.",
-          "enum": [
-            "Disabled",
-            "Copy",
-            "Run"
-          ],
-          "markdownEnumDescriptions": [
-            "Do not make code examples clickable.",
-            "Copy the code to the clipboard.",
-            "Run the code in the terminal."
-          ]
+          "type": "object",
+          "markdownDescription": "What happens when clicking code examples on help pages. Might require restarting to take effect.",
+          "default": {
+            "Click": "Copy",
+            "Ctrl+Click": "Run",
+            "Shift+Click": "Ignore"
+          },
+          "properties": {
+            "Click": {
+              "type": "string",
+              "default": "Copy",
+              "enum": [
+                "Ignore",
+                "Copy",
+                "Run"
+              ],
+              "enumDescriptions": [
+                "Do nothing",
+                "Copy the code to the clipboard",
+                "Run the code in the terminal"
+              ]
+            },
+            "Ctrl+Click": {
+              "type": "string",
+              "default": "Run",
+              "enum": [
+                "Ignore",
+                "Copy",
+                "Run"
+              ],
+              "enumDescriptions": [
+                "Do nothing",
+                "Copy the code to the clipboard",
+                "Run the code in the terminal"
+              ]
+            },
+            "Shift+Click": {
+              "type": "string",
+              "default": "Ignore",
+              "enum": [
+                "Ignore",
+                "Copy",
+                "Run"
+              ],
+              "enumDescriptions": [
+                "Do nothing",
+                "Copy the code to the clipboard",
+                "Run the code in the terminal"
+              ]
+            }
+          },
+          "additionalProperties": false
         },
         "r.source.encoding": {
           "type": "string",

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -568,6 +568,7 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
     
     // Split code examples at empty lines:
     if(config().get<CodeClickAction>('helpPanel.clickCodeExamples') !== 'Disabled'){
+        $('body').addClass('preClickable');
         const codeSections = $('pre');
         codeSections.each((i, section) => {
             const innerHtml = $(section).html();

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -20,6 +20,8 @@ import {HelpTreeWrapper} from './treeView';
 import {PackageManager} from './packages';
 import {isGuestSession, rGuestService} from '../liveShare';
 
+export type CodeClickAction = 'Disabled' | 'Copy' | 'Run';
+
 // Initialization function that is called once when activating the extension
 export async function initializeHelp(
     context: vscode.ExtensionContext,
@@ -565,13 +567,15 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
     $('head style').remove();
     
     // Split code examples at empty lines:
-    const codeSections = $('pre');
-    codeSections.each((i, section) => {
-        const innerHtml = $(section).html();
-        const newPres = innerHtml.split('\n\n').map(s => `<pre>${s}</pre>`);
-        $(section).replaceWith(newPres.join('\n'));
-    });
-    
+    if(config().get<CodeClickAction>('helpPanel.clickCodeExamples') !== 'Disabled'){
+        const codeSections = $('pre');
+        codeSections.each((i, section) => {
+            const innerHtml = $(section).html();
+            const newPres = innerHtml.split('\n\n').map(s => `<pre>${s}</pre>`);
+            $(section).replaceWith(newPres.join('\n'));
+        });
+    }
+
     // Apply syntax highlighting:
     if (config().get<boolean>('helpPanel.enableSyntaxHighlighting')) {
         // find all code sections, enclosed by <pre>...</pre>

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -573,7 +573,8 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
         codeSections.each((i, section) => {
             const innerHtml = $(section).html();
             const newPres = innerHtml.split('\n\n').map(s => `<pre>${s}</pre>`);
-            $(section).replaceWith(newPres.join('\n'));
+            const newHtml = '<div class="preDiv">' + newPres.join('\n') + '</div>';
+            $(section).replaceWith(newHtml);
         });
     }
 

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -563,7 +563,15 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
 
     // Remove style elements specified in the html itself (replaced with custom CSS)
     $('head style').remove();
-
+    
+    // Split code examples at empty lines:
+    const codeSections = $('pre');
+    codeSections.each((i, section) => {
+        const innerHtml = $(section).html();
+        const newPres = innerHtml.split('\n\n').map(s => `<pre>${s}</pre>`);
+        $(section).replaceWith(newPres.join('\n'));
+    });
+    
     // Apply syntax highlighting:
     if (config().get<boolean>('helpPanel.enableSyntaxHighlighting')) {
         // find all code sections, enclosed by <pre>...</pre>

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -20,7 +20,13 @@ import {HelpTreeWrapper} from './treeView';
 import {PackageManager} from './packages';
 import {isGuestSession, rGuestService} from '../liveShare';
 
-export type CodeClickAction = 'Disabled' | 'Copy' | 'Run';
+export type CodeClickAction = 'Ignore' | 'Copy' | 'Run';
+export interface CodeClickConfig {
+    'Click': CodeClickAction,
+    'Ctrl+Click': CodeClickAction,
+    'Shift+Click': CodeClickAction,
+}
+const CODE_CLICKS: (keyof CodeClickConfig)[] = ['Click', 'Ctrl+Click', 'Shift+Click'];
 
 // Initialization function that is called once when activating the extension
 export async function initializeHelp(
@@ -567,7 +573,9 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
     $('head style').remove();
     
     // Split code examples at empty lines:
-    if(config().get<CodeClickAction>('helpPanel.clickCodeExamples') !== 'Disabled'){
+    const codeClickConfig = config().get<CodeClickConfig>('helpPanel.clickCodeExamples');
+    const isEnabled = CODE_CLICKS.some(k => codeClickConfig[k] !== 'Ignore');
+    if(isEnabled){
         $('body').addClass('preClickable');
         const codeSections = $('pre');
         codeSections.each((i, section) => {
@@ -576,6 +584,9 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
             const newHtml = '<div class="preDiv">' + newPres.join('\n') + '</div>';
             $(section).replaceWith(newHtml);
         });
+    }
+    if(codeClickConfig.Click !== 'Ignore'){
+        $('body').addClass('preHoverPointer');
     }
 
     // Apply syntax highlighting:

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -3,8 +3,9 @@
 import * as vscode from 'vscode';
 import * as cheerio from 'cheerio';
 
-import { HelpFile, RHelp } from '.';
+import { CodeClickAction, HelpFile, RHelp } from '.';
 import { setContext, UriIcon, config } from '../util';
+import { runTextInTerm } from '../rTerminal';
 
 //// Declaration of interfaces used/implemented by the Help Panel class
 // specified when creating a new help panel
@@ -267,9 +268,14 @@ export class HelpPanel {
 		} else if(msg.message === 'codeClicked') {
 			const code = String(msg.code || '');
 			console.log(`Code clicked: ${code}`);
-			if(code){
+			const codeClickAction = config().get<CodeClickAction>('helpPanel.clickCodeExamples');
+			if(codeClickAction === 'Disabled' || !code){
+				// pass
+			} else if(codeClickAction === 'Copy'){
 				void vscode.env.clipboard.writeText(code);
 				void vscode.window.showInformationMessage(`Copied to clipboard: ${code}`);
+			} else if(codeClickAction === 'Run'){
+				void runTextInTerm(code);
 			}
 		} else{
 			console.log('Unknown message:', msg);

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -273,7 +273,7 @@ export class HelpPanel {
 				// pass
 			} else if(codeClickAction === 'Copy'){
 				void vscode.env.clipboard.writeText(code);
-				void vscode.window.showInformationMessage(`Copied to clipboard: ${code}`);
+				void vscode.window.showInformationMessage(`Copied to clipboard: \`${code}\`.`);
 			} else if(codeClickAction === 'Run'){
 				void runTextInTerm(code);
 			}

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -264,6 +264,13 @@ export class HelpPanel {
 		} else if(msg.message === 'text'){
 			// used for logging/debugging
 			console.log(`Message (text): ${String(msg.text)}`);
+		} else if(msg.message === 'codeClicked') {
+			const code = String(msg.code || '');
+			console.log(`Code clicked: ${code}`);
+			if(code){
+				void vscode.env.clipboard.writeText(code);
+				void vscode.window.showInformationMessage(`Copied to clipboard: ${code}`);
+			}
 		} else{
 			console.log('Unknown message:', msg);
 		}

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -3,9 +3,10 @@
 import * as vscode from 'vscode';
 import * as cheerio from 'cheerio';
 
-import { CodeClickAction, HelpFile, RHelp } from '.';
+import { CodeClickConfig, HelpFile, RHelp } from '.';
 import { setContext, UriIcon, config } from '../util';
 import { runTextInTerm } from '../rTerminal';
+import { OutMessage } from './webviewMessages';
 
 //// Declaration of interfaces used/implemented by the Help Panel class
 // specified when creating a new help panel
@@ -103,7 +104,7 @@ export class HelpPanel {
 		});
 
 		// sent by javascript added to the help pages, e.g. when a link or mouse button is clicked
-		this.panel.webview.onDidReceiveMessage((e: {[key: string]: any}) => {
+		this.panel.webview.onDidReceiveMessage((e: OutMessage) => {
 			void this.handleMessage(e);
 		});
 
@@ -210,11 +211,11 @@ export class HelpPanel {
 	}
 
 	// handle message produced by javascript inside the help page
-	private async handleMessage(msg: {[key: string]: any}){
-		if('message' in msg && msg.message === 'linkClicked'){
+	private async handleMessage(msg: OutMessage){
+		if(msg.message === 'linkClicked'){
 			// handle hyperlinks clicked in the webview
 			// normal navigation does not work in webviews (even on localhost)
-			const href: string = <string>msg.href || '';
+			const href: string = msg.href || '';
 			const currentScrollY: number = Number(msg.scrollY) || 0;
 			console.log('Link clicked: ' + href);
 
@@ -262,20 +263,35 @@ export class HelpPanel {
 			} else if(button === 4){
 				this._goForward(currentScrollY);
 			}
-		} else if(msg.message === 'text'){
-			// used for logging/debugging
-			console.log(`Message (text): ${String(msg.text)}`);
 		} else if(msg.message === 'codeClicked') {
-			const code = String(msg.code || '');
-			console.log(`Code clicked: ${code}`);
-			const codeClickAction = config().get<CodeClickAction>('helpPanel.clickCodeExamples');
-			if(codeClickAction === 'Disabled' || !code){
-				// pass
-			} else if(codeClickAction === 'Copy'){
-				void vscode.env.clipboard.writeText(code);
-				void vscode.window.showInformationMessage(`Copied to clipboard: \`${code}\`.`);
-			} else if(codeClickAction === 'Run'){
-				void runTextInTerm(code);
+			if(!msg.code){
+				return;
+			}
+			// Process modifiers:
+			const isCtrlClick = msg.modifiers.ctrlKey || msg.modifiers.metaKey;
+			const isShiftClick = msg.modifiers.shiftKey;
+			const isNormalClick = !isCtrlClick && !isShiftClick;
+			
+			// Check wheter to copy or run the code (or both or none)
+			const codeClickConfig = config().get<CodeClickConfig>('helpPanel.clickCodeExamples');
+			const runCode = (
+				isCtrlClick && codeClickConfig['Ctrl+Click'] === 'Run'
+				|| isShiftClick && codeClickConfig['Shift+Click'] === 'Run'
+				|| isNormalClick && codeClickConfig['Click'] === 'Run'
+			);
+			const copyCode = (
+				isCtrlClick && codeClickConfig['Ctrl+Click'] === 'Copy'
+				|| isShiftClick && codeClickConfig['Shift+Click'] === 'Copy'
+				|| isNormalClick && codeClickConfig['Click'] === 'Copy'
+			);
+			
+			// Execute action:
+			if(copyCode){
+				void vscode.env.clipboard.writeText(msg.code);
+				void vscode.window.showInformationMessage('Copied code example to clipboard.');
+			}
+			if(runCode){
+				void runTextInTerm(msg.code);
 			}
 		} else{
 			console.log('Unknown message:', msg);

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -290,12 +290,12 @@ export class HelpPanel {
 		$('body').attr('relpath', relPath);
 		$('body').attr('scrollyto', `${helpFile.scrollY ?? -1}`);
 
-        if(styleUri){
-            $('body').append(`\n<link rel="stylesheet" href="${styleUri.toString()}"></link>`);
-        }
-        if(scriptUri){
-            $('body').append(`\n<script src=${scriptUri.toString()}></script>`);
-        }
+		if(styleUri){
+			$('body').append(`\n<link rel="stylesheet" href="${styleUri.toString()}"></link>`);
+		}
+		if(scriptUri){
+			$('body').append(`\n<script src=${scriptUri.toString()}></script>`);
+		}
 
 
 		// convert to string

--- a/src/helpViewer/webviewMessages.d.ts
+++ b/src/helpViewer/webviewMessages.d.ts
@@ -31,7 +31,13 @@ export interface LinkClickedMessage extends IMessage {
 }
 export interface CodeClickedMessage extends IMessage {
   message: 'codeClicked',
-  code: string
+  code: string,
+  modifiers: {
+    altKey: boolean,
+    ctrlKey: boolean,
+    shiftKey: boolean,
+    metaKey: boolean,
+  }
 }
 
 export type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage | CodeClickedMessage;

--- a/src/helpViewer/webviewMessages.d.ts
+++ b/src/helpViewer/webviewMessages.d.ts
@@ -29,7 +29,11 @@ export interface LinkClickedMessage extends IMessage {
   href: string,
   scrollY: number
 }
+export interface CodeClickedMessage extends IMessage {
+  message: 'codeClicked',
+  code: string
+}
 
-export type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage;
+export type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage | CodeClickedMessage;
 
 


### PR DESCRIPTION
Closes #459 #1137

Code sections in the help viewer are highlighted on hover, and can be clicked to be copied to the clipboard, or run in the terminal.

The behavior can be modified with the setting `"r.helpPanel.clickCodeExamples"`. Changes to this setting might require reloading the window to take effect.