### PR TITLE
Adapt to lintr 3.0

### DIFF
--- a/R/.lintr
+++ b/R/.lintr
@@ -1,4 +1,4 @@
-linters: with_defaults(
+linters: linters_with_defaults(
   line_length_linter(120),
   cyclocomp_linter = NULL,
   object_name_linter = NULL,

--- a/R/session/rstudioapi_util.R
+++ b/R/session/rstudioapi_util.R
@@ -180,8 +180,7 @@ normalise_pos_or_range_arg <- function(location) {
 normalise_text_arg <- function(text, location_length) {
     if (length(text) == location_length) {
         text
-    }
-    else if (length(text) == 1 && location_length > 1) {
+    } else if (length(text) == 1 && location_length > 1) {
         rep(text, location_length)
     } else {
         stop(


### PR DESCRIPTION
* Use `linters_with_defaults()` instead of `with_defaults()`.
* Fix a linter complaint.