### PR TITLE
Whitespace in typescript files

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -34,3 +34,4 @@ rules:
   indent:
     - 'error'
     - 4
+    - SwitchCase: 1

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -31,3 +31,6 @@ rules:
     - 'warn'
     - ignoreParameters: true
       ignoreProperties: true
+  indent:
+    - 'error'
+    - 4

--- a/html/help/script.ts
+++ b/html/help/script.ts
@@ -6,7 +6,7 @@
 
 declare function acquireVsCodeApi(): VsCode;
 
-const vscode = acquireVsCodeApi(); 
+const vscode = acquireVsCodeApi();
 
 // notify vscode when mouse buttons are clicked
 // used to implement back/forward on mouse buttons 3/4
@@ -61,7 +61,7 @@ window.document.body.onload = () => {
     }
 
     // notify vscode when links are clicked:
-    const hyperLinks = document.getElementsByTagName('a'); 
+    const hyperLinks = document.getElementsByTagName('a');
 
     for(let i=0; i<hyperLinks.length; i++){
         const hrefAbs = hyperLinks[i].href;
@@ -72,7 +72,7 @@ window.document.body.onload = () => {
                 document.location.hash = hrefRel;
             };
         } else if(hrefAbs && hrefAbs.startsWith('vscode-webview://')){
-            hyperLinks[i].onclick = () => { 
+            hyperLinks[i].onclick = () => {
 
                 const url2 = new URL(hrefRel, url1);
                 const finalHref = url2.toString();
@@ -81,11 +81,11 @@ window.document.body.onload = () => {
                     message: 'linkClicked',
                     href: finalHref,
                     scrollY: window.scrollY
-                }); 
+                });
             };
         }
     }
-    
+
     // notify vscode when code is clicked:
     if(document.body.classList.contains('preClickable')){
         const codeElements = document.getElementsByTagName('pre');

--- a/html/help/webviewMessages.d.ts
+++ b/html/help/webviewMessages.d.ts
@@ -1,37 +1,37 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 interface VsCode {
-  postMessage: (msg: OutMessage) => void;
-  setState: (state: string) => void;
+    postMessage: (msg: OutMessage) => void;
+    setState: (state: string) => void;
 }
 
 
 interface IOutMessage {
-  message: string;
+    message: string;
 }
 interface LogMessage extends IOutMessage {
-  message: 'log',
-  body: any
+    message: 'log',
+    body: any
 }
 interface MouseClickMessage extends IOutMessage {
-  message: 'mouseClick',
-  button: number,
-  scrollY: number
+    message: 'mouseClick',
+    button: number,
+    scrollY: number
 }
 interface LinkClickedMessage extends IOutMessage {
-  message: 'linkClicked',
-  href: string,
-  scrollY: number
+    message: 'linkClicked',
+    href: string,
+    scrollY: number
 }
 interface CodeClickedMessage extends IOutMessage {
-  message: 'codeClicked',
-  code: string,
-  modifiers: {
-    altKey: boolean,
-    ctrlKey: boolean,
-    shiftKey: boolean,
-    metaKey: boolean,
-  }
+    message: 'codeClicked',
+    code: string,
+    modifiers: {
+        altKey: boolean,
+        ctrlKey: boolean,
+        shiftKey: boolean,
+        metaKey: boolean,
+    }
 }
 
 type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage | CodeClickedMessage;

--- a/html/httpgd/index.ts
+++ b/html/httpgd/index.ts
@@ -11,7 +11,7 @@ interface Plot {
 
     // svg of the plot
     svg: string;
-    
+
     height?: number;
     width?: number;
 }
@@ -104,7 +104,7 @@ function addPlot(html: string){
 }
 
 function focusPlot(plotId: string): void {
-    
+
     const smallPlots = getSmallPlots();
 
     const ind = findIndex(plotId, smallPlots);
@@ -115,25 +115,25 @@ function focusPlot(plotId: string): void {
     for(const elm of smallPlots){
         elm.classList.remove('active');
     }
-    
+
     const smallPlot = smallPlots[ind];
 
     smallPlot.classList.add('active');
-    
+
     largePlotDiv.innerHTML = smallPlot.innerHTML;
 }
 
 function updatePlot(plt: Plot): void {
-    
+
     const smallPlots = getSmallPlots();
 
     const ind = findIndex(plt.id, smallPlots);
     if(ind<0){
         return;
     }
-    
+
     smallPlots[ind].innerHTML = plt.svg;
-    
+
     if(smallPlots[ind].classList.contains('active')){
         largePlotDiv.innerHTML = plt.svg;
     }
@@ -146,11 +146,11 @@ function hidePlot(plotId: string): void {
     if(ind<0){
         return;
     }
-    
+
     if(smallPlots[ind].classList.contains('active')){
         largePlotDiv.innerHTML = '';
     }
-    
+
     smallPlots[ind].parentElement?.remove();
 }
 
@@ -212,7 +212,7 @@ document.addEventListener('mousemove', (e) => {
     if (isFullWindow || !isHandlerDragging) {
         return false;
     }
-    
+
     // postLogMessage('mousemove');
 
     // Get offset
@@ -220,7 +220,7 @@ document.addEventListener('mousemove', (e) => {
 
     // Get x-coordinate of pointer relative to container
     const pointerRelativeYpos = e.clientY - containerOffsetTop + window.scrollY;
-    
+
     // Arbitrary minimum width set on box A, otherwise its inner content will collapse to width of 0
     const largePlotMinHeight = 60;
 

--- a/html/httpgd/index.ts
+++ b/html/httpgd/index.ts
@@ -6,14 +6,14 @@
 
 
 interface Plot {
-  // unique ID for this plot (w.r.t. this connection/device)
-  id: string;
+    // unique ID for this plot (w.r.t. this connection/device)
+    id: string;
 
-  // svg of the plot
-  svg: string;
-  
-  height?: number;
-  width?: number;
+    // svg of the plot
+    svg: string;
+    
+    height?: number;
+    width?: number;
 }
 
 // get vscode api
@@ -34,11 +34,11 @@ const placeholderDiv = document.querySelector('#placeholder') as HTMLDivElement;
 
 
 function getSmallPlots(): HTMLAnchorElement[] {
-  const smallPlots: HTMLAnchorElement[] = [];
-  document.querySelectorAll('a.focusPlot').forEach(elm => {
-    smallPlots.push(elm as HTMLAnchorElement);
-  });
-  return smallPlots;
+    const smallPlots: HTMLAnchorElement[] = [];
+    document.querySelectorAll('a.focusPlot').forEach(elm => {
+        smallPlots.push(elm as HTMLAnchorElement);
+    });
+    return smallPlots;
 }
 
 let isHandlerDragging = false;
@@ -47,140 +47,140 @@ let isHandlerDragging = false;
 let isFullWindow = false;
 
 function postResizeMessage(userTriggered: boolean = false){
-  let newHeight = largePlotDiv.clientHeight;
-  let newWidth = largePlotDiv.clientWidth;
-  if(isFullWindow){
-    newHeight = window.innerHeight;
-    newWidth = window.innerWidth;
-  }
-  if(userTriggered || newHeight !== oldHeight || newWidth !== oldWidth){
-    const msg: ResizeMessage = {
-      message: 'resize',
-      height: newHeight,
-      width: newWidth,
-      userTriggered: userTriggered
-    };
-    vscode.postMessage(msg);
-    oldHeight = newHeight;
-    oldWidth = newWidth;
-  }
+    let newHeight = largePlotDiv.clientHeight;
+    let newWidth = largePlotDiv.clientWidth;
+    if(isFullWindow){
+        newHeight = window.innerHeight;
+        newWidth = window.innerWidth;
+    }
+    if(userTriggered || newHeight !== oldHeight || newWidth !== oldWidth){
+        const msg: ResizeMessage = {
+            message: 'resize',
+            height: newHeight,
+            width: newWidth,
+            userTriggered: userTriggered
+        };
+        vscode.postMessage(msg);
+        oldHeight = newHeight;
+        oldWidth = newWidth;
+    }
 }
 
 function postLogMessage(content: any){
-  console.log(content);
-  vscode.postMessage({
-    message: 'log',
-    body: content
-  });
+    console.log(content);
+    vscode.postMessage({
+        message: 'log',
+        body: content
+    });
 }
 
 window.addEventListener('message', (ev: MessageEvent<InMessage>) => {
-  const msg = ev.data;
-  if(msg.message === 'updatePlot'){
-    updatePlot({
-      id: String(msg.plotId),
-      svg: msg.svg
-    });
-  } else if(msg.message === 'focusPlot'){
-    focusPlot(String(msg.plotId));
-  } else if(msg.message === 'toggleStyle'){
-    toggleStyle(msg.useOverwrites);
-  } else if(msg.message === 'hidePlot'){
-    hidePlot(msg.plotId);
-  } else if(msg.message === 'addPlot'){
-    addPlot(msg.html);
-  } else if(msg.message === 'togglePreviewPlotLayout'){
-    togglePreviewPlotLayout(msg.style);
-  } else if(msg.message === 'toggleFullWindow'){
-    toggleFullWindowMode(msg.useFullWindow);
-  }
+    const msg = ev.data;
+    if(msg.message === 'updatePlot'){
+        updatePlot({
+            id: String(msg.plotId),
+            svg: msg.svg
+        });
+    } else if(msg.message === 'focusPlot'){
+        focusPlot(String(msg.plotId));
+    } else if(msg.message === 'toggleStyle'){
+        toggleStyle(msg.useOverwrites);
+    } else if(msg.message === 'hidePlot'){
+        hidePlot(msg.plotId);
+    } else if(msg.message === 'addPlot'){
+        addPlot(msg.html);
+    } else if(msg.message === 'togglePreviewPlotLayout'){
+        togglePreviewPlotLayout(msg.style);
+    } else if(msg.message === 'toggleFullWindow'){
+        toggleFullWindowMode(msg.useFullWindow);
+    }
 });
 
 function addPlot(html: string){
-  const wrapper = document.createElement('div');
-  wrapper.classList.add('wrapper');
-  wrapper.innerHTML = html;
-  smallPlotDiv.appendChild(wrapper);
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('wrapper');
+    wrapper.innerHTML = html;
+    smallPlotDiv.appendChild(wrapper);
 }
 
 function focusPlot(plotId: string): void {
-  
-  const smallPlots = getSmallPlots();
+    
+    const smallPlots = getSmallPlots();
 
-  const ind = findIndex(plotId, smallPlots);
-  if(ind < 0){
-    return;
-  }
+    const ind = findIndex(plotId, smallPlots);
+    if(ind < 0){
+        return;
+    }
 
-  for(const elm of smallPlots){
-    elm.classList.remove('active');
-  }
-  
-  const smallPlot = smallPlots[ind];
+    for(const elm of smallPlots){
+        elm.classList.remove('active');
+    }
+    
+    const smallPlot = smallPlots[ind];
 
-  smallPlot.classList.add('active');
-  
-  largePlotDiv.innerHTML = smallPlot.innerHTML;
+    smallPlot.classList.add('active');
+    
+    largePlotDiv.innerHTML = smallPlot.innerHTML;
 }
 
 function updatePlot(plt: Plot): void {
-  
-  const smallPlots = getSmallPlots();
+    
+    const smallPlots = getSmallPlots();
 
-  const ind = findIndex(plt.id, smallPlots);
-  if(ind<0){
-    return;
-  }
-  
-  smallPlots[ind].innerHTML = plt.svg;
-  
-  if(smallPlots[ind].classList.contains('active')){
-    largePlotDiv.innerHTML = plt.svg;
-  }
+    const ind = findIndex(plt.id, smallPlots);
+    if(ind<0){
+        return;
+    }
+    
+    smallPlots[ind].innerHTML = plt.svg;
+    
+    if(smallPlots[ind].classList.contains('active')){
+        largePlotDiv.innerHTML = plt.svg;
+    }
 }
 
 function hidePlot(plotId: string): void {
-  const smallPlots = getSmallPlots();
+    const smallPlots = getSmallPlots();
 
-  const ind = findIndex(plotId, smallPlots);
-  if(ind<0){
-    return;
-  }
-  
-  if(smallPlots[ind].classList.contains('active')){
-    largePlotDiv.innerHTML = '';
-  }
-  
-  smallPlots[ind].parentElement?.remove();
+    const ind = findIndex(plotId, smallPlots);
+    if(ind<0){
+        return;
+    }
+    
+    if(smallPlots[ind].classList.contains('active')){
+        largePlotDiv.innerHTML = '';
+    }
+    
+    smallPlots[ind].parentElement?.remove();
 }
 
 function findIndex(plotId: string, smallPlots?: Element[]): number {
-  smallPlots ||= getSmallPlots();
-  const ind = smallPlots.findIndex(elm => elm.getAttribute('plotId') === String(plotId));
-  if(ind<0){
-    console.warn(`plotId not found: ${plotId}`);
-  }
-  return ind;
+    smallPlots ||= getSmallPlots();
+    const ind = smallPlots.findIndex(elm => elm.getAttribute('plotId') === String(plotId));
+    if(ind<0){
+        console.warn(`plotId not found: ${plotId}`);
+    }
+    return ind;
 }
 
 function toggleStyle(useOverwrites: boolean): void {
-  cssLink.disabled = !useOverwrites;
+    cssLink.disabled = !useOverwrites;
 }
 
 function togglePreviewPlotLayout(newStyle: PreviewPlotLayout): void {
-  smallPlotDiv.classList.remove('multirow', 'scroll', 'hidden');
-  smallPlotDiv.classList.add(newStyle);
+    smallPlotDiv.classList.remove('multirow', 'scroll', 'hidden');
+    smallPlotDiv.classList.add(newStyle);
 }
 
 function toggleFullWindowMode(useFullWindow): void {
-  isFullWindow = useFullWindow;
-  if(useFullWindow){
-    document.body.classList.add('fullWindow');
-    window.scrollTo(0, 0);
-  } else {
-    document.body.classList.remove('fullWindow');
-  }
-  postResizeMessage(true);
+    isFullWindow = useFullWindow;
+    if(useFullWindow){
+        document.body.classList.add('fullWindow');
+        window.scrollTo(0, 0);
+    } else {
+        document.body.classList.remove('fullWindow');
+    }
+    postResizeMessage(true);
 }
 
 ////
@@ -188,8 +188,8 @@ function toggleFullWindowMode(useFullWindow): void {
 ////
 
 window.onload = () => {
-  largePlotDiv.style.height = `${largeSvg.clientHeight}px`;
-  postResizeMessage(true);
+    largePlotDiv.style.height = `${largeSvg.clientHeight}px`;
+    postResizeMessage(true);
 };
 
 
@@ -199,50 +199,50 @@ window.onload = () => {
 
 
 document.addEventListener('mousedown', (e) => {
-  // If mousedown event is fired from .handler, toggle flag to true
-  if (!isFullWindow && e.target === handler) {
-    isHandlerDragging = true;
-    handler.classList.add('dragging');
-    document.body.style.cursor = 'ns-resize';
-  }
+    // If mousedown event is fired from .handler, toggle flag to true
+    if (!isFullWindow && e.target === handler) {
+        isHandlerDragging = true;
+        handler.classList.add('dragging');
+        document.body.style.cursor = 'ns-resize';
+    }
 });
 
 document.addEventListener('mousemove', (e) => {
-  // Don't do anything if dragging flag is false
-  if (isFullWindow || !isHandlerDragging) {
-    return false;
-  }
-  
-  // postLogMessage('mousemove');
+    // Don't do anything if dragging flag is false
+    if (isFullWindow || !isHandlerDragging) {
+        return false;
+    }
+    
+    // postLogMessage('mousemove');
 
-  // Get offset
-  const containerOffsetTop = document.body.offsetTop;
+    // Get offset
+    const containerOffsetTop = document.body.offsetTop;
 
-  // Get x-coordinate of pointer relative to container
-  const pointerRelativeYpos = e.clientY - containerOffsetTop + window.scrollY;
-  
-  // Arbitrary minimum width set on box A, otherwise its inner content will collapse to width of 0
-  const largePlotMinHeight = 60;
+    // Get x-coordinate of pointer relative to container
+    const pointerRelativeYpos = e.clientY - containerOffsetTop + window.scrollY;
+    
+    // Arbitrary minimum width set on box A, otherwise its inner content will collapse to width of 0
+    const largePlotMinHeight = 60;
 
-  // Resize large plot
-  const newHeight = Math.max(largePlotMinHeight, pointerRelativeYpos - 5); // <- why 5?
-  const newHeightString = `${newHeight}px`;
+    // Resize large plot
+    const newHeight = Math.max(largePlotMinHeight, pointerRelativeYpos - 5); // <- why 5?
+    const newHeightString = `${newHeight}px`;
 
-  if(largePlotDiv.style.height !== newHeightString){
-    largePlotDiv.style.height = newHeightString;
-    postResizeMessage();
-  }
+    if(largePlotDiv.style.height !== newHeightString){
+        largePlotDiv.style.height = newHeightString;
+        postResizeMessage();
+    }
 });
 
 window.onresize = () => postResizeMessage();
 
 document.addEventListener('mouseup', () => {
-  // Turn off dragging flag when user mouse is up
-  if(isHandlerDragging){
-    postResizeMessage(true);
-    document.body.style.cursor = '';
-  }
-  handler.classList.remove('dragging');
-  isHandlerDragging = false;
+    // Turn off dragging flag when user mouse is up
+    if(isHandlerDragging){
+        postResizeMessage(true);
+        document.body.style.cursor = '';
+    }
+    handler.classList.remove('dragging');
+    isHandlerDragging = false;
 });
 

--- a/html/httpgd/webviewMessages.d.ts
+++ b/html/httpgd/webviewMessages.d.ts
@@ -1,23 +1,23 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 interface VsCode {
-  postMessage: (msg: OutMessage) => void;
-  setState: (state: string) => void;
+    postMessage: (msg: OutMessage) => void;
+    setState: (state: string) => void;
 }
 
 
 interface IMessage {
-  message: string;
+    message: string;
 }
 interface ResizeMessage extends IMessage {
-  message: 'resize',
-  height: number,
-  width: number,
-  userTriggered: boolean
+    message: 'resize',
+    height: number,
+    width: number,
+    userTriggered: boolean
 }
 interface LogMessage extends IMessage {
-  message: 'log',
-  body: any
+    message: 'log',
+    body: any
 }
 
 type OutMessage = ResizeMessage | LogMessage;
@@ -26,40 +26,40 @@ type OutMessage = ResizeMessage | LogMessage;
 
 
 interface UpdatePlotMessage extends IMessage {
-  message: 'updatePlot',
-  svg: string,
-  plotId: string
+    message: 'updatePlot',
+    svg: string,
+    plotId: string
 }
 
 interface FocusPlotMessage extends IMessage {
-  message: 'focusPlot',
-  plotId: string
+    message: 'focusPlot',
+    plotId: string
 }
 
 interface ToggleStyleMessage extends IMessage {
-  message: 'toggleStyle',
-  useOverwrites: boolean
+    message: 'toggleStyle',
+    useOverwrites: boolean
 }
 
 interface ToggleFullWindowMessage extends IMessage {
-  message: 'toggleFullWindow',
-  useFullWindow: boolean
+    message: 'toggleFullWindow',
+    useFullWindow: boolean
 }
 
 type PreviewPlotLayout = 'multirow' | 'scroll' | 'hidden';
 interface PreviewPlotLayoutMessage extends IMessage {
-  message: 'togglePreviewPlotLayout',
-  style: PreviewPlotLayout
+    message: 'togglePreviewPlotLayout',
+    style: PreviewPlotLayout
 }
 
 interface HidePlotMessage extends IMessage {
-  message: 'hidePlot',
-  plotId: string
+    message: 'hidePlot',
+    plotId: string
 }
 
 interface AddPlotMessage extends IMessage {
-  message: 'addPlot',
-  html: string
+    message: 'addPlot',
+    html: string
 }
 
 type InMessage = UpdatePlotMessage | FocusPlotMessage | ToggleStyleMessage | HidePlotMessage | AddPlotMessage | PreviewPlotLayoutMessage | ToggleFullWindowMessage;

--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -11,9 +11,9 @@ export declare class RExtension {
 export type HelpSubMenu = 'doc' | 'pkgList' | 'refresh' | '?' | '??';
 
 export interface HelpPanel {
-	showHelpForPath(requestPath?: string): void;
-	dispose(): void;
-	refresh(): void;
+    showHelpForPath(requestPath?: string): void;
+    dispose(): void;
+    refresh(): void;
 }
 
 

--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -1,6 +1,6 @@
 
 // declaration of the api exported by the extension
-// implemented in apiImplementation.ts 
+// implemented in apiImplementation.ts
 // used e.g. by vscode-r-debugger to show the help panel from within debug sessions
 
 

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -7,10 +7,10 @@ import { extensionContext } from '../extension';
 import { DisposableProcess, getRLibPaths, spawn, spawnAsync } from '../util';
 
 export interface RHelpProviderOptions {
-	// path of the R executable
+    // path of the R executable
     rPath: string;
-	// directory in which to launch R processes
-	cwd?: string;
+    // directory in which to launch R processes
+    cwd?: string;
     // listener to notify when new packages are installed
     pkgListener?: () => void;
 }
@@ -40,8 +40,8 @@ export class HelpProvider {
     }
 
     public launchRHelpServer(): ChildProcessWithPort{
-		const lim = '---vsc---';
-		const portRegex = new RegExp(`.*${lim}(.*)${lim}.*`, 'ms');
+        const lim = '---vsc---';
+        const portRegex = new RegExp(`.*${lim}(.*)${lim}.*`, 'ms');
         
         const newPackageRegex = new RegExp('NEW_PACKAGES');
 
@@ -104,7 +104,7 @@ export class HelpProvider {
         return childProcess;
     }
 
-	public async getHelpFileFromRequestPath(requestPath: string): Promise<undefined|rHelp.HelpFile> {
+    public async getHelpFileFromRequestPath(requestPath: string): Promise<undefined|rHelp.HelpFile> {
 
         const port = await this.cp?.port;
         if(!port || typeof port !== 'number'){
@@ -179,11 +179,11 @@ export class HelpProvider {
 
 
 export interface AliasProviderArgs {
-	// R path, must be vanilla R
-	rPath: string;
+    // R path, must be vanilla R
+    rPath: string;
     // cwd
     cwd?: string;
-	// getAliases.R
+    // getAliases.R
     rScriptFile: string;
 
     persistentState: Memento;
@@ -208,7 +208,7 @@ export class AliasProvider {
     private readonly cwd?: string;
     private readonly rScriptFile: string;
     private aliases?: undefined | rHelp.Alias[];
-	private readonly persistentState?: Memento;
+    private readonly persistentState?: Memento;
 
     constructor(args: AliasProviderArgs){
         this.rPath = args.rPath;

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -42,7 +42,7 @@ export class HelpProvider {
     public launchRHelpServer(): ChildProcessWithPort{
         const lim = '---vsc---';
         const portRegex = new RegExp(`.*${lim}(.*)${lim}.*`, 'ms');
-        
+
         const newPackageRegex = new RegExp('NEW_PACKAGES');
 
         // starts the background help server and waits forever to keep the R process running
@@ -90,7 +90,7 @@ export class HelpProvider {
                 resolve(0);
             });
         });
-        
+
         const exitHandler = () => {
             childProcess.port = 0;
         };
@@ -230,14 +230,14 @@ export class AliasProvider {
         if(this.aliases){
             return this.aliases;
         }
-        
+
         // try cached aliases:
         const cachedAliases = this.persistentState?.get<rHelp.Alias[]>('r.helpPanel.cachedAliases');
         if(cachedAliases){
             this.aliases = cachedAliases;
             return cachedAliases;
         }
-        
+
         // try to make new aliases (returns undefined if unsuccessful):
         const newAliases = await this.makeAllAliases();
         this.aliases = newAliases;
@@ -252,7 +252,7 @@ export class AliasProvider {
         if(!allPackageAliases){
             return undefined;
         }
-        
+
         // flatten aliases into one list:
         const allAliases: rHelp.Alias[] = [];
         for(const pkg in allPackageAliases){
@@ -289,7 +289,7 @@ export class AliasProvider {
             '-f',
             this.rScriptFile
         ];
-        
+
         try {
             const result = await spawnAsync(this.rPath, args, options);
             if (result.status !== 0) {

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -52,8 +52,8 @@ export async function initializeHelp(
         cacheConfig === 'Workspace'
             ? context.workspaceState
             : cacheConfig === 'Global'
-            ? context.globalState
-            : new DummyMemento();
+                ? context.globalState
+                : new DummyMemento();
 
     // Gather options used in r help related files
     const rHelpOptions: HelpOptions = {
@@ -168,8 +168,7 @@ export interface HelpOptions {
 
 // The name api.HelpPanel is a bit misleading
 // This class manages all R-help and R-packages related functions
-export class RHelp
-    implements api.HelpPanel, vscode.WebviewPanelSerializer<string>
+export class RHelp implements api.HelpPanel, vscode.WebviewPanelSerializer<string>
 {
     // Path of a vanilla R installation
     readonly rPath: string
@@ -429,8 +428,8 @@ export class RHelp
 
     // helper function to get aliases from aliasprovider
     private async getAllAliases(): Promise<Alias[] | undefined> {
-        const aliases = await doWithProgress(() =>
-            this.aliasProvider.getAllAliases(),
+        const aliases = await doWithProgress(
+            () => this.aliasProvider.getAllAliases(),
             vscode.ProgressLocation.Window
         );
         if (!aliases) {
@@ -505,8 +504,8 @@ export class RHelp
         if (!this.cachedHelpFiles.has(requestPath)) {
             const helpFile = !isGuestSession
                 ? await this.helpProvider.getHelpFileFromRequestPath(
-                      requestPath,
-                  )
+                    requestPath,
+                )
                 : await rGuestService.requestHelpContent(requestPath);
             this.cachedHelpFiles.set(requestPath, helpFile);
         }

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -571,7 +571,7 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
 
     // Remove style elements specified in the html itself (replaced with custom CSS)
     $('head style').remove();
-    
+
     // Split code examples at empty lines:
     const codeClickConfig = config().get<CodeClickConfig>('helpPanel.clickCodeExamples');
     const isEnabled = CODE_CLICKS.some(k => codeClickConfig[k] !== 'Ignore');

--- a/src/helpViewer/packages.ts
+++ b/src/helpViewer/packages.ts
@@ -82,7 +82,7 @@ export class PackageManager {
 
     readonly rHelp: RHelp;
 
-	readonly aliasProvider: AliasProvider;
+    readonly aliasProvider: AliasProvider;
 
     readonly state: vscode.Memento;
 
@@ -109,7 +109,7 @@ export class PackageManager {
     }
 
     // Funciton to clear only the cached files regarding an individual package etc.
-	public async clearCachedFiles(re?: string|RegExp): Promise<void> {
+    public async clearCachedFiles(re?: string|RegExp): Promise<void> {
         let cache: CachedIndexFiles | undefined;
         if(re){
             const oldCache = this.state.get<CachedIndexFiles>('r.helpPanel.cachedIndexFiles', []);
@@ -121,7 +121,7 @@ export class PackageManager {
             cache = undefined;
         }
         await this.state.update('r.helpPanel.cachedIndexFiles', cache);
-	}
+    }
 
     // Function to add/remove packages from favorites
     public addFavorite(pkgName: string): string[] {
@@ -350,33 +350,33 @@ export class PackageManager {
         return ret;
     }
 
-	// retrieve and parse an index file
-	// (either list of all packages, or documentation entries of a package)
-	private async getParsedIndexFile(path: string): Promise<IndexEntry[]|undefined> {
+    // retrieve and parse an index file
+    // (either list of all packages, or documentation entries of a package)
+    private async getParsedIndexFile(path: string): Promise<IndexEntry[]|undefined> {
 
         let indexItems = this.getCachedIndexFile(path);
 
-		// only read and parse file if not cached yet
-		if(!indexItems){
-			const helpFile = await this.rHelp.getHelpFileForPath(path, false);
-			if(!helpFile?.html){
-				// set missing files to null
+        // only read and parse file if not cached yet
+        if(!indexItems){
+            const helpFile = await this.rHelp.getHelpFileForPath(path, false);
+            if(!helpFile?.html){
+                // set missing files to null
                 indexItems = undefined;
-			} else{
-				// parse and cache file
-				indexItems = parseIndexFile(helpFile.html);
-			}
+            } else{
+                // parse and cache file
+                indexItems = parseIndexFile(helpFile.html);
+            }
             void this.updateCachedIndexFile(path, indexItems);
-		}
+        }
 
-		// return cache entry. make new array to avoid messing with the cache
+        // return cache entry. make new array to avoid messing with the cache
         let ret: IndexEntry[] | undefined = undefined;
         if(indexItems){
             ret = [];
             ret.push(...indexItems);
         }
-		return ret;
-	}
+        return ret;
+    }
 }
 
 

--- a/src/helpViewer/packages.ts
+++ b/src/helpViewer/packages.ts
@@ -90,7 +90,7 @@ export class PackageManager {
 
     // names of packages to be highlighted in the package list
     // public favoriteNames: string[] = [];
-    
+
     public favoriteNames: Set<string> = new Set();
 
 
@@ -176,7 +176,7 @@ export class PackageManager {
         }
     }
 
-    // let the user pick and install a package from CRAN 
+    // let the user pick and install a package from CRAN
     public async pickAndInstallPackages(pickMany: boolean = false): Promise<boolean> {
         const packages = await doWithProgress(() => this.getPackages(true), this.rHelp.treeViewWrapper.viewId);
         if(!packages?.length){
@@ -226,7 +226,7 @@ export class PackageManager {
         }
         return false;
     }
-    
+
     public async updatePackages(skipConfirmation: boolean = false): Promise<boolean> {
         const rPath = await getRpath();
         const cranUrl = await getCranUrl('', this.cwd);
@@ -463,7 +463,7 @@ async function pickPackages(packages: Package[], placeHolder: string, pickMany: 
         const qp = await vscode.window.showQuickPick(qpItems, qpOptions);
         ret = (qp ? [qp.package] : undefined);
     }
-    
+
     return ret;
 }
 

--- a/src/helpViewer/packages.ts
+++ b/src/helpViewer/packages.ts
@@ -267,8 +267,8 @@ export class PackageManager {
                 pkg.isFavorite = this.favoriteNames.has(pkg.name);
                 pkg.helpPath = (
                     pkg.name === 'doc' ?
-                    '/doc/html/packages.html' :
-                    `/library/${pkg.name}/html/00Index.html`
+                        '/doc/html/packages.html' :
+                        `/library/${pkg.name}/html/00Index.html`
                 );
             }
         }
@@ -300,8 +300,8 @@ export class PackageManager {
 
             topic.helpPath = (
                 topic.pkgName === 'doc' ?
-                `/doc/html/${topic.href}` :
-                `/library/${topic.pkgName}/html/${topic.href}`
+                    `/doc/html/${topic.href}` :
+                    `/library/${topic.pkgName}/html/${topic.href}`
             );
             return topic;
         });

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -271,7 +271,7 @@ export class HelpPanel {
             const isCtrlClick = msg.modifiers.ctrlKey || msg.modifiers.metaKey;
             const isShiftClick = msg.modifiers.shiftKey;
             const isNormalClick = !isCtrlClick && !isShiftClick;
-            
+
             // Check wheter to copy or run the code (or both or none)
             const codeClickConfig = config().get<CodeClickConfig>('helpPanel.clickCodeExamples');
             const runCode = (
@@ -284,7 +284,7 @@ export class HelpPanel {
                 || isShiftClick && codeClickConfig['Shift+Click'] === 'Copy'
                 || isNormalClick && codeClickConfig['Click'] === 'Copy'
             );
-            
+
             // Execute action:
             if(copyCode){
                 void vscode.env.clipboard.writeText(msg.code);

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -11,320 +11,320 @@ import { OutMessage } from './webviewMessages';
 //// Declaration of interfaces used/implemented by the Help Panel class
 // specified when creating a new help panel
 export interface HelpPanelOptions {
-	/* Local path of script.js, used to send messages to vs code */
-	webviewScriptPath: string;
-	/* Local path of theme.css, used to actually format the highlighted syntax */
-	webviewStylePath: string;
+    /* Local path of script.js, used to send messages to vs code */
+    webviewScriptPath: string;
+    /* Local path of theme.css, used to actually format the highlighted syntax */
+    webviewStylePath: string;
 }
 
 // internal interface used to store history of help panel
 interface HistoryEntry {
-	helpFile: HelpFile;
+    helpFile: HelpFile;
 }
 
 export class HelpPanel {
 
     private readonly rHelp: RHelp;
 
-	// the webview panel where the help is shown
-	public panel?: vscode.WebviewPanel;
-	private viewColumn: vscode.ViewColumn = vscode.ViewColumn.Two;
+    // the webview panel where the help is shown
+    public panel?: vscode.WebviewPanel;
+    private viewColumn: vscode.ViewColumn = vscode.ViewColumn.Two;
 
-	// locations on disk, only changed on construction
-	readonly webviewScriptFile: vscode.Uri; // the javascript added to help pages
-	readonly webviewStyleFile: vscode.Uri; // the css file applied to help pages
+    // locations on disk, only changed on construction
+    readonly webviewScriptFile: vscode.Uri; // the javascript added to help pages
+    readonly webviewStyleFile: vscode.Uri; // the css file applied to help pages
 
-	// virtual locations used by webview, changed each time a new webview is created
-	private webviewScriptUri?: vscode.Uri;
+    // virtual locations used by webview, changed each time a new webview is created
+    private webviewScriptUri?: vscode.Uri;
     private webviewStyleUri?: vscode.Uri;
 
-	// keep track of history to go back/forward:
-	private currentEntry: HistoryEntry|undefined = undefined;
-	private history: HistoryEntry[] = [];
-	private forwardHistory: HistoryEntry[] = [];
+    // keep track of history to go back/forward:
+    private currentEntry: HistoryEntry|undefined = undefined;
+    private history: HistoryEntry[] = [];
+    private forwardHistory: HistoryEntry[] = [];
 
-	constructor(options: HelpPanelOptions, rHelp: RHelp, panel?: vscode.WebviewPanel){
-		this.webviewScriptFile = vscode.Uri.file(options.webviewScriptPath);
+    constructor(options: HelpPanelOptions, rHelp: RHelp, panel?: vscode.WebviewPanel){
+        this.webviewScriptFile = vscode.Uri.file(options.webviewScriptPath);
         this.webviewStyleFile = vscode.Uri.file(options.webviewStylePath);
         this.rHelp = rHelp;
-		if(panel){
-			this.panel = panel;
-			this.initializePanel();
-		}
-	}
-
-	// used to close files, stop servers etc.
-	public dispose(): void {
-		if(this.panel){
-			this.panel.dispose();
-		}
+        if(panel){
+            this.panel = panel;
+            this.initializePanel();
+        }
     }
 
-	// retrieves the stored webview or creates a new one if the webview was closed
-	private getWebview(preserveFocus: boolean = false): vscode.Webview {
-		// create webview if necessary
-		if(!this.panel){
-			const webViewOptions: vscode.WebviewOptions & vscode.WebviewPanelOptions = {
-				enableScripts: true,
-				enableFindWidget: true,
-				retainContextWhenHidden: true // keep scroll position when not focussed
-			};
-			const showOptions = {
-				viewColumn: this.viewColumn,
-				preserveFocus: preserveFocus
-			};
-			this.panel = vscode.window.createWebviewPanel('rhelp', 'R Help', showOptions, webViewOptions);
-			this.initializePanel();
-		}
-
-		this.panel.reveal(undefined, preserveFocus);
-		void this.setContextValues();
-
-		return this.panel.webview;
+    // used to close files, stop servers etc.
+    public dispose(): void {
+        if(this.panel){
+            this.panel.dispose();
+        }
     }
 
-	private initializePanel(): void {
-		if(!this.panel){
-			return;
-		}
-		this.panel.iconPath = new UriIcon('help');
-		// virtual uris used to access local files
-		this.webviewScriptUri = this.panel.webview.asWebviewUri(this.webviewScriptFile);
-		this.webviewStyleUri = this.panel.webview.asWebviewUri(this.webviewStyleFile);
+    // retrieves the stored webview or creates a new one if the webview was closed
+    private getWebview(preserveFocus: boolean = false): vscode.Webview {
+        // create webview if necessary
+        if(!this.panel){
+            const webViewOptions: vscode.WebviewOptions & vscode.WebviewPanelOptions = {
+                enableScripts: true,
+                enableFindWidget: true,
+                retainContextWhenHidden: true // keep scroll position when not focussed
+            };
+            const showOptions = {
+                viewColumn: this.viewColumn,
+                preserveFocus: preserveFocus
+            };
+            this.panel = vscode.window.createWebviewPanel('rhelp', 'R Help', showOptions, webViewOptions);
+            this.initializePanel();
+        }
 
-		// called e.g. when the webview panel is closed by the user
-		this.panel.onDidDispose(() => {
-			this.panel = undefined;
-			this.history = [];
-			this.forwardHistory = [];
-			this.currentEntry = undefined;
-			this.webviewScriptUri = undefined;
-			this.webviewStyleUri = undefined;
-			void this.setContextValues();
-		});
+        this.panel.reveal(undefined, preserveFocus);
+        void this.setContextValues();
 
-		// sent by javascript added to the help pages, e.g. when a link or mouse button is clicked
-		this.panel.webview.onDidReceiveMessage((e: OutMessage) => {
-			void this.handleMessage(e);
-		});
+        return this.panel.webview;
+    }
 
-		// set context variable to show forward/backward buttons
-		this.panel.onDidChangeViewState(() => {
-			void this.setContextValues();
-		});
-	}
+    private initializePanel(): void {
+        if(!this.panel){
+            return;
+        }
+        this.panel.iconPath = new UriIcon('help');
+        // virtual uris used to access local files
+        this.webviewScriptUri = this.panel.webview.asWebviewUri(this.webviewScriptFile);
+        this.webviewStyleUri = this.panel.webview.asWebviewUri(this.webviewStyleFile);
 
+        // called e.g. when the webview panel is closed by the user
+        this.panel.onDidDispose(() => {
+            this.panel = undefined;
+            this.history = [];
+            this.forwardHistory = [];
+            this.currentEntry = undefined;
+            this.webviewScriptUri = undefined;
+            this.webviewStyleUri = undefined;
+            void this.setContextValues();
+        });
 
-	public async setContextValues(): Promise<void> {
-		await setContext('r.helpPanel.active', !!this.panel?.active);
-		await setContext('r.helpPanel.canGoBack', this.history.length > 0);
-		await setContext('r.helpPanel.canGoForward', this.forwardHistory.length > 0);
-	}
+        // sent by javascript added to the help pages, e.g. when a link or mouse button is clicked
+        this.panel.webview.onDidReceiveMessage((e: OutMessage) => {
+            void this.handleMessage(e);
+        });
 
-	// shows (internal) help file object in webview
-	public async showHelpFile(helpFile: HelpFile | Promise<HelpFile>, updateHistory = true, currentScrollY = 0, viewer?: vscode.ViewColumn | string, preserveFocus: boolean = false): Promise<boolean>{
-		if (viewer === undefined) {
-			viewer = config().get<string>('session.viewers.viewColumn.helpPanel');
-		}
-
-		// update this.viewColumn if a valid viewer argument was supplied
-		if (typeof viewer === 'string'){
-			this.viewColumn = <vscode.ViewColumn>vscode.ViewColumn[String(viewer)];
-		}
-
-		// get or create webview:
-		const webview = this.getWebview(preserveFocus);
-
-		// make sure helpFile is not a promise:
-		helpFile = await helpFile;
-
-		helpFile.scrollY = helpFile.scrollY || 0;
-
-		// modify html
-		helpFile = this.pimpMyHelp(helpFile, this.webviewStyleUri, this.webviewScriptUri);
-
-		// actually show the hel page
-		webview.html = helpFile.html;
-
-		// update history to enable back/forward
-		if(updateHistory){
-			if(this.currentEntry){
-				this.currentEntry.helpFile.scrollY = currentScrollY;
-				this.history.push(this.currentEntry);
-			}
-			this.forwardHistory = [];
-		}
-		this.currentEntry = {
-			helpFile: helpFile
-		};
-
-		await this.setContextValues();
-
-		return true;
-	}
-
-	public async openInExternalBrowser(helpFile?: HelpFile): Promise<boolean> {
-		if(!this.currentEntry){
-			return false;
-		}
-		if(!helpFile){
-			helpFile = this.currentEntry.helpFile;
-		}
-		const url = helpFile.url;
-		if(!url){
-			return false;
-		}
-		const uri = vscode.Uri.parse(url);
-		return vscode.env.openExternal(uri);
-	}
-
-	// go back/forward in the history of the webview:
-	public goBack(): void {
-		void this.panel?.webview.postMessage({command: 'goBack'});
-	}
-	private _goBack(currentScrollY = 0): void{
-		const entry = this.history.pop();
-		if(entry){
-			if(this.currentEntry){ // should always be true
-				this.currentEntry.helpFile.scrollY = currentScrollY;
-				this.forwardHistory.push(this.currentEntry);
-			}
-			this.showHistoryEntry(entry);
-		}
-	}
-	public goForward(): void {
-		void this.panel?.webview.postMessage({command: 'goForward'});
-	}
-	private _goForward(currentScrollY = 0): void{
-		const entry = this.forwardHistory.pop();
-		if(entry){
-			if(this.currentEntry){ // should always be true
-				this.currentEntry.helpFile.scrollY = currentScrollY;
-				this.history.push(this.currentEntry);
-			}
-			this.showHistoryEntry(entry);
-		}
-	}
-	private showHistoryEntry(entry: HistoryEntry){
-		const helpFile = entry.helpFile;
-		void this.showHelpFile(helpFile, false);
-	}
-
-	// handle message produced by javascript inside the help page
-	private async handleMessage(msg: OutMessage){
-		if(msg.message === 'linkClicked'){
-			// handle hyperlinks clicked in the webview
-			// normal navigation does not work in webviews (even on localhost)
-			const href: string = msg.href || '';
-			const currentScrollY: number = Number(msg.scrollY) || 0;
-			console.log('Link clicked: ' + href);
-
-			// remove first to path entries (if these are webview internal stuff):
-			const uri = vscode.Uri.parse(href);
-			const parts = uri.path.split('/');
-			if(parts[0] !== 'library' && parts[0] !== 'doc'){
-				parts.shift();
-			}
-			if(parts[0] !== 'library' && parts[0] !== 'doc'){
-				parts.shift();
-			}
-
-			// actual request path as used by R:
-			const requestPath = parts.join('/');
-
-			// retrieve helpfile for path:
-			const helpFile = await this.rHelp.getHelpFileForPath(requestPath);
-
-			// if successful, show helpfile:
-			if(helpFile){
-				if(uri.fragment){
-					helpFile.hash = '#' + uri.fragment;
-				} else{
-					helpFile.scrollY = 0;
-				}
-				if(uri.path.endsWith('.pdf')){
-					void this.openInExternalBrowser(helpFile);
-				} else if(uri.path.endsWith('.R')){
-					const doc = await vscode.workspace.openTextDocument({
-						language: 'r',
-						content: helpFile.html0
-					});
-					void vscode.window.showTextDocument(doc);
-				} else{
-					void this.showHelpFile(helpFile, true, currentScrollY);
-				}
-			}
-		} else if(msg.message === 'mouseClick'){
-			// use the additional mouse buttons to go forward/backwards
-			const currentScrollY = Number(msg.scrollY) || 0;
-			const button: number = Number(msg.button) || 0;
-			if(button === 3){
-				this._goBack(currentScrollY);
-			} else if(button === 4){
-				this._goForward(currentScrollY);
-			}
-		} else if(msg.message === 'codeClicked') {
-			if(!msg.code){
-				return;
-			}
-			// Process modifiers:
-			const isCtrlClick = msg.modifiers.ctrlKey || msg.modifiers.metaKey;
-			const isShiftClick = msg.modifiers.shiftKey;
-			const isNormalClick = !isCtrlClick && !isShiftClick;
-			
-			// Check wheter to copy or run the code (or both or none)
-			const codeClickConfig = config().get<CodeClickConfig>('helpPanel.clickCodeExamples');
-			const runCode = (
-				isCtrlClick && codeClickConfig['Ctrl+Click'] === 'Run'
-				|| isShiftClick && codeClickConfig['Shift+Click'] === 'Run'
-				|| isNormalClick && codeClickConfig['Click'] === 'Run'
-			);
-			const copyCode = (
-				isCtrlClick && codeClickConfig['Ctrl+Click'] === 'Copy'
-				|| isShiftClick && codeClickConfig['Shift+Click'] === 'Copy'
-				|| isNormalClick && codeClickConfig['Click'] === 'Copy'
-			);
-			
-			// Execute action:
-			if(copyCode){
-				void vscode.env.clipboard.writeText(msg.code);
-				void vscode.window.showInformationMessage('Copied code example to clipboard.');
-			}
-			if(runCode){
-				void runTextInTerm(msg.code);
-			}
-		} else{
-			console.log('Unknown message:', msg);
-		}
-	}
-
-	// improves the help display by applying syntax highlighting and adjusting hyperlinks:
-	private pimpMyHelp(helpFile: HelpFile, styleUri?: vscode.Uri|string, scriptUri?: vscode.Uri|string): HelpFile {
-
-		// get requestpath of helpfile
-		const relPath = helpFile.requestPath + (helpFile.hash || '');
-
-		// parse the html string
-		const $ = cheerio.load(helpFile.html);
-
-		// set relPath attribute. Used by js inside the page to adjust hyperlinks
-		// scroll to top (=0) or last viewed position (if the page is from history)
-		$('body').attr('relpath', relPath);
-		$('body').attr('scrollyto', `${helpFile.scrollY ?? -1}`);
-
-		if(styleUri){
-			$('body').append(`\n<link rel="stylesheet" href="${styleUri.toString()}"></link>`);
-		}
-		if(scriptUri){
-			$('body').append(`\n<script src=${scriptUri.toString()}></script>`);
-		}
+        // set context variable to show forward/backward buttons
+        this.panel.onDidChangeViewState(() => {
+            void this.setContextValues();
+        });
+    }
 
 
-		// convert to string
-		helpFile.html = $.html();
+    public async setContextValues(): Promise<void> {
+        await setContext('r.helpPanel.active', !!this.panel?.active);
+        await setContext('r.helpPanel.canGoBack', this.history.length > 0);
+        await setContext('r.helpPanel.canGoForward', this.forwardHistory.length > 0);
+    }
 
-		// return the html of the modified page:
-		return helpFile;
-	}
+    // shows (internal) help file object in webview
+    public async showHelpFile(helpFile: HelpFile | Promise<HelpFile>, updateHistory = true, currentScrollY = 0, viewer?: vscode.ViewColumn | string, preserveFocus: boolean = false): Promise<boolean>{
+        if (viewer === undefined) {
+            viewer = config().get<string>('session.viewers.viewColumn.helpPanel');
+        }
+
+        // update this.viewColumn if a valid viewer argument was supplied
+        if (typeof viewer === 'string'){
+            this.viewColumn = <vscode.ViewColumn>vscode.ViewColumn[String(viewer)];
+        }
+
+        // get or create webview:
+        const webview = this.getWebview(preserveFocus);
+
+        // make sure helpFile is not a promise:
+        helpFile = await helpFile;
+
+        helpFile.scrollY = helpFile.scrollY || 0;
+
+        // modify html
+        helpFile = this.pimpMyHelp(helpFile, this.webviewStyleUri, this.webviewScriptUri);
+
+        // actually show the hel page
+        webview.html = helpFile.html;
+
+        // update history to enable back/forward
+        if(updateHistory){
+            if(this.currentEntry){
+                this.currentEntry.helpFile.scrollY = currentScrollY;
+                this.history.push(this.currentEntry);
+            }
+            this.forwardHistory = [];
+        }
+        this.currentEntry = {
+            helpFile: helpFile
+        };
+
+        await this.setContextValues();
+
+        return true;
+    }
+
+    public async openInExternalBrowser(helpFile?: HelpFile): Promise<boolean> {
+        if(!this.currentEntry){
+            return false;
+        }
+        if(!helpFile){
+            helpFile = this.currentEntry.helpFile;
+        }
+        const url = helpFile.url;
+        if(!url){
+            return false;
+        }
+        const uri = vscode.Uri.parse(url);
+        return vscode.env.openExternal(uri);
+    }
+
+    // go back/forward in the history of the webview:
+    public goBack(): void {
+        void this.panel?.webview.postMessage({command: 'goBack'});
+    }
+    private _goBack(currentScrollY = 0): void{
+        const entry = this.history.pop();
+        if(entry){
+            if(this.currentEntry){ // should always be true
+                this.currentEntry.helpFile.scrollY = currentScrollY;
+                this.forwardHistory.push(this.currentEntry);
+            }
+            this.showHistoryEntry(entry);
+        }
+    }
+    public goForward(): void {
+        void this.panel?.webview.postMessage({command: 'goForward'});
+    }
+    private _goForward(currentScrollY = 0): void{
+        const entry = this.forwardHistory.pop();
+        if(entry){
+            if(this.currentEntry){ // should always be true
+                this.currentEntry.helpFile.scrollY = currentScrollY;
+                this.history.push(this.currentEntry);
+            }
+            this.showHistoryEntry(entry);
+        }
+    }
+    private showHistoryEntry(entry: HistoryEntry){
+        const helpFile = entry.helpFile;
+        void this.showHelpFile(helpFile, false);
+    }
+
+    // handle message produced by javascript inside the help page
+    private async handleMessage(msg: OutMessage){
+        if(msg.message === 'linkClicked'){
+            // handle hyperlinks clicked in the webview
+            // normal navigation does not work in webviews (even on localhost)
+            const href: string = msg.href || '';
+            const currentScrollY: number = Number(msg.scrollY) || 0;
+            console.log('Link clicked: ' + href);
+
+            // remove first to path entries (if these are webview internal stuff):
+            const uri = vscode.Uri.parse(href);
+            const parts = uri.path.split('/');
+            if(parts[0] !== 'library' && parts[0] !== 'doc'){
+                parts.shift();
+            }
+            if(parts[0] !== 'library' && parts[0] !== 'doc'){
+                parts.shift();
+            }
+
+            // actual request path as used by R:
+            const requestPath = parts.join('/');
+
+            // retrieve helpfile for path:
+            const helpFile = await this.rHelp.getHelpFileForPath(requestPath);
+
+            // if successful, show helpfile:
+            if(helpFile){
+                if(uri.fragment){
+                    helpFile.hash = '#' + uri.fragment;
+                } else{
+                    helpFile.scrollY = 0;
+                }
+                if(uri.path.endsWith('.pdf')){
+                    void this.openInExternalBrowser(helpFile);
+                } else if(uri.path.endsWith('.R')){
+                    const doc = await vscode.workspace.openTextDocument({
+                        language: 'r',
+                        content: helpFile.html0
+                    });
+                    void vscode.window.showTextDocument(doc);
+                } else{
+                    void this.showHelpFile(helpFile, true, currentScrollY);
+                }
+            }
+        } else if(msg.message === 'mouseClick'){
+            // use the additional mouse buttons to go forward/backwards
+            const currentScrollY = Number(msg.scrollY) || 0;
+            const button: number = Number(msg.button) || 0;
+            if(button === 3){
+                this._goBack(currentScrollY);
+            } else if(button === 4){
+                this._goForward(currentScrollY);
+            }
+        } else if(msg.message === 'codeClicked') {
+            if(!msg.code){
+                return;
+            }
+            // Process modifiers:
+            const isCtrlClick = msg.modifiers.ctrlKey || msg.modifiers.metaKey;
+            const isShiftClick = msg.modifiers.shiftKey;
+            const isNormalClick = !isCtrlClick && !isShiftClick;
+            
+            // Check wheter to copy or run the code (or both or none)
+            const codeClickConfig = config().get<CodeClickConfig>('helpPanel.clickCodeExamples');
+            const runCode = (
+                isCtrlClick && codeClickConfig['Ctrl+Click'] === 'Run'
+                || isShiftClick && codeClickConfig['Shift+Click'] === 'Run'
+                || isNormalClick && codeClickConfig['Click'] === 'Run'
+            );
+            const copyCode = (
+                isCtrlClick && codeClickConfig['Ctrl+Click'] === 'Copy'
+                || isShiftClick && codeClickConfig['Shift+Click'] === 'Copy'
+                || isNormalClick && codeClickConfig['Click'] === 'Copy'
+            );
+            
+            // Execute action:
+            if(copyCode){
+                void vscode.env.clipboard.writeText(msg.code);
+                void vscode.window.showInformationMessage('Copied code example to clipboard.');
+            }
+            if(runCode){
+                void runTextInTerm(msg.code);
+            }
+        } else{
+            console.log('Unknown message:', msg);
+        }
+    }
+
+    // improves the help display by applying syntax highlighting and adjusting hyperlinks:
+    private pimpMyHelp(helpFile: HelpFile, styleUri?: vscode.Uri|string, scriptUri?: vscode.Uri|string): HelpFile {
+
+        // get requestpath of helpfile
+        const relPath = helpFile.requestPath + (helpFile.hash || '');
+
+        // parse the html string
+        const $ = cheerio.load(helpFile.html);
+
+        // set relPath attribute. Used by js inside the page to adjust hyperlinks
+        // scroll to top (=0) or last viewed position (if the page is from history)
+        $('body').attr('relpath', relPath);
+        $('body').attr('scrollyto', `${helpFile.scrollY ?? -1}`);
+
+        if(styleUri){
+            $('body').append(`\n<link rel="stylesheet" href="${styleUri.toString()}"></link>`);
+        }
+        if(scriptUri){
+            $('body').append(`\n<script src=${scriptUri.toString()}></script>`);
+        }
+
+
+        // convert to string
+        helpFile.html = $.html();
+
+        // return the html of the modified page:
+        return helpFile;
+    }
 
 }

--- a/src/helpViewer/treeView.ts
+++ b/src/helpViewer/treeView.ts
@@ -565,7 +565,7 @@ class HomeNode extends MetaNode {
 }
 
 class Search1Node extends MetaNode {
-	label = 'Open Help Topic using `?`';
+    label = 'Open Help Topic using `?`';
     iconPath = new vscode.ThemeIcon('zap');
     
     callBack(){
@@ -574,7 +574,7 @@ class Search1Node extends MetaNode {
 }
 
 class Search2Node extends MetaNode {
-	label = 'Search Help Topics using `??`';
+    label = 'Search Help Topics using `??`';
     iconPath = new vscode.ThemeIcon('search');
 
     callBack(){
@@ -584,7 +584,7 @@ class Search2Node extends MetaNode {
 
 class RefreshNode extends MetaNode {
     parent: RootNode;
-	label = 'Clear Cache & Restart Help Server';
+    label = 'Clear Cache & Restart Help Server';
     iconPath = new vscode.ThemeIcon('refresh');
 
     async callBack(){

--- a/src/helpViewer/treeView.ts
+++ b/src/helpViewer/treeView.ts
@@ -9,7 +9,7 @@ import { Package, Topic, TopicType } from './packages';
 const CollapsibleState = vscode.TreeItemCollapsibleState;
 
 
-// the commands contributed in package.json for the tree view 
+// the commands contributed in package.json for the tree view
 // the commands are registered in HelpTreeWrapper.constructor
 // the node-objects only need to handle the keys ('QUICKPICK' etc.) in Node.handleCommand()
 const nodeCommands = {
@@ -77,7 +77,7 @@ export class HelpTreeWrapper {
             listener(node);
         }
     }
-    
+
     public refreshPackageRootNode(): void {
         this.helpViewProvider.rootItem?.pkgRootNode?.refresh();
     }
@@ -551,7 +551,7 @@ class HomeNode extends MetaNode {
     collapsibleState = CollapsibleState.None;
     iconPath = new vscode.ThemeIcon('home');
     contextValue = Node.makeContextValue('openInNewPanel');
-    
+
     _handleCommand(cmd: cmdName){
         if(cmd === 'openInNewPanel'){
             void this.rHelp.makeNewHelpPanel();
@@ -567,7 +567,7 @@ class HomeNode extends MetaNode {
 class Search1Node extends MetaNode {
     label = 'Open Help Topic using `?`';
     iconPath = new vscode.ThemeIcon('zap');
-    
+
     callBack(){
         void this.rHelp.searchHelpByAlias();
     }
@@ -597,7 +597,7 @@ class OpenForSelectionNode extends MetaNode {
     parent: RootNode;
     label = 'Open Help Page for Selected Text';
     iconPath = new vscode.ThemeIcon('symbol-key');
-    
+
     callBack(){
         void this.rHelp.openHelpForSelection();
     }

--- a/src/helpViewer/webviewMessages.d.ts
+++ b/src/helpViewer/webviewMessages.d.ts
@@ -4,40 +4,40 @@
 
 
 interface VsCode {
-  postMessage: (msg: OutMessage) => void;
-  setState: (state: string) => void;
+    postMessage: (msg: OutMessage) => void;
+    setState: (state: string) => void;
 }
 declare function acquireVsCodeApi(): VsCode;
 
 
 
 export interface IMessage {
-  message: string;
+    message: string;
 }
 
 export interface LogMessage extends IMessage {
-  message: 'log',
-  body: any
+    message: 'log',
+    body: any
 }
 export interface MouseClickMessage extends IMessage {
-  message: 'mouseClick',
-  button: number,
-  scrollY: number
+    message: 'mouseClick',
+    button: number,
+    scrollY: number
 }
 export interface LinkClickedMessage extends IMessage {
-  message: 'linkClicked',
-  href: string,
-  scrollY: number
+    message: 'linkClicked',
+    href: string,
+    scrollY: number
 }
 export interface CodeClickedMessage extends IMessage {
-  message: 'codeClicked',
-  code: string,
-  modifiers: {
-    altKey: boolean,
-    ctrlKey: boolean,
-    shiftKey: boolean,
-    metaKey: boolean,
-  }
+    message: 'codeClicked',
+    code: string,
+    modifiers: {
+        altKey: boolean,
+        ctrlKey: boolean,
+        shiftKey: boolean,
+        metaKey: boolean,
+    }
 }
 
 export type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage | CodeClickedMessage;

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -14,300 +14,300 @@ import { extensionContext } from './extension';
 import { CommonOptions } from 'child_process';
 
 export class LanguageService implements Disposable {
-  private readonly clients: Map<string, LanguageClient> = new Map();
-  private readonly initSet: Set<string> = new Set();
+    private readonly clients: Map<string, LanguageClient> = new Map();
+    private readonly initSet: Set<string> = new Set();
 
-  constructor() {
-    this.startLanguageService(this);
-  }
+    constructor() {
+        this.startLanguageService(this);
+    }
 
-  dispose(): Thenable<void> {
-    return this.stopLanguageService();
-  }
+    dispose(): Thenable<void> {
+        return this.stopLanguageService();
+    }
 
-  private spawnServer(client: LanguageClient, rPath: string, args: readonly string[], options: CommonOptions): DisposableProcess {
-    const childProcess = spawn(rPath, args, options);
-    client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) started`);
-    childProcess.stderr.on('data', (chunk: Buffer) => {
-      client.outputChannel.appendLine(chunk.toString());
-    });
-    childProcess.on('exit', (code, signal) => {
-      client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) exited ` +
-        (signal ? `from signal ${signal}` : `with exit code ${code}`));
-      if (code !== 0) {
-        if (code === 10) {
-          // languageserver is not installed.
-          void promptToInstallRPackage(
-            'languageserver', 'lsp.promptToInstall', options.cwd,
-            'R package {languageserver} is required to enable R language service features such as code completion, function signature, find references, etc. Do you want to install it?',
-            'You may need to reopen an R file to start the language service after the package is installed.'
-          );
+    private spawnServer(client: LanguageClient, rPath: string, args: readonly string[], options: CommonOptions): DisposableProcess {
+        const childProcess = spawn(rPath, args, options);
+        client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) started`);
+        childProcess.stderr.on('data', (chunk: Buffer) => {
+            client.outputChannel.appendLine(chunk.toString());
+        });
+        childProcess.on('exit', (code, signal) => {
+            client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) exited ` +
+                (signal ? `from signal ${signal}` : `with exit code ${code}`));
+            if (code !== 0) {
+                if (code === 10) {
+                    // languageserver is not installed.
+                    void promptToInstallRPackage(
+                        'languageserver', 'lsp.promptToInstall', options.cwd,
+                        'R package {languageserver} is required to enable R language service features such as code completion, function signature, find references, etc. Do you want to install it?',
+                        'You may need to reopen an R file to start the language service after the package is installed.'
+                    );
+                } else {
+                    client.outputChannel.show();
+                }
+            }
+            void client.stop();
+        });
+        return childProcess;
+    }
+
+    private async createClient(config: WorkspaceConfiguration, selector: DocumentFilter[],
+        cwd: string, workspaceFolder: WorkspaceFolder, outputChannel: OutputChannel): Promise<LanguageClient> {
+
+        let client: LanguageClient;
+
+        const debug = config.get<boolean>('lsp.debug');
+        const rPath = await getRpath();
+        if (debug) {
+            console.log(`R path: ${rPath}`);
+        }
+        const use_stdio = config.get<boolean>('lsp.use_stdio');
+        const env = Object.create(process.env);
+        env.VSCR_LSP_DEBUG = debug ? 'TRUE' : 'FALSE';
+        env.VSCR_LIB_PATHS = getRLibPaths();
+
+        const lang = config.get<string>('lsp.lang');
+        if (lang !== '') {
+            env.LANG = lang;
+        } else if (env.LANG === undefined) {
+            env.LANG = 'en_US.UTF-8';
+        }
+
+        if (debug) {
+            console.log(`LANG: ${env.LANG}`);
+        }
+
+        const rScriptPath = extensionContext.asAbsolutePath('R/languageServer.R');
+        const options = { cwd: cwd, env: env };
+        const args = config.get<string[]>('lsp.args').concat(
+            '--silent',
+            '--slave',
+            '--no-save',
+            '--no-restore',
+            '-f',
+            rScriptPath
+        );
+
+        const tcpServerOptions = () => new Promise<DisposableProcess | StreamInfo>((resolve, reject) => {
+            // Use a TCP socket because of problems with blocking STDIO
+            const server = net.createServer(socket => {
+                // 'connection' listener
+                console.log('R process connected');
+                socket.on('end', () => {
+                    console.log('R process disconnected');
+                });
+                socket.on('error', (e: Error) => {
+                    console.log(`R process error: ${e.message}`);
+                    reject(e);
+                });
+                server.close();
+                resolve({ reader: socket, writer: socket });
+            });
+            // Listen on random port
+            server.listen(0, '127.0.0.1', () => {
+                const port = (server.address() as net.AddressInfo).port;
+                env.VSCR_LSP_PORT = String(port);
+                return this.spawnServer(client, rPath, args, options);
+            });
+        });
+
+        // Options to control the language client
+        const clientOptions: LanguageClientOptions = {
+            // Register the server for selected R documents
+            documentSelector: selector,
+            uriConverters: {
+                // VS Code by default %-encodes even the colon after the drive letter
+                // NodeJS handles it much better
+                code2Protocol: uri => new url.URL(uri.toString(true)).toString(),
+                protocol2Code: str => Uri.parse(str)
+            },
+            workspaceFolder: workspaceFolder,
+            outputChannel: outputChannel,
+            synchronize: {
+                // Synchronize the setting section 'r' to the server
+                configurationSection: 'r.lsp',
+                fileEvents: workspace.createFileSystemWatcher('**/*.{R,r}'),
+            },
+            revealOutputChannelOn: RevealOutputChannelOn.Never,
+            errorHandler: {
+                error: () => ErrorAction.Shutdown,
+                closed: () => CloseAction.DoNotRestart,
+            },
+        };
+
+        // Create the language client and start the client.
+        if (use_stdio && process.platform !== 'win32') {
+            client = new LanguageClient('r', 'R Language Server', { command: rPath, args: args, options: options }, clientOptions);
         } else {
-          client.outputChannel.show();
+            client = new LanguageClient('r', 'R Language Server', tcpServerOptions, clientOptions);
         }
-      }
-      void client.stop();
-    });
-    return childProcess;
-  }
-
-  private async createClient(config: WorkspaceConfiguration, selector: DocumentFilter[],
-    cwd: string, workspaceFolder: WorkspaceFolder, outputChannel: OutputChannel): Promise<LanguageClient> {
-
-    let client: LanguageClient;
-
-    const debug = config.get<boolean>('lsp.debug');
-    const rPath = await getRpath();
-    if (debug) {
-      console.log(`R path: ${rPath}`);
-    }
-    const use_stdio = config.get<boolean>('lsp.use_stdio');
-    const env = Object.create(process.env);
-    env.VSCR_LSP_DEBUG = debug ? 'TRUE' : 'FALSE';
-    env.VSCR_LIB_PATHS = getRLibPaths();
-
-    const lang = config.get<string>('lsp.lang');
-    if (lang !== '') {
-      env.LANG = lang;
-    } else if (env.LANG === undefined) {
-      env.LANG = 'en_US.UTF-8';
+        return client;
     }
 
-    if (debug) {
-      console.log(`LANG: ${env.LANG}`);
-    }
-
-    const rScriptPath = extensionContext.asAbsolutePath('R/languageServer.R');
-    const options = { cwd: cwd, env: env };
-    const args = config.get<string[]>('lsp.args').concat(
-      '--silent',
-      '--slave',
-      '--no-save',
-      '--no-restore',
-      '-f',
-      rScriptPath
-    );
-
-    const tcpServerOptions = () => new Promise<DisposableProcess | StreamInfo>((resolve, reject) => {
-      // Use a TCP socket because of problems with blocking STDIO
-      const server = net.createServer(socket => {
-        // 'connection' listener
-        console.log('R process connected');
-        socket.on('end', () => {
-          console.log('R process disconnected');
-        });
-        socket.on('error', (e: Error) => {
-          console.log(`R process error: ${e.message}`);
-          reject(e);
-        });
-        server.close();
-        resolve({ reader: socket, writer: socket });
-      });
-      // Listen on random port
-      server.listen(0, '127.0.0.1', () => {
-        const port = (server.address() as net.AddressInfo).port;
-        env.VSCR_LSP_PORT = String(port);
-        return this.spawnServer(client, rPath, args, options);
-      });
-    });
-
-    // Options to control the language client
-    const clientOptions: LanguageClientOptions = {
-      // Register the server for selected R documents
-      documentSelector: selector,
-      uriConverters: {
-        // VS Code by default %-encodes even the colon after the drive letter
-        // NodeJS handles it much better
-        code2Protocol: uri => new url.URL(uri.toString(true)).toString(),
-        protocol2Code: str => Uri.parse(str)
-      },
-      workspaceFolder: workspaceFolder,
-      outputChannel: outputChannel,
-      synchronize: {
-        // Synchronize the setting section 'r' to the server
-        configurationSection: 'r.lsp',
-        fileEvents: workspace.createFileSystemWatcher('**/*.{R,r}'),
-      },
-      revealOutputChannelOn: RevealOutputChannelOn.Never,
-      errorHandler: {
-        error: () => ErrorAction.Shutdown,
-        closed: () => CloseAction.DoNotRestart,
-      },
-    };
-
-    // Create the language client and start the client.
-    if (use_stdio && process.platform !== 'win32') {
-      client = new LanguageClient('r', 'R Language Server', { command: rPath, args: args, options: options }, clientOptions);
-    } else {
-      client = new LanguageClient('r', 'R Language Server', tcpServerOptions, clientOptions);
-    }
-    return client;
-  }
-
-  private checkClient(name: string): boolean {
-    if (this.initSet.has(name)) {
-      return true;
-    }
-    this.initSet.add(name);
-    const client = this.clients.get(name);
-    return client && client.needsStop();
-  }
-
-  private getKey(uri: Uri): string {
-    switch (uri.scheme) {
-      case 'untitled':
-        return uri.scheme;
-      case 'vscode-notebook-cell':
-        return `vscode-notebook:${uri.fsPath}`;
-      default:
-        return uri.toString(true);
-    }
-  }
-
-  private startLanguageService(self: LanguageService): void {
-    const config = workspace.getConfiguration('r');
-    const outputChannel: OutputChannel = window.createOutputChannel('R Language Server');
-
-    async function didOpenTextDocument(document: TextDocument) {
-      if (document.uri.scheme !== 'file' && document.uri.scheme !== 'untitled' && document.uri.scheme !== 'vscode-notebook-cell') {
-        return;
-      }
-
-      if (document.languageId !== 'r' && document.languageId !== 'rmd') {
-        return;
-      }
-
-      const folder = workspace.getWorkspaceFolder(document.uri);
-
-      // Each notebook uses a server started from parent folder
-      if (document.uri.scheme === 'vscode-notebook-cell') {
-        const key = self.getKey(document.uri);
-        if (!self.checkClient(key)) {
-          console.log(`Start language server for ${document.uri.toString(true)}`);
-          const documentSelector: DocumentFilter[] = [
-            { scheme: 'vscode-notebook-cell', language: 'r', pattern: `${document.uri.fsPath}` },
-          ];
-          const client = await self.createClient(config, documentSelector,
-            path.dirname(document.uri.fsPath), folder, outputChannel);
-          if (client) {
-            extensionContext.subscriptions.push(client.start());
-            self.clients.set(key, client);
-          }
-          self.initSet.delete(key);
+    private checkClient(name: string): boolean {
+        if (this.initSet.has(name)) {
+            return true;
         }
-        return;
-      }
+        this.initSet.add(name);
+        const client = this.clients.get(name);
+        return client && client.needsStop();
+    }
 
-      if (folder) {
-
-        // Each workspace uses a server started from the workspace folder
-        const key = self.getKey(folder.uri);
-        if (!self.checkClient(key)) {
-          console.log(`Start language server for ${document.uri.toString(true)}`);
-          const pattern = `${folder.uri.fsPath}/**/*`;
-          const documentSelector: DocumentFilter[] = [
-            { scheme: 'file', language: 'r', pattern: pattern },
-            { scheme: 'file', language: 'rmd', pattern: pattern },
-          ];
-          const client = await self.createClient(config, documentSelector, folder.uri.fsPath, folder, outputChannel);
-          if (client) {
-            extensionContext.subscriptions.push(client.start());
-            self.clients.set(key, client);
-          }
-          self.initSet.delete(key);
+    private getKey(uri: Uri): string {
+        switch (uri.scheme) {
+            case 'untitled':
+                return uri.scheme;
+            case 'vscode-notebook-cell':
+                return `vscode-notebook:${uri.fsPath}`;
+            default:
+                return uri.toString(true);
         }
+    }
 
-      } else {
+    private startLanguageService(self: LanguageService): void {
+        const config = workspace.getConfiguration('r');
+        const outputChannel: OutputChannel = window.createOutputChannel('R Language Server');
 
-        // All untitled documents share a server started from home folder
-        if (document.uri.scheme === 'untitled') {
-          const key = self.getKey(document.uri);
-          if (!self.checkClient(key)) {
-            console.log(`Start language server for ${document.uri.toString(true)}`);
-            const documentSelector: DocumentFilter[] = [
-              { scheme: 'untitled', language: 'r' },
-              { scheme: 'untitled', language: 'rmd' },
-            ];
-            const client = await self.createClient(config, documentSelector, os.homedir(), undefined, outputChannel);
-            if (client) {
-              extensionContext.subscriptions.push(client.start());
-              self.clients.set(key, client);
+        async function didOpenTextDocument(document: TextDocument) {
+            if (document.uri.scheme !== 'file' && document.uri.scheme !== 'untitled' && document.uri.scheme !== 'vscode-notebook-cell') {
+                return;
             }
-            self.initSet.delete(key);
-          }
-          return;
-        }
 
-        // Each file outside workspace uses a server started from parent folder
-        if (document.uri.scheme === 'file') {
-          const key = self.getKey(document.uri);
-          if (!self.checkClient(key)) {
-            console.log(`Start language server for ${document.uri.toString(true)}`);
-            const documentSelector: DocumentFilter[] = [
-              { scheme: 'file', pattern: document.uri.fsPath },
-            ];
-            const client = await self.createClient(config, documentSelector,
-              path.dirname(document.uri.fsPath), undefined, outputChannel);
-            if (client) {
-              extensionContext.subscriptions.push(client.start());
-              self.clients.set(key, client);
+            if (document.languageId !== 'r' && document.languageId !== 'rmd') {
+                return;
             }
-            self.initSet.delete(key);
-          }
-          return;
+
+            const folder = workspace.getWorkspaceFolder(document.uri);
+
+            // Each notebook uses a server started from parent folder
+            if (document.uri.scheme === 'vscode-notebook-cell') {
+                const key = self.getKey(document.uri);
+                if (!self.checkClient(key)) {
+                    console.log(`Start language server for ${document.uri.toString(true)}`);
+                    const documentSelector: DocumentFilter[] = [
+                        { scheme: 'vscode-notebook-cell', language: 'r', pattern: `${document.uri.fsPath}` },
+                    ];
+                    const client = await self.createClient(config, documentSelector,
+                        path.dirname(document.uri.fsPath), folder, outputChannel);
+                    if (client) {
+                        extensionContext.subscriptions.push(client.start());
+                        self.clients.set(key, client);
+                    }
+                    self.initSet.delete(key);
+                }
+                return;
+            }
+
+            if (folder) {
+
+                // Each workspace uses a server started from the workspace folder
+                const key = self.getKey(folder.uri);
+                if (!self.checkClient(key)) {
+                    console.log(`Start language server for ${document.uri.toString(true)}`);
+                    const pattern = `${folder.uri.fsPath}/**/*`;
+                    const documentSelector: DocumentFilter[] = [
+                        { scheme: 'file', language: 'r', pattern: pattern },
+                        { scheme: 'file', language: 'rmd', pattern: pattern },
+                    ];
+                    const client = await self.createClient(config, documentSelector, folder.uri.fsPath, folder, outputChannel);
+                    if (client) {
+                        extensionContext.subscriptions.push(client.start());
+                        self.clients.set(key, client);
+                    }
+                    self.initSet.delete(key);
+                }
+
+            } else {
+
+                // All untitled documents share a server started from home folder
+                if (document.uri.scheme === 'untitled') {
+                    const key = self.getKey(document.uri);
+                    if (!self.checkClient(key)) {
+                        console.log(`Start language server for ${document.uri.toString(true)}`);
+                        const documentSelector: DocumentFilter[] = [
+                            { scheme: 'untitled', language: 'r' },
+                            { scheme: 'untitled', language: 'rmd' },
+                        ];
+                        const client = await self.createClient(config, documentSelector, os.homedir(), undefined, outputChannel);
+                        if (client) {
+                            extensionContext.subscriptions.push(client.start());
+                            self.clients.set(key, client);
+                        }
+                        self.initSet.delete(key);
+                    }
+                    return;
+                }
+
+                // Each file outside workspace uses a server started from parent folder
+                if (document.uri.scheme === 'file') {
+                    const key = self.getKey(document.uri);
+                    if (!self.checkClient(key)) {
+                        console.log(`Start language server for ${document.uri.toString(true)}`);
+                        const documentSelector: DocumentFilter[] = [
+                            { scheme: 'file', pattern: document.uri.fsPath },
+                        ];
+                        const client = await self.createClient(config, documentSelector,
+                            path.dirname(document.uri.fsPath), undefined, outputChannel);
+                        if (client) {
+                            extensionContext.subscriptions.push(client.start());
+                            self.clients.set(key, client);
+                        }
+                        self.initSet.delete(key);
+                    }
+                    return;
+                }
+            }
         }
-      }
+
+        function didCloseTextDocument(document: TextDocument): void {
+            if (document.uri.scheme === 'untitled') {
+                const result = workspace.textDocuments.find((doc) => doc.uri.scheme === 'untitled');
+                if (result) {
+                    // Stop the language server when all untitled documents are closed.
+                    return;
+                }
+            }
+
+            if (document.uri.scheme === 'vscode-notebook-cell') {
+                const result = workspace.textDocuments.find((doc) =>
+                    doc.uri.scheme === document.uri.scheme && doc.uri.fsPath === document.uri.fsPath);
+                if (result) {
+                    // Stop the language server when all cell documents are closed (notebook closed).
+                    return;
+                }
+            }
+
+            // Stop the language server when single file outside workspace is closed, or the above cases.
+            const key = self.getKey(document.uri);
+            const client = self.clients.get(key);
+            if (client) {
+                self.clients.delete(key);
+                self.initSet.delete(key);
+                void client.stop();
+            }
+        }
+
+        workspace.onDidOpenTextDocument(didOpenTextDocument);
+        workspace.onDidCloseTextDocument(didCloseTextDocument);
+        workspace.textDocuments.forEach((doc) => void didOpenTextDocument(doc));
+        workspace.onDidChangeWorkspaceFolders((event) => {
+            for (const folder of event.removed) {
+                const key = self.getKey(folder.uri);
+                const client = self.clients.get(key);
+                if (client) {
+                    self.clients.delete(key);
+                    self.initSet.delete(key);
+                    void client.stop();
+                }
+            }
+        });
     }
 
-    function didCloseTextDocument(document: TextDocument): void {
-      if (document.uri.scheme === 'untitled') {
-        const result = workspace.textDocuments.find((doc) => doc.uri.scheme === 'untitled');
-        if (result) {
-          // Stop the language server when all untitled documents are closed.
-          return;
+    private stopLanguageService(): Thenable<void> {
+        const promises: Thenable<void>[] = [];
+        for (const client of this.clients.values()) {
+            promises.push(client.stop());
         }
-      }
-
-      if (document.uri.scheme === 'vscode-notebook-cell') {
-        const result = workspace.textDocuments.find((doc) =>
-          doc.uri.scheme === document.uri.scheme && doc.uri.fsPath === document.uri.fsPath);
-        if (result) {
-          // Stop the language server when all cell documents are closed (notebook closed).
-          return;
-        }
-      }
-
-      // Stop the language server when single file outside workspace is closed, or the above cases.
-      const key = self.getKey(document.uri);
-      const client = self.clients.get(key);
-      if (client) {
-        self.clients.delete(key);
-        self.initSet.delete(key);
-        void client.stop();
-      }
+        return Promise.all(promises).then(() => undefined);
     }
-
-    workspace.onDidOpenTextDocument(didOpenTextDocument);
-    workspace.onDidCloseTextDocument(didCloseTextDocument);
-    workspace.textDocuments.forEach((doc) => void didOpenTextDocument(doc));
-    workspace.onDidChangeWorkspaceFolders((event) => {
-      for (const folder of event.removed) {
-        const key = self.getKey(folder.uri);
-        const client = self.clients.get(key);
-        if (client) {
-          self.clients.delete(key);
-          self.initSet.delete(key);
-          void client.stop();
-        }
-      }
-    });
-  }
-
-  private stopLanguageService(): Thenable<void> {
-    const promises: Thenable<void>[] = [];
-    for (const client of this.clients.values()) {
-      promises.push(client.stop());
-    }
-    return Promise.all(promises).then(() => undefined);
-  }
 }

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -204,9 +204,9 @@ function getGuestImageHtml(content: string) {
 <!doctype HTML>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style type="text/css">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
     body {
         color: black;
         background-color: var(--vscode-editor-background);
@@ -219,10 +219,10 @@ function getGuestImageHtml(content: string) {
         right: 0;
         margin: auto;
     }
-  </style>
+    </style>
 </head>
 <body>
-  <img src = "data:image/png;base64, ${String(content)}">
+    <img src = "data:image/png;base64, ${String(content)}">
 </body>
 </html>
 `;

--- a/src/plotViewer/httpgdTypes.d.ts
+++ b/src/plotViewer/httpgdTypes.d.ts
@@ -15,7 +15,7 @@ export interface HttpgdPlot<T> {
 
     // data of the plot
     data: T;
-    
+
     // Size
     height: number;
     width: number;
@@ -47,14 +47,14 @@ export class IHttpgdViewer {
 
     // active plots
     plots: HttpgdPlot<string>[];
-    
+
     // Id of the currently viewed plot
     activePlot?: HttpgdPlotId;
-    
+
     // Size of the view area:
     viewHeight: number;
     viewWidth: number;
-    
+
     // constructor called by the session watcher if a corresponding function was called in R
     // creates a new api instance itself
     constructor(options: HttpgdViewerOptions);
@@ -65,17 +65,17 @@ export class IHttpgdViewer {
 
     // Called to create a new webview if the user closed the old one:
     show(preserveFocus?: boolean): void;
-    
+
     // focus a specific plot id
     focusPlot(id: HttpgdPlotId): void;
-    
+
     // navigate through plots (supply `true` to go to end/beginning of list)
     nextPlot(last?: boolean): void;
     prevPlot(first?: boolean): void;
-    
+
     // restore closed plots, show most recent plot etc.?
     resetPlots(): void;
-    
+
     // export plot
     // if no format supplied, show a quickpick menu etc.
     // if no filename supplied, show selector window

--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -300,7 +300,7 @@ export class HttpgdViewer implements IHttpgdViewer {
 
     protected refreshTimeout?: NodeJS.Timeout;
     readonly refreshTimeoutLength: number = 10;
-    
+
     private lastExportUri?: vscode.Uri;
 
     readonly htmlTemplate: string;
@@ -574,14 +574,14 @@ export class HttpgdViewer implements IHttpgdViewer {
         this.plotHeight = plt.height;
         this.updatePlot(plt);
     }
-    
+
     protected async refreshPlotsDelayed(plotsIdResponse: HttpgdIdResponse[], redraw: boolean = false, force: boolean = false): Promise<void> {
         if(this.refreshTimeoutLength === 0){
             await this.refreshPlots(plotsIdResponse, redraw, force);
         } else{
             clearTimeout(this.refreshTimeout);
             this.refreshTimeout = setTimeout(() => {
-                void this.refreshPlots(plotsIdResponse, redraw, force).then(() => 
+                void this.refreshPlots(plotsIdResponse, redraw, force).then(() =>
                     this.refreshTimeout = undefined
                 );
             }, this.refreshTimeoutLength);
@@ -644,7 +644,7 @@ export class HttpgdViewer implements IHttpgdViewer {
 
     // get content of a single plot
     protected async getPlotContent(id: HttpgdPlotId, width: number, height: number, zoom: number): Promise<HttpgdPlot<string>> {
-        
+
         const args = {
             id: id,
             height: height,
@@ -652,10 +652,10 @@ export class HttpgdViewer implements IHttpgdViewer {
             zoom: zoom,
             renderer: 'svgp'
         };
-        
+
         const plotContent = await this.api.getPlot(args);
         const svg = await plotContent?.text() || '';
-        
+
         const plt: HttpgdPlot<string> = {
             id: id,
             data: svg,
@@ -833,10 +833,10 @@ export class HttpgdViewer implements IHttpgdViewer {
         const plt = await this.api.getPlot({
             id: this.activePlot,
             renderer: rendererId
-        }) as unknown as Response; // I am not sure why eslint thinks this is the 
-        // browser Response object and not the node-fetch one. 
+        }) as unknown as Response; // I am not sure why eslint thinks this is the
+        // browser Response object and not the node-fetch one.
         // cross-fetch problem or config problem in vscode-r?
-        
+
         const dest = fs.createWriteStream(outFile);
         dest.on('error', (err) => void vscode.window.showErrorMessage(
             `Export failed: ${err.message}`

--- a/src/plotViewer/webviewMessages.d.ts
+++ b/src/plotViewer/webviewMessages.d.ts
@@ -4,26 +4,26 @@
 
 
 interface VsCode {
-  postMessage: (msg: OutMessage) => void;
-  setState: (state: string) => void;
+    postMessage: (msg: OutMessage) => void;
+    setState: (state: string) => void;
 }
 declare function acquireVsCodeApi(): VsCode;
 
 
 
 export interface IMessage {
-  message: string;
+    message: string;
 }
 
 export interface ResizeMessage extends IMessage {
-  message: 'resize',
-  height: number,
-  width: number,
-  userTriggered: boolean
+    message: 'resize',
+    height: number,
+    width: number,
+    userTriggered: boolean
 }
 export interface LogMessage extends IMessage {
-  message: 'log',
-  body: any
+    message: 'log',
+    body: any
 }
 
 export type OutMessage = ResizeMessage | LogMessage;
@@ -31,41 +31,41 @@ export type OutMessage = ResizeMessage | LogMessage;
 
 
 export interface UpdatePlotMessage extends IMessage {
-  message: 'updatePlot',
-  svg: string,
-  plotId: string
+    message: 'updatePlot',
+    svg: string,
+    plotId: string
 }
 
 export interface FocusPlotMessage extends IMessage {
-  message: 'focusPlot',
-  plotId: string
+    message: 'focusPlot',
+    plotId: string
 }
 
 export interface ToggleStyleMessage extends IMessage {
-  message: 'toggleStyle',
-  useOverwrites: boolean
+    message: 'toggleStyle',
+    useOverwrites: boolean
 }
 
 export interface ToggleFullWindowMessage extends IMessage {
-  message: 'toggleFullWindow',
-  useFullWindow: boolean
+    message: 'toggleFullWindow',
+    useFullWindow: boolean
 }
 
 
 export type PreviewPlotLayout = 'multirow' | 'scroll' | 'hidden';
 export interface PreviewPlotLayoutMessage extends IMessage {
-  message: 'togglePreviewPlotLayout',
-  style: PreviewPlotLayout
+    message: 'togglePreviewPlotLayout',
+    style: PreviewPlotLayout
 }
 
 export interface HidePlotMessage extends IMessage {
-  message: 'hidePlot',
-  plotId: string
+    message: 'hidePlot',
+    plotId: string
 }
 
 export interface AddPlotMessage extends IMessage {
-  message: 'addPlot',
-  html: string
+    message: 'addPlot',
+    html: string
 }
 
 export type InMessage = UpdatePlotMessage | FocusPlotMessage | ToggleStyleMessage | HidePlotMessage | AddPlotMessage | PreviewPlotLayoutMessage | ToggleFullWindowMessage;

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -77,11 +77,12 @@ async function openTmpCSV(pathToTmpCsv: string, tmpDir: string) {
     }
 
     // Open CSV in Excel Viewer and clean up.
-    void workspace.openTextDocument(pathToTmpCsv)
-             .then(async (file) => {
-                await commands.executeCommand('csv.preview', file.uri);
-                removeSync(tmpDir);
-            });
+    void workspace.openTextDocument(pathToTmpCsv).then(
+        async (file) => {
+            await commands.executeCommand('csv.preview', file.uri);
+            removeSync(tmpDir);
+        }
+    );
 }
 
 async function waitForFileToFinish(filePath: string) {
@@ -127,9 +128,11 @@ function checkcsv() {
     if (iscsv !== undefined && iscsv.isActive) {
         return true;
     }
-    void window.showInformationMessage('This function need to install `GrapeCity.gc-excelviewer`, will you install?',
-                                       'Yes', 'No')
-          .then((select) => {
+    void window.showInformationMessage(
+        'This function need to install `GrapeCity.gc-excelviewer`, will you install?',
+        'Yes',
+        'No'
+    ).then((select) => {
         if (select === 'Yes') {
             void commands.executeCommand('workbench.extensions.installExtension', 'GrapeCity.gc-excelviewer');
         }

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -8,455 +8,455 @@ export { RMarkdownPreviewManager } from './preview';
 export { newDraft } from './draft';
 
 function isRDocument(document: vscode.TextDocument) {
-  return (document.languageId === 'r');
+    return (document.languageId === 'r');
 }
 
 function isRChunkLine(text: string) {
-  return (!!text.match(/^#+\s*%%/g));
+    return (!!text.match(/^#+\s*%%/g));
 }
 
 function isChunkStartLine(text: string, isRDoc: boolean) {
-  if (isRDoc) {
-    return (isRChunkLine(text));
-  } else {
-    return (!!text.match(/^\s*```+\s*\{\w+\s*.*$/g));
-  }
+    if (isRDoc) {
+        return (isRChunkLine(text));
+    } else {
+        return (!!text.match(/^\s*```+\s*\{\w+\s*.*$/g));
+    }
 }
 
 function isChunkEndLine(text: string, isRDoc: boolean) {
-  if (isRDoc) {
-    return (isRChunkLine(text));
-  } else {
-    return (!!text.match(/^\s*```+\s*$/g));
-  }
+    if (isRDoc) {
+        return (isRChunkLine(text));
+    } else {
+        return (!!text.match(/^\s*```+\s*$/g));
+    }
 }
 
 function getChunkLanguage(text: string) {
-  return text.replace(/^\s*```+\s*\{(\w+)\s*.*\}\s*$/g, '$1').toLowerCase();
+    return text.replace(/^\s*```+\s*\{(\w+)\s*.*\}\s*$/g, '$1').toLowerCase();
 }
 
 function getChunkOptions(text: string) {
-  return text.replace(/^\s*```+\s*\{\w+\s*,?\s*(.*)\s*\}\s*$/g, '$1');
+    return text.replace(/^\s*```+\s*\{\w+\s*,?\s*(.*)\s*\}\s*$/g, '$1');
 }
 
 function getChunkEval(chunkOptions: string) {
-  return (!chunkOptions.match(/eval\s*=\s*(F|FALSE)/g));
+    return (!chunkOptions.match(/eval\s*=\s*(F|FALSE)/g));
 }
 
 export class RMarkdownCodeLensProvider implements vscode.CodeLensProvider {
-  private codeLenses: vscode.CodeLens[] = [];
-  private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
-  private readonly decoration: vscode.TextEditorDecorationType;
-  public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+    private codeLenses: vscode.CodeLens[] = [];
+    private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+    private readonly decoration: vscode.TextEditorDecorationType;
+    public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
 
-  constructor() {
-    this.decoration = vscode.window.createTextEditorDecorationType({
-      isWholeLine: true,
-      backgroundColor: config().get('rmarkdown.chunkBackgroundColor'),
-    });
-  }
+    constructor() {
+        this.decoration = vscode.window.createTextEditorDecorationType({
+            isWholeLine: true,
+            backgroundColor: config().get('rmarkdown.chunkBackgroundColor'),
+        });
+    }
 
-  public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-    this.codeLenses = [];
-    const chunks = getChunks(document);
-    const chunkRanges: vscode.Range[] = [];
-    const rmdCodeLensCommands: string[] = config().get('rmarkdown.codeLensCommands');
+    public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+        this.codeLenses = [];
+        const chunks = getChunks(document);
+        const chunkRanges: vscode.Range[] = [];
+        const rmdCodeLensCommands: string[] = config().get('rmarkdown.codeLensCommands');
 
-    // Iterate through all code chunks for getting chunk information for both CodeLens and chunk background color (set by `editor.setDecorations`)
-    for (let i = 1; i <= chunks.length; i++) {
-      const chunk = chunks.find(e => e.id === i);
-      const chunkRange = chunk.chunkRange;
-      const line = chunk.startLine;
-      chunkRanges.push(chunkRange);
+        // Iterate through all code chunks for getting chunk information for both CodeLens and chunk background color (set by `editor.setDecorations`)
+        for (let i = 1; i <= chunks.length; i++) {
+            const chunk = chunks.find(e => e.id === i);
+            const chunkRange = chunk.chunkRange;
+            const line = chunk.startLine;
+            chunkRanges.push(chunkRange);
 
-      // Enable/disable only CodeLens, without affecting chunk background color.
-      if (config().get<boolean>('rmarkdown.enableCodeLens') && (chunk.language === 'r') || isRDocument(document)) {
-        if (token.isCancellationRequested) {
-          break;
+            // Enable/disable only CodeLens, without affecting chunk background color.
+            if (config().get<boolean>('rmarkdown.enableCodeLens') && (chunk.language === 'r') || isRDocument(document)) {
+                if (token.isCancellationRequested) {
+                    break;
+                }
+                this.codeLenses.push(
+                    new vscode.CodeLens(chunkRange, {
+                        title: 'Run Chunk',
+                        tooltip: 'Run current chunk',
+                        command: 'r.runCurrentChunk',
+                        arguments: [chunks, line]
+                    }),
+                    new vscode.CodeLens(chunkRange, {
+                        title: 'Run Above',
+                        tooltip: 'Run all chunks above',
+                        command: 'r.runAboveChunks',
+                        arguments: [chunks, line]
+                    }),
+                    new vscode.CodeLens(chunkRange, {
+                        title: 'Run Current & Below',
+                        tooltip: 'Run current and all chunks below',
+                        command: 'r.runCurrentAndBelowChunks',
+                        arguments: [chunks, line]
+                    }),
+                    new vscode.CodeLens(chunkRange, {
+                        title: 'Run Below',
+                        tooltip: 'Run all chunks below',
+                        command: 'r.runBelowChunks',
+                        arguments: [chunks, line]
+                    }),
+                    new vscode.CodeLens(chunkRange, {
+                        title: 'Run Previous',
+                        tooltip: 'Run previous chunk',
+                        command: 'r.runPreviousChunk',
+                        arguments: [chunks, line]
+                    }),
+                    new vscode.CodeLens(chunkRange, {
+                        title: 'Run Next',
+                        tooltip: 'Run next chunk',
+                        command: 'r.runNextChunk',
+                        arguments: [chunks, line]
+                    }),
+                    new vscode.CodeLens(chunkRange, {
+                        title: 'Run All',
+                        tooltip: 'Run all chunks',
+                        command: 'r.runAllChunks',
+                        arguments: [chunks]
+                    }),
+                    new vscode.CodeLens(chunkRange, {
+                        title: 'Go Previous',
+                        tooltip: 'Go to previous chunk',
+                        command: 'r.goToPreviousChunk',
+                        arguments: [chunks, line]
+                    }),
+                    new vscode.CodeLens(chunkRange, {
+                        title: 'Go Next',
+                        tooltip: 'Go to next chunk',
+                        command: 'r.goToNextChunk',
+                        arguments: [chunks, line]
+                    }),
+                    new vscode.CodeLens(chunkRange, {
+                        title: 'Select Chunk',
+                        tooltip: 'Select current chunk',
+                        command: 'r.selectCurrentChunk',
+                        arguments: [chunks, line]
+                    }),
+                );
+            }
         }
-        this.codeLenses.push(
-          new vscode.CodeLens(chunkRange, {
-            title: 'Run Chunk',
-            tooltip: 'Run current chunk',
-            command: 'r.runCurrentChunk',
-            arguments: [chunks, line]
-          }),
-          new vscode.CodeLens(chunkRange, {
-            title: 'Run Above',
-            tooltip: 'Run all chunks above',
-            command: 'r.runAboveChunks',
-            arguments: [chunks, line]
-          }),
-          new vscode.CodeLens(chunkRange, {
-            title: 'Run Current & Below',
-            tooltip: 'Run current and all chunks below',
-            command: 'r.runCurrentAndBelowChunks',
-            arguments: [chunks, line]
-          }),
-          new vscode.CodeLens(chunkRange, {
-            title: 'Run Below',
-            tooltip: 'Run all chunks below',
-            command: 'r.runBelowChunks',
-            arguments: [chunks, line]
-          }),
-          new vscode.CodeLens(chunkRange, {
-            title: 'Run Previous',
-            tooltip: 'Run previous chunk',
-            command: 'r.runPreviousChunk',
-            arguments: [chunks, line]
-          }),
-          new vscode.CodeLens(chunkRange, {
-            title: 'Run Next',
-            tooltip: 'Run next chunk',
-            command: 'r.runNextChunk',
-            arguments: [chunks, line]
-          }),
-          new vscode.CodeLens(chunkRange, {
-            title: 'Run All',
-            tooltip: 'Run all chunks',
-            command: 'r.runAllChunks',
-            arguments: [chunks]
-          }),
-          new vscode.CodeLens(chunkRange, {
-            title: 'Go Previous',
-            tooltip: 'Go to previous chunk',
-            command: 'r.goToPreviousChunk',
-            arguments: [chunks, line]
-          }),
-          new vscode.CodeLens(chunkRange, {
-            title: 'Go Next',
-            tooltip: 'Go to next chunk',
-            command: 'r.goToNextChunk',
-            arguments: [chunks, line]
-          }),
-          new vscode.CodeLens(chunkRange, {
-            title: 'Select Chunk',
-            tooltip: 'Select current chunk',
-            command: 'r.selectCurrentChunk',
-            arguments: [chunks, line]
-          }),
-        );
-      }
-    }
 
-    for (const editor of vscode.window.visibleTextEditors) {
-      if (editor.document.uri.toString() === document.uri.toString()) {
-        editor.setDecorations(this.decoration, chunkRanges);
-      }
-    }
+        for (const editor of vscode.window.visibleTextEditors) {
+            if (editor.document.uri.toString() === document.uri.toString()) {
+                editor.setDecorations(this.decoration, chunkRanges);
+            }
+        }
 
-    // For default options, both options and sort order are based on options specified in package.json.
-    // For user-specified options, both options and sort order are based on options specified in settings UI or settings.json.
-    return this.codeLenses.
-      filter(e => rmdCodeLensCommands.includes(e.command.command)).
-      sort(function (a, b) {
-        const sorted = rmdCodeLensCommands.indexOf(a.command.command) -
-          rmdCodeLensCommands.indexOf(b.command.command);
-        return sorted;
-      });
-  }
-  public resolveCodeLens(codeLens: vscode.CodeLens): vscode.CodeLens {
-    return codeLens;
-  }
+        // For default options, both options and sort order are based on options specified in package.json.
+        // For user-specified options, both options and sort order are based on options specified in settings UI or settings.json.
+        return this.codeLenses.
+            filter(e => rmdCodeLensCommands.includes(e.command.command)).
+            sort(function (a, b) {
+                const sorted = rmdCodeLensCommands.indexOf(a.command.command) -
+                    rmdCodeLensCommands.indexOf(b.command.command);
+                return sorted;
+            });
+    }
+    public resolveCodeLens(codeLens: vscode.CodeLens): vscode.CodeLens {
+        return codeLens;
+    }
 }
 
 interface RMarkdownChunk {
-  id: number;
-  startLine: number;
-  endLine: number;
-  language: string;
-  options: string;
-  eval: boolean;
-  chunkRange: vscode.Range;
-  codeRange: vscode.Range;
+    id: number;
+    startLine: number;
+    endLine: number;
+    language: string;
+    options: string;
+    eval: boolean;
+    chunkRange: vscode.Range;
+    codeRange: vscode.Range;
 }
 
 // Scan document and return chunk info (e.g. ID, chunk range) from all chunks
 export function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
-  const lines = document.getText().split(/\r?\n/);
-  const chunks: RMarkdownChunk[] = [];
+    const lines = document.getText().split(/\r?\n/);
+    const chunks: RMarkdownChunk[] = [];
 
-  let line = 0;
-  let chunkId = 0;  // One-based index
-  let chunkStartLine: number = undefined;
-  let chunkEndLine: number = undefined;
-  let chunkLanguage: string = undefined;
-  let chunkOptions: string = undefined;
-  let chunkEval: boolean = undefined;
-  const isRDoc = isRDocument(document);
+    let line = 0;
+    let chunkId = 0;  // One-based index
+    let chunkStartLine: number = undefined;
+    let chunkEndLine: number = undefined;
+    let chunkLanguage: string = undefined;
+    let chunkOptions: string = undefined;
+    let chunkEval: boolean = undefined;
+    const isRDoc = isRDocument(document);
 
-  while (line < lines.length) {
-    if (chunkStartLine === undefined) {
-      if (isChunkStartLine(lines[line], isRDoc)) {
-        chunkId++;
-        chunkStartLine = line;
-        chunkLanguage = getChunkLanguage(lines[line]);
-        chunkOptions = getChunkOptions(lines[line]);
-        chunkEval = getChunkEval(chunkOptions);
-      }
-    } else {
-      if (isChunkEndLine(lines[line], isRDoc)) {
-        chunkEndLine = line;
+    while (line < lines.length) {
+        if (chunkStartLine === undefined) {
+            if (isChunkStartLine(lines[line], isRDoc)) {
+                chunkId++;
+                chunkStartLine = line;
+                chunkLanguage = getChunkLanguage(lines[line]);
+                chunkOptions = getChunkOptions(lines[line]);
+                chunkEval = getChunkEval(chunkOptions);
+            }
+        } else {
+            if (isChunkEndLine(lines[line], isRDoc)) {
+                chunkEndLine = line;
 
-        const chunkRange = new vscode.Range(
-          new vscode.Position(chunkStartLine, 0),
-          new vscode.Position(line, lines[line].length)
-        );
-        const codeRange = new vscode.Range(
-          new vscode.Position(chunkStartLine + 1, 0),
-          new vscode.Position(line - 1, lines[line - 1].length)
-        );
+                const chunkRange = new vscode.Range(
+                    new vscode.Position(chunkStartLine, 0),
+                    new vscode.Position(line, lines[line].length)
+                );
+                const codeRange = new vscode.Range(
+                    new vscode.Position(chunkStartLine + 1, 0),
+                    new vscode.Position(line - 1, lines[line - 1].length)
+                );
 
-        chunks.push({
-          id: chunkId, // One-based index
-          startLine: chunkStartLine,
-          endLine: chunkEndLine,
-          language: chunkLanguage,
-          options: chunkOptions,
-          eval: chunkEval,
-          chunkRange: chunkRange,
-          codeRange: codeRange
-        });
+                chunks.push({
+                    id: chunkId, // One-based index
+                    startLine: chunkStartLine,
+                    endLine: chunkEndLine,
+                    language: chunkLanguage,
+                    options: chunkOptions,
+                    eval: chunkEval,
+                    chunkRange: chunkRange,
+                    codeRange: codeRange
+                });
 
-        chunkStartLine = undefined;
-      }
+                chunkStartLine = undefined;
+            }
+        }
+        line++;
     }
-    line++;
-  }
-  return chunks;
+    return chunks;
 }
 
 function getCurrentChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
-  const lines = vscode.window.activeTextEditor.document.getText().split(/\r?\n/);
+    const lines = vscode.window.activeTextEditor.document.getText().split(/\r?\n/);
 
-  let chunkStartLineAtOrAbove = line;
-  // `- 1` to cover edge case when cursor is at 'chunk end line'
-  let chunkEndLineAbove = line - 1;
+    let chunkStartLineAtOrAbove = line;
+    // `- 1` to cover edge case when cursor is at 'chunk end line'
+    let chunkEndLineAbove = line - 1;
 
-  const isRDoc = isRDocument(vscode.window.activeTextEditor.document);
+    const isRDoc = isRDocument(vscode.window.activeTextEditor.document);
 
-  while (chunkStartLineAtOrAbove >= 0 && !isChunkStartLine(lines[chunkStartLineAtOrAbove], isRDoc)) {
-    chunkStartLineAtOrAbove--;
-  }
-
-  while (chunkEndLineAbove >= 0 && !isChunkEndLine(lines[chunkEndLineAbove], isRDoc)) {
-    chunkEndLineAbove--;
-  }
-
-  // Case: Cursor is within chunk
-  if (chunkEndLineAbove < chunkStartLineAtOrAbove) {
-    line = chunkStartLineAtOrAbove;
-  } else {
-    // Cases: Cursor is above the first chunk, at the first chunk or outside of chunk. Find the 'chunk start line' of the next chunk below the cursor.
-    let chunkStartLineBelow = line + 1;
-    while (!isChunkStartLine(lines[chunkStartLineBelow], isRDoc)) {
-      chunkStartLineBelow++;
+    while (chunkStartLineAtOrAbove >= 0 && !isChunkStartLine(lines[chunkStartLineAtOrAbove], isRDoc)) {
+        chunkStartLineAtOrAbove--;
     }
-    line = chunkStartLineBelow;
-  }
-  const currentChunk = chunks.find(i => i.startLine <= line && i.endLine >= line);
-  return currentChunk;
+
+    while (chunkEndLineAbove >= 0 && !isChunkEndLine(lines[chunkEndLineAbove], isRDoc)) {
+        chunkEndLineAbove--;
+    }
+
+    // Case: Cursor is within chunk
+    if (chunkEndLineAbove < chunkStartLineAtOrAbove) {
+        line = chunkStartLineAtOrAbove;
+    } else {
+        // Cases: Cursor is above the first chunk, at the first chunk or outside of chunk. Find the 'chunk start line' of the next chunk below the cursor.
+        let chunkStartLineBelow = line + 1;
+        while (!isChunkStartLine(lines[chunkStartLineBelow], isRDoc)) {
+            chunkStartLineBelow++;
+        }
+        line = chunkStartLineBelow;
+    }
+    const currentChunk = chunks.find(i => i.startLine <= line && i.endLine >= line);
+    return currentChunk;
 }
 
 // Alternative `getCurrentChunk` for cases:
 // - commands (e.g. `selectCurrentChunk`) only make sense when cursor is within chunk
 // - when cursor is outside of chunk, no response is triggered for chunk navigation commands (e.g. `goToPreviousChunk`) and chunk running commands (e.g. `runAboveChunks`)
 function getCurrentChunk__CursorWithinChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
-  return chunks.find(i => i.startLine <= line && i.endLine >= line);
+    return chunks.find(i => i.startLine <= line && i.endLine >= line);
 }
 
 function getPreviousChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
-  const currentChunk = getCurrentChunk(chunks, line);
-  if (currentChunk.id !== 1) {
-    // When cursor is below the last 'chunk end line', the definition of the previous chunk is the last chunk
-    const previousChunkId = currentChunk.endLine < line ? currentChunk.id : currentChunk.id - 1;
-    const previousChunk = chunks.find(i => i.id === previousChunkId);
-    return previousChunk;
-  } else {
-    return (currentChunk);
-  }
+    const currentChunk = getCurrentChunk(chunks, line);
+    if (currentChunk.id !== 1) {
+        // When cursor is below the last 'chunk end line', the definition of the previous chunk is the last chunk
+        const previousChunkId = currentChunk.endLine < line ? currentChunk.id : currentChunk.id - 1;
+        const previousChunk = chunks.find(i => i.id === previousChunkId);
+        return previousChunk;
+    } else {
+        return (currentChunk);
+    }
 }
 
 function getNextChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
-  const currentChunk = getCurrentChunk(chunks, line);
-  if (currentChunk.id !== chunks.length) {
-    // When cursor is above the first 'chunk start line', the definition of the next chunk is the first chunk
-    const nextChunkId = line < currentChunk.startLine ? currentChunk.id : currentChunk.id + 1;
-    const nextChunk = chunks.find(i => i.id === nextChunkId);
-    return nextChunk;
-  } else {
-    return currentChunk;
-  }
+    const currentChunk = getCurrentChunk(chunks, line);
+    if (currentChunk.id !== chunks.length) {
+        // When cursor is above the first 'chunk start line', the definition of the next chunk is the first chunk
+        const nextChunkId = line < currentChunk.startLine ? currentChunk.id : currentChunk.id + 1;
+        const nextChunk = chunks.find(i => i.id === nextChunkId);
+        return nextChunk;
+    } else {
+        return currentChunk;
+    }
 
 }
 
 // Helpers
 function _getChunks() {
-  return getChunks(vscode.window.activeTextEditor.document);
+    return getChunks(vscode.window.activeTextEditor.document);
 }
 function _getStartLine() {
-  return vscode.window.activeTextEditor.selection.start.line;
+    return vscode.window.activeTextEditor.selection.start.line;
 }
 
 export async function runCurrentChunk(chunks: RMarkdownChunk[] = _getChunks(),
-  line: number = _getStartLine()): Promise<void> {
-  const currentChunk = getCurrentChunk(chunks, line);
-  await runChunksInTerm([currentChunk.codeRange]);
+    line: number = _getStartLine()): Promise<void> {
+    const currentChunk = getCurrentChunk(chunks, line);
+    await runChunksInTerm([currentChunk.codeRange]);
 }
 
 export async function runPreviousChunk(chunks: RMarkdownChunk[] = _getChunks(),
-  line: number = _getStartLine()): Promise<void> {
-  const currentChunk = getCurrentChunk(chunks, line);
-  const previousChunk = getPreviousChunk(chunks, line);
+    line: number = _getStartLine()): Promise<void> {
+    const currentChunk = getCurrentChunk(chunks, line);
+    const previousChunk = getPreviousChunk(chunks, line);
 
-  if (previousChunk !== currentChunk) {
-    await runChunksInTerm([previousChunk.codeRange]);
-  }
+    if (previousChunk !== currentChunk) {
+        await runChunksInTerm([previousChunk.codeRange]);
+    }
 
 }
 
 export async function runNextChunk(chunks: RMarkdownChunk[] = _getChunks(),
-  line: number = _getStartLine()): Promise<void> {
-  const currentChunk = getCurrentChunk(chunks, line);
-  const nextChunk = getNextChunk(chunks, line);
+    line: number = _getStartLine()): Promise<void> {
+    const currentChunk = getCurrentChunk(chunks, line);
+    const nextChunk = getNextChunk(chunks, line);
 
-  if (nextChunk !== currentChunk) {
-    await runChunksInTerm([nextChunk.codeRange]);
-  }
+    if (nextChunk !== currentChunk) {
+        await runChunksInTerm([nextChunk.codeRange]);
+    }
 }
 
 export async function runAboveChunks(chunks: RMarkdownChunk[] = _getChunks(),
-  line: number = _getStartLine()): Promise<void> {
-  const currentChunk = getCurrentChunk(chunks, line);
-  const previousChunk = getPreviousChunk(chunks, line);
-  const firstChunkId = 1;
-  const previousChunkId = previousChunk.id;
+    line: number = _getStartLine()): Promise<void> {
+    const currentChunk = getCurrentChunk(chunks, line);
+    const previousChunk = getPreviousChunk(chunks, line);
+    const firstChunkId = 1;
+    const previousChunkId = previousChunk.id;
 
-  const codeRanges: vscode.Range[] = [];
+    const codeRanges: vscode.Range[] = [];
 
-  if (previousChunk !== currentChunk) {
-    for (let i = firstChunkId; i <= previousChunkId; i++) {
-      const chunk = chunks.find(e => e.id === i);
-      if (chunk.eval) {
-        codeRanges.push(chunk.codeRange);
-      }
+    if (previousChunk !== currentChunk) {
+        for (let i = firstChunkId; i <= previousChunkId; i++) {
+            const chunk = chunks.find(e => e.id === i);
+            if (chunk.eval) {
+                codeRanges.push(chunk.codeRange);
+            }
+        }
+        await runChunksInTerm(codeRanges);
     }
-    await runChunksInTerm(codeRanges);
-  }
 }
 
 export async function runBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
-  line: number = _getStartLine()): Promise<void> {
+    line: number = _getStartLine()): Promise<void> {
 
-  const currentChunk = getCurrentChunk(chunks, line);
-  const nextChunk = getNextChunk(chunks, line);
-  const nextChunkId = nextChunk.id;
-  const lastChunkId = chunks.length;
+    const currentChunk = getCurrentChunk(chunks, line);
+    const nextChunk = getNextChunk(chunks, line);
+    const nextChunkId = nextChunk.id;
+    const lastChunkId = chunks.length;
 
-  const codeRanges: vscode.Range[] = [];
-  if (nextChunk !== currentChunk) {
-    for (let i = nextChunkId; i <= lastChunkId; i++) {
-      const chunk = chunks.find(e => e.id === i);
-      if (chunk.eval) {
-        codeRanges.push(chunk.codeRange);
-      }
+    const codeRanges: vscode.Range[] = [];
+    if (nextChunk !== currentChunk) {
+        for (let i = nextChunkId; i <= lastChunkId; i++) {
+            const chunk = chunks.find(e => e.id === i);
+            if (chunk.eval) {
+                codeRanges.push(chunk.codeRange);
+            }
+        }
+        await runChunksInTerm(codeRanges);
     }
-    await runChunksInTerm(codeRanges);
-  }
 }
 
 export async function runCurrentAndBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
-  line: number = _getStartLine()): Promise<void> {
-  const currentChunk = getCurrentChunk(chunks, line);
-  const currentChunkId = currentChunk.id;
-  const lastChunkId = chunks.length;
+    line: number = _getStartLine()): Promise<void> {
+    const currentChunk = getCurrentChunk(chunks, line);
+    const currentChunkId = currentChunk.id;
+    const lastChunkId = chunks.length;
 
-  const codeRanges: vscode.Range[] = [];
+    const codeRanges: vscode.Range[] = [];
 
-  for (let i = currentChunkId; i <= lastChunkId; i++) {
-    const chunk = chunks.find(e => e.id === i);
-    codeRanges.push(chunk.codeRange);
-  }
-  await runChunksInTerm(codeRanges);
+    for (let i = currentChunkId; i <= lastChunkId; i++) {
+        const chunk = chunks.find(e => e.id === i);
+        codeRanges.push(chunk.codeRange);
+    }
+    await runChunksInTerm(codeRanges);
 }
 
 export async function runAllChunks(chunks: RMarkdownChunk[] = _getChunks()): Promise<void> {
 
-  const firstChunkId = 1;
-  const lastChunkId = chunks.length;
+    const firstChunkId = 1;
+    const lastChunkId = chunks.length;
 
-  const codeRanges: vscode.Range[] = [];
+    const codeRanges: vscode.Range[] = [];
 
-  for (let i = firstChunkId; i <= lastChunkId; i++) {
-    const chunk = chunks.find(e => e.id === i);
-    if (chunk.eval) {
-      codeRanges.push(chunk.codeRange);
+    for (let i = firstChunkId; i <= lastChunkId; i++) {
+        const chunk = chunks.find(e => e.id === i);
+        if (chunk.eval) {
+            codeRanges.push(chunk.codeRange);
+        }
     }
-  }
-  await runChunksInTerm(codeRanges);
+    await runChunksInTerm(codeRanges);
 }
 
 async function goToChunk(chunk: RMarkdownChunk) {
-  // Move cursor 1 line below 'chunk start line'
-  const line = chunk.startLine + 1;
-  vscode.window.activeTextEditor.selection = new vscode.Selection(line, 0, line, 0);
-  await vscode.commands.executeCommand('revealLine', { lineNumber: line, at: 'center' });
+    // Move cursor 1 line below 'chunk start line'
+    const line = chunk.startLine + 1;
+    vscode.window.activeTextEditor.selection = new vscode.Selection(line, 0, line, 0);
+    await vscode.commands.executeCommand('revealLine', { lineNumber: line, at: 'center' });
 }
 
 export function goToPreviousChunk(chunks: RMarkdownChunk[] = _getChunks(),
-  line: number = _getStartLine()): void {
-  const previousChunk = getPreviousChunk(chunks, line);
-  void goToChunk(previousChunk);
+    line: number = _getStartLine()): void {
+    const previousChunk = getPreviousChunk(chunks, line);
+    void goToChunk(previousChunk);
 }
 
 export function goToNextChunk(chunks: RMarkdownChunk[] = _getChunks(),
-  line: number = _getStartLine()): void {
-  const nextChunk = getNextChunk(chunks, line);
-  void goToChunk(nextChunk);
+    line: number = _getStartLine()): void {
+    const nextChunk = getNextChunk(chunks, line);
+    void goToChunk(nextChunk);
 }
 
 export function selectCurrentChunk(chunks: RMarkdownChunk[] = _getChunks(),
-  line: number = _getStartLine()): void {
-  const editor = vscode.window.activeTextEditor;
-  const currentChunk = getCurrentChunk__CursorWithinChunk(chunks, line);
-  const lines = editor.document.getText().split(/\r?\n/);
+    line: number = _getStartLine()): void {
+    const editor = vscode.window.activeTextEditor;
+    const currentChunk = getCurrentChunk__CursorWithinChunk(chunks, line);
+    const lines = editor.document.getText().split(/\r?\n/);
 
-  editor.selection = new vscode.Selection(
-    currentChunk.startLine, 0,
-    currentChunk.endLine, lines[currentChunk.endLine].length
-  );
+    editor.selection = new vscode.Selection(
+        currentChunk.startLine, 0,
+        currentChunk.endLine, lines[currentChunk.endLine].length
+    );
 }
 
 export class RMarkdownCompletionItemProvider implements vscode.CompletionItemProvider {
 
-  // obtained from R code
-  // paste0("[", paste0(paste0("'", names(knitr:: opts_chunk$merge(NULL)), "'"), collapse = ", "), "]")
-  public readonly chunkOptions = ['eval', 'echo', 'results', 'tidy', 'tidy.opts', 'collapse',
-    'prompt', 'comment', 'highlight', 'strip.white', 'size', 'background',
-    'cache', 'cache.path', 'cache.vars', 'cache.lazy', 'dependson',
-    'autodep', 'cache.rebuild', 'fig.keep', 'fig.show', 'fig.align',
-    'fig.path', 'dev', 'dev.args', 'dpi', 'fig.ext', 'fig.width',
-    'fig.height', 'fig.env', 'fig.cap', 'fig.scap', 'fig.lp', 'fig.subcap',
-    'fig.pos', 'out.width', 'out.height', 'out.extra', 'fig.retina',
-    'external', 'sanitize', 'interval', 'aniopts', 'warning', 'error',
-    'message', 'render', 'ref.label', 'child', 'engine', 'split',
-    'include', 'purl'];
-  public readonly chunkOptionCompletionItems: vscode.CompletionItem[];
+    // obtained from R code
+    // paste0("[", paste0(paste0("'", names(knitr:: opts_chunk$merge(NULL)), "'"), collapse = ", "), "]")
+    public readonly chunkOptions = ['eval', 'echo', 'results', 'tidy', 'tidy.opts', 'collapse',
+        'prompt', 'comment', 'highlight', 'strip.white', 'size', 'background',
+        'cache', 'cache.path', 'cache.vars', 'cache.lazy', 'dependson',
+        'autodep', 'cache.rebuild', 'fig.keep', 'fig.show', 'fig.align',
+        'fig.path', 'dev', 'dev.args', 'dpi', 'fig.ext', 'fig.width',
+        'fig.height', 'fig.env', 'fig.cap', 'fig.scap', 'fig.lp', 'fig.subcap',
+        'fig.pos', 'out.width', 'out.height', 'out.extra', 'fig.retina',
+        'external', 'sanitize', 'interval', 'aniopts', 'warning', 'error',
+        'message', 'render', 'ref.label', 'child', 'engine', 'split',
+        'include', 'purl'];
+    public readonly chunkOptionCompletionItems: vscode.CompletionItem[];
 
-  constructor() {
-    this.chunkOptionCompletionItems = this.chunkOptions.map((x: string) => {
-      const item = new vscode.CompletionItem(`${x}`);
-      item.insertText = `${x}=`;
-      return item;
-    });
-  }
-
-  public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position): vscode.CompletionItem[] {
-    const line = document.lineAt(position).text;
-    if (isChunkStartLine(line, false) && getChunkLanguage(line) === 'r') {
-      return this.chunkOptionCompletionItems;
+    constructor() {
+        this.chunkOptionCompletionItems = this.chunkOptions.map((x: string) => {
+            const item = new vscode.CompletionItem(`${x}`);
+            item.insertText = `${x}=`;
+            return item;
+        });
     }
 
-    return undefined;
-  }
+    public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position): vscode.CompletionItem[] {
+        const line = document.lineAt(position).text;
+        if (isChunkStartLine(line, false) && getChunkLanguage(line) === 'r') {
+            return this.chunkOptionCompletionItems;
+        }
+
+        return undefined;
+    }
 }

--- a/src/rmarkdown/knit.ts
+++ b/src/rmarkdown/knit.ts
@@ -12,263 +12,263 @@ import { DisposableProcess } from '../util';
 export let knitDir: KnitWorkingDirectory = util.config().get<KnitWorkingDirectory>('rmarkdown.knit.defaults.knitWorkingDirectory') ?? undefined;
 
 interface IKnitQuickPickItem {
-	label: string,
-	description: string,
-	detail: string,
-	value: KnitWorkingDirectory
+    label: string,
+    description: string,
+    detail: string,
+    value: KnitWorkingDirectory
 }
 
 interface IYamlFrontmatter {
-	title?: string,
-	author?: string,
-	knit?: string,
-	site?: string,
-	[key: string]: unknown
+    title?: string,
+    author?: string,
+    knit?: string,
+    site?: string,
+    [key: string]: unknown
 }
 
 export class RMarkdownKnitManager extends RMarkdownManager {
-	private async renderDocument(rDocumentPath: string, docPath: string, docName: string, yamlParams: IYamlFrontmatter, outputFormat?: string): Promise<DisposableProcess> {
-		const openOutfile: boolean = util.config().get<boolean>('rmarkdown.knit.openOutputFile') ?? false;
-		const knitWorkingDir = this.getKnitDir(knitDir, docPath);
-		const knitWorkingDirText = knitWorkingDir ? `${knitWorkingDir}` : '';
-		const knitCommand = await this.getKnitCommand(yamlParams, rDocumentPath, outputFormat);
-		this.rPath = await util.getRpath();
+    private async renderDocument(rDocumentPath: string, docPath: string, docName: string, yamlParams: IYamlFrontmatter, outputFormat?: string): Promise<DisposableProcess> {
+        const openOutfile: boolean = util.config().get<boolean>('rmarkdown.knit.openOutputFile') ?? false;
+        const knitWorkingDir = this.getKnitDir(knitDir, docPath);
+        const knitWorkingDirText = knitWorkingDir ? `${knitWorkingDir}` : '';
+        const knitCommand = await this.getKnitCommand(yamlParams, rDocumentPath, outputFormat);
+        this.rPath = await util.getRpath();
 
-		const lim = '<<<vsc>>>';
-		const re = new RegExp(`.*${lim}(.*)${lim}.*`, 'gms');
-		const scriptValues = {
-			'VSCR_KNIT_DIR': knitWorkingDirText,
-			'VSCR_LIM': lim,
-			'VSCR_KNIT_COMMAND': knitCommand
-		};
+        const lim = '<<<vsc>>>';
+        const re = new RegExp(`.*${lim}(.*)${lim}.*`, 'gms');
+        const scriptValues = {
+            'VSCR_KNIT_DIR': knitWorkingDirText,
+            'VSCR_LIM': lim,
+            'VSCR_KNIT_COMMAND': knitCommand
+        };
 
-		const callback = (dat: string) => {
-			const outputUrl = re.exec(dat)?.[0]?.replace(re, '$1');
-			if (!outputUrl) {
-				return false;
-			}
-			if (openOutfile) {
-				const outFile = vscode.Uri.file(outputUrl);
-				if (fs.existsSync(outFile.fsPath)) {
-					void vscode.commands.executeCommand('vscode.open', outFile);
-				} else {
-					void vscode.window.showWarningMessage(`Could not find the output file at path: "${outFile.fsPath}"`);
-				}
-			}
-			return true;
-		};
+        const callback = (dat: string) => {
+            const outputUrl = re.exec(dat)?.[0]?.replace(re, '$1');
+            if (!outputUrl) {
+                return false;
+            }
+            if (openOutfile) {
+                const outFile = vscode.Uri.file(outputUrl);
+                if (fs.existsSync(outFile.fsPath)) {
+                    void vscode.commands.executeCommand('vscode.open', outFile);
+                } else {
+                    void vscode.window.showWarningMessage(`Could not find the output file at path: "${outFile.fsPath}"`);
+                }
+            }
+            return true;
+        };
 
-		if (util.config().get<boolean>('rmarkdown.knit.focusOutputChannel')) {
-			this.rMarkdownOutput.show(true);
-		}
+        if (util.config().get<boolean>('rmarkdown.knit.focusOutputChannel')) {
+            this.rMarkdownOutput.show(true);
+        }
 
-		return await this.knitWithProgress(
-			{
-				workingDirectory: knitWorkingDir,
-				fileName: docName,
-				filePath: rDocumentPath,
-				scriptArgs: scriptValues,
-				scriptPath: extensionContext.asAbsolutePath('R/rmarkdown/knit.R'),
-				rCmd: knitCommand,
-				rOutputFormat: outputFormat,
-				callback: callback
-			}
-		);
+        return await this.knitWithProgress(
+            {
+                workingDirectory: knitWorkingDir,
+                fileName: docName,
+                filePath: rDocumentPath,
+                scriptArgs: scriptValues,
+                scriptPath: extensionContext.asAbsolutePath('R/rmarkdown/knit.R'),
+                rCmd: knitCommand,
+                rOutputFormat: outputFormat,
+                callback: callback
+            }
+        );
 
-	}
+    }
 
-	private getYamlFrontmatter(docPath: string): IYamlFrontmatter {
-		const text = fs.readFileSync(docPath, 'utf8');
-		const lines = text.split('\n');
-		let startLine = -1;
-		let endLine = -1;
-		for (let i = 0; i < lines.length; i++) {
-			if (/\S/.test(lines[i])) {
-				if (startLine < 0) {
-					if (lines[i].startsWith('---')) {
-						startLine = i;
-					} else {
-						break;
-					}
-				} else {
-					if (lines[i].startsWith('---')) {
-						endLine = i;
-						break;
-					}
-				}
-			}
-		}
+    private getYamlFrontmatter(docPath: string): IYamlFrontmatter {
+        const text = fs.readFileSync(docPath, 'utf8');
+        const lines = text.split('\n');
+        let startLine = -1;
+        let endLine = -1;
+        for (let i = 0; i < lines.length; i++) {
+            if (/\S/.test(lines[i])) {
+                if (startLine < 0) {
+                    if (lines[i].startsWith('---')) {
+                        startLine = i;
+                    } else {
+                        break;
+                    }
+                } else {
+                    if (lines[i].startsWith('---')) {
+                        endLine = i;
+                        break;
+                    }
+                }
+            }
+        }
 
-		let yamlText = undefined;
-		if (startLine + 1 < endLine) {
-			yamlText = lines.slice(startLine + 1, endLine).join('\n');
-		}
+        let yamlText = undefined;
+        if (startLine + 1 < endLine) {
+            yamlText = lines.slice(startLine + 1, endLine).join('\n');
+        }
 
-		let paramObj = {};
-		if (yamlText) {
-			try {
-				paramObj = yaml.load(
-					yamlText
-				);
-			} catch (e) {
-				console.error(`Could not parse YAML frontmatter for "${docPath}". Error: ${String(e)}`);
-			}
-		}
+        let paramObj = {};
+        if (yamlText) {
+            try {
+                paramObj = yaml.load(
+                    yamlText
+                );
+            } catch (e) {
+                console.error(`Could not parse YAML frontmatter for "${docPath}". Error: ${String(e)}`);
+            }
+        }
 
-		return paramObj;
-	}
+        return paramObj;
+    }
 
-	private async getKnitCommand(yamlParams: IYamlFrontmatter, docPath: string, outputFormat: string): Promise<string> {
-		let knitCommand: string;
+    private async getKnitCommand(yamlParams: IYamlFrontmatter, docPath: string, outputFormat: string): Promise<string> {
+        let knitCommand: string;
 
-		if (!yamlParams?.['site']) {
-			yamlParams['site'] = await this.findSiteParam();
-		}
+        if (!yamlParams?.['site']) {
+            yamlParams['site'] = await this.findSiteParam();
+        }
 
-		// precedence:
-		// knit > site > configuration
-		if (yamlParams?.['knit']) {
-			const knitParam = yamlParams['knit'];
-			knitCommand = outputFormat ?
-				`${knitParam}(${docPath}, output_format = '${outputFormat}')` :
-				`${knitParam}(${docPath})`;
-		} else if (!this.isREADME(docPath) && yamlParams?.['site']) {
-			knitCommand = outputFormat ?
-				`rmarkdown::render_site(${docPath}, output_format = '${outputFormat}')` :
-				`rmarkdown::render_site(${docPath})`;
-		} else {
-			const cmd = util.config().get<string>('rmarkdown.knit.command');
-			knitCommand = outputFormat ?
-				`${cmd}(${docPath}, output_format = '${outputFormat}')` :
-				`${cmd}(${docPath})`;
-		}
+        // precedence:
+        // knit > site > configuration
+        if (yamlParams?.['knit']) {
+            const knitParam = yamlParams['knit'];
+            knitCommand = outputFormat ?
+                `${knitParam}(${docPath}, output_format = '${outputFormat}')` :
+                `${knitParam}(${docPath})`;
+        } else if (!this.isREADME(docPath) && yamlParams?.['site']) {
+            knitCommand = outputFormat ?
+                `rmarkdown::render_site(${docPath}, output_format = '${outputFormat}')` :
+                `rmarkdown::render_site(${docPath})`;
+        } else {
+            const cmd = util.config().get<string>('rmarkdown.knit.command');
+            knitCommand = outputFormat ?
+                `${cmd}(${docPath}, output_format = '${outputFormat}')` :
+                `${cmd}(${docPath})`;
+        }
 
-		return knitCommand.replace(/['"]/g, '\'');
-	}
+        return knitCommand.replace(/['"]/g, '\'');
+    }
 
-	// check if the workspace of the document is a R Markdown site.
-	// the definition of what constitutes an R Markdown site differs
-	// depending on the type of R Markdown site (i.e., "simple" vs. blogdown sites)
-	private async findSiteParam(): Promise<string | undefined> {
-		const wad = vscode.window.activeTextEditor.document.uri.fsPath;
-		const rootFolder = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath ?? path.dirname(wad);
-		const indexFile = (await vscode.workspace.findFiles(new vscode.RelativePattern(rootFolder, 'index.{Rmd,rmd, md}'), null, 1))?.[0];
-		const siteRoot = path.join(path.dirname(wad), '_site.yml');
+    // check if the workspace of the document is a R Markdown site.
+    // the definition of what constitutes an R Markdown site differs
+    // depending on the type of R Markdown site (i.e., "simple" vs. blogdown sites)
+    private async findSiteParam(): Promise<string | undefined> {
+        const wad = vscode.window.activeTextEditor.document.uri.fsPath;
+        const rootFolder = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath ?? path.dirname(wad);
+        const indexFile = (await vscode.workspace.findFiles(new vscode.RelativePattern(rootFolder, 'index.{Rmd,rmd, md}'), null, 1))?.[0];
+        const siteRoot = path.join(path.dirname(wad), '_site.yml');
 
-		// 'Simple' R Markdown websites require all docs to be in the root folder
-		if (fs.existsSync(siteRoot)) {
-			return 'rmarkdown::render_site';
-			// Other generators may allow for docs in subdirs
-		} else if (indexFile) {
-			const indexData = this.getYamlFrontmatter(indexFile.fsPath);
-			if (indexData?.['site']) {
-				return indexData['site'];
-			}
-		}
+        // 'Simple' R Markdown websites require all docs to be in the root folder
+        if (fs.existsSync(siteRoot)) {
+            return 'rmarkdown::render_site';
+            // Other generators may allow for docs in subdirs
+        } else if (indexFile) {
+            const indexData = this.getYamlFrontmatter(indexFile.fsPath);
+            if (indexData?.['site']) {
+                return indexData['site'];
+            }
+        }
 
-		return undefined;
-	}
+        return undefined;
+    }
 
-	// readme files should not be knitted via render_site
-	private isREADME(docPath: string) {
-		return !!path.basename(docPath).includes('README');
-	}
+    // readme files should not be knitted via render_site
+    private isREADME(docPath: string) {
+        return !!path.basename(docPath).includes('README');
+    }
 
-	// alters the working directory for evaluating chunks
-	public setKnitDir(): void {
-		const currentDocumentWorkspacePath: string = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor?.document?.uri)?.uri?.fsPath;
-		const currentDocumentFolderPath: string = path.dirname(vscode.window?.activeTextEditor.document?.uri?.fsPath);
-		const items: IKnitQuickPickItem[] = [];
+    // alters the working directory for evaluating chunks
+    public setKnitDir(): void {
+        const currentDocumentWorkspacePath: string = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor?.document?.uri)?.uri?.fsPath;
+        const currentDocumentFolderPath: string = path.dirname(vscode.window?.activeTextEditor.document?.uri?.fsPath);
+        const items: IKnitQuickPickItem[] = [];
 
-		if (currentDocumentWorkspacePath) {
-			items.push(
-				{
-					label: (knitDir === KnitWorkingDirectory.workspaceRoot ? '$(check)' : '') + KnitWorkingDirectory.workspaceRoot,
-					value: KnitWorkingDirectory.workspaceRoot,
-					detail: 'Use the workspace root as the knit working directory',
-					description: currentDocumentWorkspacePath ?? currentDocumentFolderPath ?? 'No available workspace'
-				}
-			);
-		}
+        if (currentDocumentWorkspacePath) {
+            items.push(
+                {
+                    label: (knitDir === KnitWorkingDirectory.workspaceRoot ? '$(check)' : '') + KnitWorkingDirectory.workspaceRoot,
+                    value: KnitWorkingDirectory.workspaceRoot,
+                    detail: 'Use the workspace root as the knit working directory',
+                    description: currentDocumentWorkspacePath ?? currentDocumentFolderPath ?? 'No available workspace'
+                }
+            );
+        }
 
-		if (currentDocumentFolderPath && currentDocumentFolderPath !== '.') {
-			items.push(
-				{
-					label: (knitDir === KnitWorkingDirectory.documentDirectory ? '$(check)' : '') + KnitWorkingDirectory.documentDirectory,
-					value: KnitWorkingDirectory.documentDirectory,
-					detail: 'Use the document\'s directory as the knit working directory',
-					description: currentDocumentFolderPath ?? 'No folder available'
+        if (currentDocumentFolderPath && currentDocumentFolderPath !== '.') {
+            items.push(
+                {
+                    label: (knitDir === KnitWorkingDirectory.documentDirectory ? '$(check)' : '') + KnitWorkingDirectory.documentDirectory,
+                    value: KnitWorkingDirectory.documentDirectory,
+                    detail: 'Use the document\'s directory as the knit working directory',
+                    description: currentDocumentFolderPath ?? 'No folder available'
 
-				}
-			);
-		}
+                }
+            );
+        }
 
-		if (items.length > 0) {
-			void vscode.window.showQuickPick(
-				items,
-				{
-					title: 'Set knit working directory',
-					canPickMany: false
-				}
-			).then(async choice => {
-				if (choice?.value && knitDir !== choice.value) {
-					knitDir = choice.value;
-					await rmdPreviewManager.updatePreview();
-				}
-			});
-		} else {
-			void vscode.window.showInformationMessage('Cannot set knit directory for untitled documents.');
-		}
+        if (items.length > 0) {
+            void vscode.window.showQuickPick(
+                items,
+                {
+                    title: 'Set knit working directory',
+                    canPickMany: false
+                }
+            ).then(async choice => {
+                if (choice?.value && knitDir !== choice.value) {
+                    knitDir = choice.value;
+                    await rmdPreviewManager.updatePreview();
+                }
+            });
+        } else {
+            void vscode.window.showInformationMessage('Cannot set knit directory for untitled documents.');
+        }
 
-	}
+    }
 
-	public async knitRmd(echo: boolean, outputFormat?: string): Promise<void> {
-		const wad: vscode.TextDocument = vscode.window.activeTextEditor.document;
+    public async knitRmd(echo: boolean, outputFormat?: string): Promise<void> {
+        const wad: vscode.TextDocument = vscode.window.activeTextEditor.document;
 
-		// handle untitled rmd
-		if (vscode.window.activeTextEditor.document.isUntitled) {
-			void vscode.window.showWarningMessage('Cannot knit an untitled file. Please save the document.');
-			await vscode.commands.executeCommand('workbench.action.files.save').then(() => {
-				if (!vscode.window.activeTextEditor.document.isUntitled) {
-					void this.knitRmd(echo, outputFormat);
-				}
-			});
-			return;
-		}
+        // handle untitled rmd
+        if (vscode.window.activeTextEditor.document.isUntitled) {
+            void vscode.window.showWarningMessage('Cannot knit an untitled file. Please save the document.');
+            await vscode.commands.executeCommand('workbench.action.files.save').then(() => {
+                if (!vscode.window.activeTextEditor.document.isUntitled) {
+                    void this.knitRmd(echo, outputFormat);
+                }
+            });
+            return;
+        }
 
-		const isSaved = await util.saveDocument(wad);
-		if (!isSaved) {
-			return;
-		}
-		let rDocumentPath = util.ToRStringLiteral(wad.fileName, '"');
-		let encodingParam = util.config().get<string>('source.encoding');
-		encodingParam = `encoding = "${encodingParam}"`;
-		rDocumentPath = [rDocumentPath, encodingParam].join(', ');
-		if (echo) {
-			rDocumentPath = [rDocumentPath, 'echo = TRUE'].join(', ');
-		}
+        const isSaved = await util.saveDocument(wad);
+        if (!isSaved) {
+            return;
+        }
+        let rDocumentPath = util.ToRStringLiteral(wad.fileName, '"');
+        let encodingParam = util.config().get<string>('source.encoding');
+        encodingParam = `encoding = "${encodingParam}"`;
+        rDocumentPath = [rDocumentPath, encodingParam].join(', ');
+        if (echo) {
+            rDocumentPath = [rDocumentPath, 'echo = TRUE'].join(', ');
+        }
 
-		// allow users to opt out of background process
-		if (util.config().get<boolean>('rmarkdown.knit.useBackgroundProcess')) {
-			const busyPath = wad.uri.fsPath + outputFormat;
-			if (this.busyUriStore.has(busyPath)) {
-				return;
-			}
-			this.busyUriStore.add(busyPath);
-			await this.renderDocument(
-				rDocumentPath,
-				wad.uri.fsPath,
-				path.basename(wad.uri.fsPath),
-				this.getYamlFrontmatter(wad.uri.fsPath),
-				outputFormat
-			);
-			this.busyUriStore.delete(busyPath);
-		} else {
-			if (outputFormat === undefined) {
-				void runTextInTerm(`rmarkdown::render(${rDocumentPath})`);
-			} else {
-				void runTextInTerm(`rmarkdown::render(${rDocumentPath}, '${outputFormat}')`);
-			}
-		}
-	}
+        // allow users to opt out of background process
+        if (util.config().get<boolean>('rmarkdown.knit.useBackgroundProcess')) {
+            const busyPath = wad.uri.fsPath + outputFormat;
+            if (this.busyUriStore.has(busyPath)) {
+                return;
+            }
+            this.busyUriStore.add(busyPath);
+            await this.renderDocument(
+                rDocumentPath,
+                wad.uri.fsPath,
+                path.basename(wad.uri.fsPath),
+                this.getYamlFrontmatter(wad.uri.fsPath),
+                outputFormat
+            );
+            this.busyUriStore.delete(busyPath);
+        } else {
+            if (outputFormat === undefined) {
+                void runTextInTerm(`rmarkdown::render(${rDocumentPath})`);
+            } else {
+                void runTextInTerm(`rmarkdown::render(${rDocumentPath}, '${outputFormat}')`);
+            }
+        }
+    }
 }

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -5,182 +5,182 @@ import path = require('path');
 import { DisposableProcess, spawn } from '../util';
 
 export enum KnitWorkingDirectory {
-	documentDirectory = 'document directory',
-	workspaceRoot = 'workspace root',
+    documentDirectory = 'document directory',
+    workspaceRoot = 'workspace root',
 }
 
 export interface IKnitRejection {
-	cp: DisposableProcess;
-	wasCancelled: boolean;
+    cp: DisposableProcess;
+    wasCancelled: boolean;
 }
 
 const rMarkdownOutput: vscode.OutputChannel = vscode.window.createOutputChannel('R Markdown');
 
 interface IKnitArgs {
-	workingDirectory: string;
-	filePath: string;
-	fileName: string;
-	scriptArgs: Record<string, string>;
-	scriptPath: string;
-	rCmd?: string;
-	rOutputFormat?: string;
-	callback: (...args: unknown[]) => boolean;
-	onRejection?: (...args: unknown[]) => unknown;
+    workingDirectory: string;
+    filePath: string;
+    fileName: string;
+    scriptArgs: Record<string, string>;
+    scriptPath: string;
+    rCmd?: string;
+    rOutputFormat?: string;
+    callback: (...args: unknown[]) => boolean;
+    onRejection?: (...args: unknown[]) => unknown;
 }
 
 export abstract class RMarkdownManager {
-	protected rPath: string = undefined;
-	protected rMarkdownOutput: vscode.OutputChannel = rMarkdownOutput;
-	// uri that are in the process of knitting
-	// so that we can't spam the knit/preview button
-	protected busyUriStore: Set<string> = new Set<string>();
+    protected rPath: string = undefined;
+    protected rMarkdownOutput: vscode.OutputChannel = rMarkdownOutput;
+    // uri that are in the process of knitting
+    // so that we can't spam the knit/preview button
+    protected busyUriStore: Set<string> = new Set<string>();
 
-	protected getKnitDir(knitDir: string, docPath: string): string {
-		switch (knitDir) {
-			// the directory containing the R Markdown document
-			case KnitWorkingDirectory.documentDirectory: {
-				return path.dirname(docPath)?.replace(/\\/g, '/')?.replace(/['"]/g, '\\"') ?? undefined;
-			}
-			// the root of the current workspace
-			case KnitWorkingDirectory.workspaceRoot: {
-				const currentDocumentWorkspace = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(docPath) ?? vscode.window.activeTextEditor?.document?.uri)?.uri?.fsPath ?? undefined;
-				return currentDocumentWorkspace?.replace(/\\/g, '/')?.replace(/['"]/g, '\\"') ?? undefined;
-			}
-			// the working directory of the attached terminal, NYI
-			// case 'current directory': {
-			// 	return NULL
-			// }
-			default: return undefined;
-		}
-	}
+    protected getKnitDir(knitDir: string, docPath: string): string {
+        switch (knitDir) {
+            // the directory containing the R Markdown document
+            case KnitWorkingDirectory.documentDirectory: {
+                return path.dirname(docPath)?.replace(/\\/g, '/')?.replace(/['"]/g, '\\"') ?? undefined;
+            }
+            // the root of the current workspace
+            case KnitWorkingDirectory.workspaceRoot: {
+                const currentDocumentWorkspace = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(docPath) ?? vscode.window.activeTextEditor?.document?.uri)?.uri?.fsPath ?? undefined;
+                return currentDocumentWorkspace?.replace(/\\/g, '/')?.replace(/['"]/g, '\\"') ?? undefined;
+            }
+            // the working directory of the attached terminal, NYI
+            // case 'current directory': {
+            //     return NULL
+            // }
+            default: return undefined;
+        }
+    }
 
-	protected async knitDocument(args: IKnitArgs, token?: vscode.CancellationToken, progress?: vscode.Progress<unknown>): Promise<DisposableProcess | IKnitRejection> {
-		// vscode.Progress auto-increments progress, so we use this
-		// variable to set progress to a specific number
-		let currentProgress = 0;
-		let printOutput = true;
+    protected async knitDocument(args: IKnitArgs, token?: vscode.CancellationToken, progress?: vscode.Progress<unknown>): Promise<DisposableProcess | IKnitRejection> {
+        // vscode.Progress auto-increments progress, so we use this
+        // variable to set progress to a specific number
+        let currentProgress = 0;
+        let printOutput = true;
 
-		return await new Promise<DisposableProcess>(
-			(resolve, reject) => {
-				const scriptArgs = args.scriptArgs;
-				const scriptPath = args.scriptPath;
-				const fileName = args.fileName;
-				// const cmd = `${this.rPath} --silent --slave --no-save --no-restore -f "${scriptPath}"`;
-				const cpArgs = [
-					'--silent',
-					'--slave',
-					'--no-save',
-					'--no-restore',
-					'-f',
-					scriptPath
-				];
-				// When there's no LANG variable, we should try to set to a UTF-8 compatible one, as R relies
-				// on locale setting (based on LANG) to render certain characters.
-				// See https://github.com/REditorSupport/vscode-R/issues/933
-				const env = process.env;
-				if (env.LANG === undefined) {
-					env.LANG = 'en_US.UTF-8';
-				}
-				const processOptions: cp.SpawnOptions = {
-					env: {
-						...env,
-						...scriptArgs
-					},
-					cwd: args.workingDirectory,
-				};
+        return await new Promise<DisposableProcess>(
+            (resolve, reject) => {
+                const scriptArgs = args.scriptArgs;
+                const scriptPath = args.scriptPath;
+                const fileName = args.fileName;
+                // const cmd = `${this.rPath} --silent --slave --no-save --no-restore -f "${scriptPath}"`;
+                const cpArgs = [
+                    '--silent',
+                    '--slave',
+                    '--no-save',
+                    '--no-restore',
+                    '-f',
+                    scriptPath
+                ];
+                // When there's no LANG variable, we should try to set to a UTF-8 compatible one, as R relies
+                // on locale setting (based on LANG) to render certain characters.
+                // See https://github.com/REditorSupport/vscode-R/issues/933
+                const env = process.env;
+                if (env.LANG === undefined) {
+                    env.LANG = 'en_US.UTF-8';
+                }
+                const processOptions: cp.SpawnOptions = {
+                    env: {
+                        ...env,
+                        ...scriptArgs
+                    },
+                    cwd: args.workingDirectory,
+                };
 
-				let childProcess: DisposableProcess;
-				try {
-					childProcess = spawn(this.rPath, cpArgs, processOptions, () => {
-						rMarkdownOutput.appendLine('[VSC-R] terminating R process');
-						printOutput = false;
-					});
-					progress.report({
-						increment: 0,
-						message: '0%'
-					});
-				} catch (e: unknown) {
-					console.warn(`[VSC-R] error: ${e as string}`);
-					reject({ cp: childProcess, wasCancelled: false });
-				}
+                let childProcess: DisposableProcess;
+                try {
+                    childProcess = spawn(this.rPath, cpArgs, processOptions, () => {
+                        rMarkdownOutput.appendLine('[VSC-R] terminating R process');
+                        printOutput = false;
+                    });
+                    progress.report({
+                        increment: 0,
+                        message: '0%'
+                    });
+                } catch (e: unknown) {
+                    console.warn(`[VSC-R] error: ${e as string}`);
+                    reject({ cp: childProcess, wasCancelled: false });
+                }
 
-				this.rMarkdownOutput.appendLine(`[VSC-R] ${fileName} process started`);
+                this.rMarkdownOutput.appendLine(`[VSC-R] ${fileName} process started`);
 
-				if (args.rCmd) {
-					this.rMarkdownOutput.appendLine(`==> ${args.rCmd}`);
-				}
+                if (args.rCmd) {
+                    this.rMarkdownOutput.appendLine(`==> ${args.rCmd}`);
+                }
 
-				childProcess.stdout.on('data',
-					(data: Buffer) => {
-						const dat = data.toString('utf8');
-						if (printOutput) {
-							this.rMarkdownOutput.appendLine(dat);
+                childProcess.stdout.on('data',
+                    (data: Buffer) => {
+                        const dat = data.toString('utf8');
+                        if (printOutput) {
+                            this.rMarkdownOutput.appendLine(dat);
 
-						}
-						const percentRegex = /[0-9]+(?=%)/g;
-						const percentRegOutput = dat.match(percentRegex);
+                        }
+                        const percentRegex = /[0-9]+(?=%)/g;
+                        const percentRegOutput = dat.match(percentRegex);
 
-						if (percentRegOutput) {
-							for (const item of percentRegOutput) {
-								const perc = Number(item);
-								progress.report(
-									{
-										increment: perc - currentProgress,
-										message: `${perc}%`
-									}
-								);
-								currentProgress = perc;
-							}
-						}
-						if (token?.isCancellationRequested) {
-							resolve(childProcess);
-						} else {
-							if (args.callback(dat, childProcess)) {
-								resolve(childProcess);
-							}
-						}
-					}
-				);
+                        if (percentRegOutput) {
+                            for (const item of percentRegOutput) {
+                                const perc = Number(item);
+                                progress.report(
+                                    {
+                                        increment: perc - currentProgress,
+                                        message: `${perc}%`
+                                    }
+                                );
+                                currentProgress = perc;
+                            }
+                        }
+                        if (token?.isCancellationRequested) {
+                            resolve(childProcess);
+                        } else {
+                            if (args.callback(dat, childProcess)) {
+                                resolve(childProcess);
+                            }
+                        }
+                    }
+                );
 
-				childProcess.stderr.on('data', (data: Buffer) => {
-					const dat = data.toString('utf8');
-					if (printOutput) {
-						this.rMarkdownOutput.appendLine(dat);
-					}
-				});
+                childProcess.stderr.on('data', (data: Buffer) => {
+                    const dat = data.toString('utf8');
+                    if (printOutput) {
+                        this.rMarkdownOutput.appendLine(dat);
+                    }
+                });
 
-				childProcess.on('exit', (code, signal) => {
-					this.rMarkdownOutput.appendLine(`[VSC-R] ${fileName} process exited ` +
-						(signal ? `from signal '${signal}'` : `with exit code ${code}`));
-					if (code !== 0) {
-						reject({ cp: childProcess, wasCancelled: false });
-					}
-				});
+                childProcess.on('exit', (code, signal) => {
+                    this.rMarkdownOutput.appendLine(`[VSC-R] ${fileName} process exited ` +
+                        (signal ? `from signal '${signal}'` : `with exit code ${code}`));
+                    if (code !== 0) {
+                        reject({ cp: childProcess, wasCancelled: false });
+                    }
+                });
 
-				token?.onCancellationRequested(() => {
-					reject({ cp: childProcess, wasCancelled: true });
-				});
-			}
-		);
-	}
+                token?.onCancellationRequested(() => {
+                    reject({ cp: childProcess, wasCancelled: true });
+                });
+            }
+        );
+    }
 
-	protected async knitWithProgress(args: IKnitArgs): Promise<DisposableProcess> {
-		let childProcess: DisposableProcess = undefined;
-		await util.doWithProgress(async (token: vscode.CancellationToken, progress: vscode.Progress<unknown>) => {
-			childProcess = await this.knitDocument(args, token, progress) as DisposableProcess;
-		},
-			vscode.ProgressLocation.Notification,
-			`Knitting ${args.fileName} ${args.rOutputFormat ? 'to ' + args.rOutputFormat : ''} `,
-			true
-		).catch((rejection: IKnitRejection) => {
-			if (!rejection.wasCancelled) {
-				void vscode.window.showErrorMessage('There was an error in knitting the document. Please check the R Markdown output stream.');
-				this.rMarkdownOutput.show(true);
-			}
-			// this can occur when a successfuly knitted document is later altered (while still being previewed) and subsequently fails to knit
-			args?.onRejection?.(args.filePath, rejection);
-			rejection.cp?.dispose();
-		});
-		return childProcess;
-	}
+    protected async knitWithProgress(args: IKnitArgs): Promise<DisposableProcess> {
+        let childProcess: DisposableProcess = undefined;
+        await util.doWithProgress(async (token: vscode.CancellationToken, progress: vscode.Progress<unknown>) => {
+            childProcess = await this.knitDocument(args, token, progress) as DisposableProcess;
+        },
+            vscode.ProgressLocation.Notification,
+            `Knitting ${args.fileName} ${args.rOutputFormat ? 'to ' + args.rOutputFormat : ''} `,
+            true
+        ).catch((rejection: IKnitRejection) => {
+            if (!rejection.wasCancelled) {
+                void vscode.window.showErrorMessage('There was an error in knitting the document. Please check the R Markdown output stream.');
+                this.rMarkdownOutput.show(true);
+            }
+            // this can occur when a successfuly knitted document is later altered (while still being previewed) and subsequently fails to knit
+            args?.onRejection?.(args.filePath, rejection);
+            rejection.cp?.dispose();
+        });
+        return childProcess;
+    }
 }

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -166,9 +166,10 @@ export abstract class RMarkdownManager {
 
     protected async knitWithProgress(args: IKnitArgs): Promise<DisposableProcess> {
         let childProcess: DisposableProcess = undefined;
-        await util.doWithProgress(async (token: vscode.CancellationToken, progress: vscode.Progress<unknown>) => {
-            childProcess = await this.knitDocument(args, token, progress) as DisposableProcess;
-        },
+        await util.doWithProgress(
+            async (token: vscode.CancellationToken, progress: vscode.Progress<unknown>) => {
+                childProcess = await this.knitDocument(args, token, progress) as DisposableProcess;
+            },
             vscode.ProgressLocation.Notification,
             `Knitting ${args.fileName} ${args.rOutputFormat ? 'to ' + args.rOutputFormat : ''} `,
             true

--- a/src/rstudioapi.ts
+++ b/src/rstudioapi.ts
@@ -6,9 +6,9 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import {
-  window, TextEditor, TextDocument, Uri,
-  workspace, WorkspaceEdit, Position, Range, Selection,
-  QuickPickItem, QuickPickOptions, ViewColumn
+    window, TextEditor, TextDocument, Uri,
+    workspace, WorkspaceEdit, Position, Range, Selection,
+    QuickPickItem, QuickPickOptions, ViewColumn
 } from 'vscode';
 import { readJSON } from 'fs-extra';
 import * as path from 'path';
@@ -20,451 +20,451 @@ let lastActiveTextEditor: TextEditor;
 
 export async function dispatchRStudioAPICall(action: string, args: any, sd: string): Promise<void> {
 
-  switch (action) {
-    case 'active_editor_context': {
-      await writeResponse(activeEditorContext(), sd);
-      break;
+    switch (action) {
+        case 'active_editor_context': {
+            await writeResponse(activeEditorContext(), sd);
+            break;
+        }
+        case 'insert_or_modify_text': {
+            await insertOrModifyText(args.query, args.id);
+            await writeSuccessResponse(sd);
+            break;
+        }
+        case 'replace_text_in_current_selection': {
+            await replaceTextInCurrentSelection(args.text, args.id);
+            await writeSuccessResponse(sd);
+            break;
+        }
+        case 'show_dialog': {
+            showDialog(args.message);
+            await writeSuccessResponse(sd);
+            break;
+        }
+        case 'navigate_to_file': {
+            await navigateToFile(args.file, args.line, args.column);
+            await writeSuccessResponse(sd);
+            break;
+        }
+        case 'set_selection_ranges': {
+            await setSelections(args.ranges, args.id);
+            await writeSuccessResponse(sd);
+            break;
+        }
+        case 'document_save': {
+            await documentSave(args.id);
+            await writeSuccessResponse(sd);
+            break;
+        }
+        case 'document_save_all': {
+            await documentSaveAll();
+            await writeSuccessResponse(sd);
+            break;
+        }
+        case 'get_project_path': {
+            await writeResponse(projectPath(), sd);
+            break;
+        }
+        case 'document_context': {
+            await writeResponse(await documentContext(args.id), sd);
+            break;
+        }
+        case 'document_new': {
+            await documentNew(args.text, args.type, args.position);
+            await writeSuccessResponse(sd);
+            break;
+        }
+        case 'restart_r': {
+            await restartRTerminal();
+            await writeSuccessResponse(sd);
+            break;
+        }
+        case 'send_to_console': {
+            await sendCodeToRTerminal(args.code, args.execute, args.focus);
+            await writeSuccessResponse(sd);
+            break;
+        }
+        default:
+            console.error(`[dispatchRStudioAPICall] Unsupported action: ${action}`);
     }
-    case 'insert_or_modify_text': {
-      await insertOrModifyText(args.query, args.id);
-      await writeSuccessResponse(sd);
-      break;
-    }
-    case 'replace_text_in_current_selection': {
-      await replaceTextInCurrentSelection(args.text, args.id);
-      await writeSuccessResponse(sd);
-      break;
-    }
-    case 'show_dialog': {
-      showDialog(args.message);
-      await writeSuccessResponse(sd);
-      break;
-    }
-    case 'navigate_to_file': {
-      await navigateToFile(args.file, args.line, args.column);
-      await writeSuccessResponse(sd);
-      break;
-    }
-    case 'set_selection_ranges': {
-      await setSelections(args.ranges, args.id);
-      await writeSuccessResponse(sd);
-      break;
-    }
-    case 'document_save': {
-      await documentSave(args.id);
-      await writeSuccessResponse(sd);
-      break;
-    }
-    case 'document_save_all': {
-      await documentSaveAll();
-      await writeSuccessResponse(sd);
-      break;
-    }
-    case 'get_project_path': {
-      await writeResponse(projectPath(), sd);
-      break;
-    }
-    case 'document_context': {
-      await writeResponse(await documentContext(args.id), sd);
-      break;
-    }
-    case 'document_new': {
-      await documentNew(args.text, args.type, args.position);
-      await writeSuccessResponse(sd);
-      break;
-    }
-    case 'restart_r': {
-      await restartRTerminal();
-      await writeSuccessResponse(sd);
-      break;
-    }
-    case 'send_to_console': {
-      await sendCodeToRTerminal(args.code, args.execute, args.focus);
-      await writeSuccessResponse(sd);
-      break;
-    }
-    default:
-      console.error(`[dispatchRStudioAPICall] Unsupported action: ${action}`);
-  }
 
 }
 
 //rstudioapi
 export function activeEditorContext() {
-  // info returned from RStudio:
-  // list with:
-  // id
-  // path
-  // contents
-  // selection - a list of selections
-  const currentDocument = getLastActiveTextEditor().document;
-  return {
-    id: currentDocument.uri,
-    contents: currentDocument.getText(),
-    path: currentDocument.fileName,
-    selection: getLastActiveTextEditor().selections
-  };
+    // info returned from RStudio:
+    // list with:
+    // id
+    // path
+    // contents
+    // selection - a list of selections
+    const currentDocument = getLastActiveTextEditor().document;
+    return {
+        id: currentDocument.uri,
+        contents: currentDocument.getText(),
+        path: currentDocument.fileName,
+        selection: getLastActiveTextEditor().selections
+    };
 }
 
 export async function documentContext(id: string) {
-  const target = findTargetUri(id);
-  const targetDocument = await workspace.openTextDocument(target);
-  console.info(`[documentContext] getting context for: ${target.path}`);
-  return {
-    id: targetDocument.uri
-  };
+    const target = findTargetUri(id);
+    const targetDocument = await workspace.openTextDocument(target);
+    console.info(`[documentContext] getting context for: ${target.path}`);
+    return {
+        id: targetDocument.uri
+    };
 }
 
 export async function insertOrModifyText(query: any[], id: string = null) {
 
 
-  const target = findTargetUri(id);
-  const targetDocument = await workspace.openTextDocument(target);
-  console.info(`[insertTextAtPosition] inserting text into: ${target.path}`);
-  const edit = new WorkspaceEdit();
+    const target = findTargetUri(id);
+    const targetDocument = await workspace.openTextDocument(target);
+    console.info(`[insertTextAtPosition] inserting text into: ${target.path}`);
+    const edit = new WorkspaceEdit();
 
-  query.forEach((op) => {
-    assertSupportedEditOperation(op.operation);
+    query.forEach((op) => {
+        assertSupportedEditOperation(op.operation);
 
-    let editLocation: any;
-    const editText = normaliseEditText(op.text, op.location, op.operation, targetDocument);
+        let editLocation: any;
+        const editText = normaliseEditText(op.text, op.location, op.operation, targetDocument);
 
-    if (op.operation === 'insertText') {
-      editLocation = parsePosition(op.location, targetDocument);
-      console.info(`[insertTextAtPosition] inserting at: ${JSON.stringify(editLocation)}`);
-      console.info(`[insertTextAtPosition] inserting text: ${editText}`);
-      edit.insert(target, editLocation, editText);
-    } else {
-      editLocation = parseRange(op.location, targetDocument);
-      console.info(`[insertTextAtPosition] replacing at: ${JSON.stringify(editLocation)}`);
-      console.info(`[insertTextAtPosition] replacing with text: ${editText}`);
-      edit.replace(target, editLocation, editText);
-    }
-  });
+        if (op.operation === 'insertText') {
+            editLocation = parsePosition(op.location, targetDocument);
+            console.info(`[insertTextAtPosition] inserting at: ${JSON.stringify(editLocation)}`);
+            console.info(`[insertTextAtPosition] inserting text: ${editText}`);
+            edit.insert(target, editLocation, editText);
+        } else {
+            editLocation = parseRange(op.location, targetDocument);
+            console.info(`[insertTextAtPosition] replacing at: ${JSON.stringify(editLocation)}`);
+            console.info(`[insertTextAtPosition] replacing with text: ${editText}`);
+            edit.replace(target, editLocation, editText);
+        }
+    });
 
-  void workspace.applyEdit(edit);
+    void workspace.applyEdit(edit);
 }
 
 export async function replaceTextInCurrentSelection(text: string, id: string): Promise<void> {
-  const target = findTargetUri(id);
-  console.info(`[replaceTextInCurrentSelection] inserting: ${text} into ${target.path}`);
-  const edit = new WorkspaceEdit();
-  edit.replace(
-    target,
-    getLastActiveTextEditor().selection,
-    text
-  );
-  await workspace.applyEdit(edit);
+    const target = findTargetUri(id);
+    console.info(`[replaceTextInCurrentSelection] inserting: ${text} into ${target.path}`);
+    const edit = new WorkspaceEdit();
+    edit.replace(
+        target,
+        getLastActiveTextEditor().selection,
+        text
+    );
+    await workspace.applyEdit(edit);
 }
 
 export function showDialog(message: string): void {
 
-  void window.showInformationMessage(message);
+    void window.showInformationMessage(message);
 
 }
 
 export async function navigateToFile(file: string, line: number, column: number): Promise<void>{
 
-  const targetDocument = await workspace.openTextDocument(Uri.file(file));
-  const editor = await window.showTextDocument(targetDocument);
-  const targetPosition = parsePosition([line, column], targetDocument);
-  editor.selection = new Selection(targetPosition, targetPosition);
-  editor.revealRange(new Range(targetPosition, targetPosition));
+    const targetDocument = await workspace.openTextDocument(Uri.file(file));
+    const editor = await window.showTextDocument(targetDocument);
+    const targetPosition = parsePosition([line, column], targetDocument);
+    editor.selection = new Selection(targetPosition, targetPosition);
+    editor.revealRange(new Range(targetPosition, targetPosition));
 }
 
 export async function setSelections(ranges: number[][], id: string): Promise<void> {
-  // Setting selections can only be done on TextEditors not TextDocuments, but
-  // it is the latter which are the things actually referred to by `id`. In
-  // VSCode it's not possible to get a list of the open text editors. it is not
-  // window.visibleTextEditors - this is only editors (tabs) with text showing.
-  // The only editors we know about are those that are visible and the last
-  // active (which may not be visible if it was overtaken by a WebViewPanel).
-  // This function looks to see if a text editor for the document id is amongst
-  // those known, and if not, it opens and shows that document, but in a
-  // texteditor 'beside' the current one.
-  // The rationale for this is:
-  // If an addin is trying to set selections in an editor that is not the active
-  // one it is most likely that it was active before the addin ran, but the addin
-  // opened a something that overtook its' focus. The most likely culprit for
-  // this is a shiny app. In the case that the target window is visible
-  // alongside the shiny app, it will be found and used. If it is not visible,
-  // there's a change it may be the last active, if the shiny app over took it.
-  // If it is neither of these things a new one needs to be opened to set
-  // selections and the question is whether open it in the same window as the
-  // shiny app, or the one 'beside'. 'beside' is preferred since it allows shiny
-  // apps that work interactively with an open document to behave more smoothly.
-  // {prefixer} is an example of one of these.
-  const target = findTargetUri(id);
-  const targetDocument = await workspace.openTextDocument(target);
-  const editor = await reuseOrCreateEditor(targetDocument);
+    // Setting selections can only be done on TextEditors not TextDocuments, but
+    // it is the latter which are the things actually referred to by `id`. In
+    // VSCode it's not possible to get a list of the open text editors. it is not
+    // window.visibleTextEditors - this is only editors (tabs) with text showing.
+    // The only editors we know about are those that are visible and the last
+    // active (which may not be visible if it was overtaken by a WebViewPanel).
+    // This function looks to see if a text editor for the document id is amongst
+    // those known, and if not, it opens and shows that document, but in a
+    // texteditor 'beside' the current one.
+    // The rationale for this is:
+    // If an addin is trying to set selections in an editor that is not the active
+    // one it is most likely that it was active before the addin ran, but the addin
+    // opened a something that overtook its' focus. The most likely culprit for
+    // this is a shiny app. In the case that the target window is visible
+    // alongside the shiny app, it will be found and used. If it is not visible,
+    // there's a change it may be the last active, if the shiny app over took it.
+    // If it is neither of these things a new one needs to be opened to set
+    // selections and the question is whether open it in the same window as the
+    // shiny app, or the one 'beside'. 'beside' is preferred since it allows shiny
+    // apps that work interactively with an open document to behave more smoothly.
+    // {prefixer} is an example of one of these.
+    const target = findTargetUri(id);
+    const targetDocument = await workspace.openTextDocument(target);
+    const editor = await reuseOrCreateEditor(targetDocument);
 
-  const selectionObjects = ranges.map(x => {
-    const newRange = parseRange(x, targetDocument);
-    const newSelection = new Selection(newRange.start, newRange.end);
-    return (newSelection);
-  });
+    const selectionObjects = ranges.map(x => {
+        const newRange = parseRange(x, targetDocument);
+        const newSelection = new Selection(newRange.start, newRange.end);
+        return (newSelection);
+    });
 
-  editor.selections = selectionObjects;
+    editor.selections = selectionObjects;
 }
 
 export async function documentSave(id: string): Promise<void> {
-  const target = findTargetUri(id);
-  const targetDocument = await workspace.openTextDocument(target);
-  await targetDocument.save();
+    const target = findTargetUri(id);
+    const targetDocument = await workspace.openTextDocument(target);
+    await targetDocument.save();
 }
 
 export async function documentSaveAll(): Promise<void> {
-  await workspace.saveAll();
+    await workspace.saveAll();
 }
 
 export function projectPath(): { path: string; } {
 
-  if (typeof workspace.workspaceFolders !== 'undefined') {
-    // Is there a root folder open?
+    if (typeof workspace.workspaceFolders !== 'undefined') {
+        // Is there a root folder open?
 
-    if (workspace.workspaceFolders.length === 1) {
-      // In single root common case, this will always work.
-      return {
-        path: workspace.workspaceFolders[0].uri.path
-      };
-    } else if (workspace.workspaceFolders.length > 1) {
-      // In less common multi-root folder case is a bit tricky. If the active
-      // text editor has scheme 'untitled:' (is unsaved), then
-      // workspace.getWorkspaceFolder() won't be able to find its Uri in any
-      // folder and will return undefined.
-      const currentDocument = getLastActiveTextEditor().document;
-      const currentDocFolder = workspace.getWorkspaceFolder(currentDocument.uri);
-      if (typeof currentDocFolder !== 'undefined') {
-        return {
-          path: currentDocFolder.uri.path
-        };
-      }
+        if (workspace.workspaceFolders.length === 1) {
+            // In single root common case, this will always work.
+            return {
+                path: workspace.workspaceFolders[0].uri.path
+            };
+        } else if (workspace.workspaceFolders.length > 1) {
+            // In less common multi-root folder case is a bit tricky. If the active
+            // text editor has scheme 'untitled:' (is unsaved), then
+            // workspace.getWorkspaceFolder() won't be able to find its Uri in any
+            // folder and will return undefined.
+            const currentDocument = getLastActiveTextEditor().document;
+            const currentDocFolder = workspace.getWorkspaceFolder(currentDocument.uri);
+            if (typeof currentDocFolder !== 'undefined') {
+                return {
+                    path: currentDocFolder.uri.path
+                };
+            }
+        }
     }
-  }
 
-  // if we got to here either:
-  //   - the workspaceFolders array was undefined (no folder open)
-  //   - the activeText editor was an unsaved document, which has undefined workspace folder.
-  // return undefined and handle with a message in R.
-  return {
-    path: undefined
-  };
+    // if we got to here either:
+    //     - the workspaceFolders array was undefined (no folder open)
+    //     - the activeText editor was an unsaved document, which has undefined workspace folder.
+    // return undefined and handle with a message in R.
+    return {
+        path: undefined
+    };
 }
 
 export async function documentNew(text: string, type: string, position: number[]): Promise<void> {
-  const documentUri = Uri.parse('untitled:' + path.join(projectPath().path, 'new_document.' + type));
-  const targetDocument = await workspace.openTextDocument(documentUri);
-  const edit = new WorkspaceEdit();
-  const docLines = targetDocument.lineCount;
-  edit.replace(documentUri,
-    targetDocument.validateRange(new Range(
-      new Position(0, 0),
-      new Position(docLines + 1, 0)
-    )),
-    text);
+    const documentUri = Uri.parse('untitled:' + path.join(projectPath().path, 'new_document.' + type));
+    const targetDocument = await workspace.openTextDocument(documentUri);
+    const edit = new WorkspaceEdit();
+    const docLines = targetDocument.lineCount;
+    edit.replace(documentUri,
+        targetDocument.validateRange(new Range(
+            new Position(0, 0),
+            new Position(docLines + 1, 0)
+        )),
+        text);
 
-  void workspace.applyEdit(edit).then(async () => {
-    const editor = await window.showTextDocument(targetDocument);
-    editor.selections = [new Selection(
-      parsePosition(position, targetDocument),
-      parsePosition(position, targetDocument)
-    )];
-  });
+    void workspace.applyEdit(edit).then(async () => {
+        const editor = await window.showTextDocument(targetDocument);
+        editor.selections = [new Selection(
+            parsePosition(position, targetDocument),
+            parsePosition(position, targetDocument)
+        )];
+    });
 }
 
 // interface
 // represents addins in a QuickPick menu
 interface AddinItem extends QuickPickItem {
-  binding: string;
-  package: string;
+    binding: string;
+    package: string;
 }
 
 let addinQuickPicks: AddinItem[] = undefined;
 
 export async function getAddinPickerItems(): Promise<AddinItem[]> {
 
-  if (typeof addinQuickPicks === 'undefined') {
-    const addins: any[] = await readJSON(path.join(sessionDir, 'addins.json')).
-      then(
-        (result) => result,
-        () => {
-          throw ('Could not find list of installed addins.' +
-            ' options(vsc.rstudioapi = TRUE) must be set in your .Rprofile to use ' +
-            ' RStudio Addins');
-        }
-      );
+    if (typeof addinQuickPicks === 'undefined') {
+        const addins: any[] = await readJSON(path.join(sessionDir, 'addins.json')).
+            then(
+                (result) => result,
+                () => {
+                    throw ('Could not find list of installed addins.' +
+                        ' options(vsc.rstudioapi = TRUE) must be set in your .Rprofile to use ' +
+                        ' RStudio Addins');
+                }
+            );
 
-    const addinItems = addins.map((x) => {
-      return {
-        alwaysShow: false,
-        description: `{${x.package}}`,
-        label: x.name,
-        detail: x.description,
-        picked: false,
-        binding: x.binding,
-        package: x.package,
-      };
-    });
-    addinQuickPicks = addinItems;
-  }
-  return addinQuickPicks;
+        const addinItems = addins.map((x) => {
+            return {
+                alwaysShow: false,
+                description: `{${x.package}}`,
+                label: x.name,
+                detail: x.description,
+                picked: false,
+                binding: x.binding,
+                package: x.package,
+            };
+        });
+        addinQuickPicks = addinItems;
+    }
+    return addinQuickPicks;
 }
 
 export function purgeAddinPickerItems(): void {
-  addinQuickPicks = undefined;
+    addinQuickPicks = undefined;
 }
 
 export async function launchAddinPicker(): Promise<void> {
 
-  if (!config().get<boolean>('sessionWatcher')) {
-    void window.showErrorMessage('{rstudioapi} emulation requires session watcher to be enabled in extension config.');
-    return;
-  }
-  if (!sessionDirectoryExists()) {
-    void window.showErrorMessage('No active R terminal session, attach one to use RStudio addins.');
-    return;
-  }
+    if (!config().get<boolean>('sessionWatcher')) {
+        void window.showErrorMessage('{rstudioapi} emulation requires session watcher to be enabled in extension config.');
+        return;
+    }
+    if (!sessionDirectoryExists()) {
+        void window.showErrorMessage('No active R terminal session, attach one to use RStudio addins.');
+        return;
+    }
 
-  const addinPickerOptions: QuickPickOptions = {
-    matchOnDescription: true,
-    matchOnDetail: true,
-    canPickMany: false,
-    ignoreFocusOut: false,
-    placeHolder: '',
-    onDidSelectItem: undefined
-  };
-  const addinSelection: AddinItem =
-    await window.showQuickPick<AddinItem>(getAddinPickerItems(), addinPickerOptions);
+    const addinPickerOptions: QuickPickOptions = {
+        matchOnDescription: true,
+        matchOnDetail: true,
+        canPickMany: false,
+        ignoreFocusOut: false,
+        placeHolder: '',
+        onDidSelectItem: undefined
+    };
+    const addinSelection: AddinItem =
+        await window.showQuickPick<AddinItem>(getAddinPickerItems(), addinPickerOptions);
 
-  if (!(typeof addinSelection === 'undefined')) {
-    await runTextInTerm(addinSelection.package + ':::' + addinSelection.binding + '()');
-  }
+    if (!(typeof addinSelection === 'undefined')) {
+        await runTextInTerm(addinSelection.package + ':::' + addinSelection.binding + '()');
+    }
 }
 
 export async function sendCodeToRTerminal(code: string, execute: boolean, focus: boolean) {
-  if (execute) {
-    console.info(`[sendCodeToRTerminal] sending code: ${code}`);
-  } else {
-    console.info(`[sendCodeToRTerminal] inserting code: ${code}`);
-  }
-
-  await runTextInTerm(code, execute);
-  if (focus) {
-    const rTerm = await chooseTerminal();
-    if (rTerm !== undefined) {
-      rTerm.show();
+    if (execute) {
+        console.info(`[sendCodeToRTerminal] sending code: ${code}`);
+    } else {
+        console.info(`[sendCodeToRTerminal] inserting code: ${code}`);
     }
-  }
+
+    await runTextInTerm(code, execute);
+    if (focus) {
+        const rTerm = await chooseTerminal();
+        if (rTerm !== undefined) {
+            rTerm.show();
+        }
+    }
 }
 
 //utils
 function toVSCCoord(coord: any) {
-  // this is necessary because RStudio will accept negative or infinite values,
-  // replacing them with the min or max or the document.
-  // These must be clamped non-negative integers accepted by VSCode.
-  // For Inf, we set the value to a very large integer, relying on the
-  // parsing functions to revise this down using the validatePosition/Range functions.
-  let coord_value: number;
-  if (coord === 'Inf') {
-    coord_value = 10000000;
-  } else if (coord === '-Inf') {
-    coord_value = 0;
-  } else if (coord <= 0) {
-    coord_value = 0;
-  }
-  else { // coord > 0
-    coord_value = coord - 1; // positions in the rstudioapi are 1 indexed.
-  }
+    // this is necessary because RStudio will accept negative or infinite values,
+    // replacing them with the min or max or the document.
+    // These must be clamped non-negative integers accepted by VSCode.
+    // For Inf, we set the value to a very large integer, relying on the
+    // parsing functions to revise this down using the validatePosition/Range functions.
+    let coord_value: number;
+    if (coord === 'Inf') {
+        coord_value = 10000000;
+    } else if (coord === '-Inf') {
+        coord_value = 0;
+    } else if (coord <= 0) {
+        coord_value = 0;
+    }
+    else { // coord > 0
+        coord_value = coord - 1; // positions in the rstudioapi are 1 indexed.
+    }
 
-  return coord_value;
+    return coord_value;
 
 }
 
 function parsePosition(rs_position: any[], targetDocument: TextDocument) {
-  if (rs_position.length !== 2) {
-    throw ('an rstudioapi position must be an array of 2 numbers');
-  }
-  return (
-    targetDocument.validatePosition(
-      new Position(toVSCCoord(rs_position[0]), toVSCCoord(rs_position[1]))
-    ));
+    if (rs_position.length !== 2) {
+        throw ('an rstudioapi position must be an array of 2 numbers');
+    }
+    return (
+        targetDocument.validatePosition(
+            new Position(toVSCCoord(rs_position[0]), toVSCCoord(rs_position[1]))
+        ));
 }
 
 function parseRange(rs_range: any, targetDocument: TextDocument) {
-  if (rs_range.start.length !== 2 || rs_range.end.length !== 2) {
-    throw ('an rstudioapi range must be an object containing two numeric arrays');
-  }
-  return (
-    targetDocument.validateRange(
-      new Range(
-        new Position(toVSCCoord(rs_range.start[0]), toVSCCoord(rs_range.start[1])),
-        new Position(toVSCCoord(rs_range.end[0]), toVSCCoord(rs_range.end[1]))
-      )
-    ));
+    if (rs_range.start.length !== 2 || rs_range.end.length !== 2) {
+        throw ('an rstudioapi range must be an object containing two numeric arrays');
+    }
+    return (
+        targetDocument.validateRange(
+            new Range(
+                new Position(toVSCCoord(rs_range.start[0]), toVSCCoord(rs_range.start[1])),
+                new Position(toVSCCoord(rs_range.end[0]), toVSCCoord(rs_range.end[1]))
+            )
+        ));
 }
 
 function assertSupportedEditOperation(operation: string) {
-  if (operation !== 'insertText' && operation !== 'modifyRange') {
-    throw ('Operation: ' + operation + ' not supported by VSCode-R API');
-  }
+    if (operation !== 'insertText' && operation !== 'modifyRange') {
+        throw ('Operation: ' + operation + ' not supported by VSCode-R API');
+    }
 }
 
 function normaliseEditText(text: string, editLocation: any,
-  operation: string, targetDocument: TextDocument) {
-  // in a document with lines, does the line position extend past the existing
-  // lines in the document? rstudioapi adds a newline in this case, so must we.
-  // n_lines is a count, line is 0 indexed position hence + 1
-  const editStartLine = operation === 'insertText' ?
-    editLocation[0] :
-    editLocation.start[0];
-  if (editStartLine === 'Inf' ||
-    (editStartLine + 1 > targetDocument.lineCount && targetDocument.lineCount > 0)) {
-    return (text + '\n');
-  } else {
-    return text;
-  }
+    operation: string, targetDocument: TextDocument) {
+    // in a document with lines, does the line position extend past the existing
+    // lines in the document? rstudioapi adds a newline in this case, so must we.
+    // n_lines is a count, line is 0 indexed position hence + 1
+    const editStartLine = operation === 'insertText' ?
+        editLocation[0] :
+        editLocation.start[0];
+    if (editStartLine === 'Inf' ||
+        (editStartLine + 1 > targetDocument.lineCount && targetDocument.lineCount > 0)) {
+        return (text + '\n');
+    } else {
+        return text;
+    }
 }
 
 // window.onActiveTextEditorDidChange handler
 export function trackLastActiveTextEditor(editor?: TextEditor): void {
-  if (typeof editor !== 'undefined') {
-    lastActiveTextEditor = editor;
-  }
+    if (typeof editor !== 'undefined') {
+        lastActiveTextEditor = editor;
+    }
 }
 
 function getLastActiveTextEditor() {
-  return (typeof window.activeTextEditor === 'undefined' ?
-    lastActiveTextEditor : window.activeTextEditor);
+    return (typeof window.activeTextEditor === 'undefined' ?
+        lastActiveTextEditor : window.activeTextEditor);
 }
 
 function findTargetUri(id: string) {
-  return (id === null ?
-    getLastActiveTextEditor().document.uri : Uri.parse(id));
+    return (id === null ?
+        getLastActiveTextEditor().document.uri : Uri.parse(id));
 }
 
 async function reuseOrCreateEditor(targetDocument: TextDocument) {
-  // if there's a known text editor for a Uri, use it. if not, open a new one
-  // 'beside' the current one. We know about the last active, and all visible.
-  // Sometimes the last active is not visible in the case it was overtaken by a
-  // WebViewPanel.
+    // if there's a known text editor for a Uri, use it. if not, open a new one
+    // 'beside' the current one. We know about the last active, and all visible.
+    // Sometimes the last active is not visible in the case it was overtaken by a
+    // WebViewPanel.
 
-  const KnownEditors: TextEditor[] = [];
+    const KnownEditors: TextEditor[] = [];
 
-  KnownEditors.push(lastActiveTextEditor);
-  KnownEditors.push(...window.visibleTextEditors);
+    KnownEditors.push(lastActiveTextEditor);
+    KnownEditors.push(...window.visibleTextEditors);
 
 
-  const matchingTextEditors = KnownEditors.filter((editor) =>
-    editor.document.uri.toString() === targetDocument.uri.toString());
+    const matchingTextEditors = KnownEditors.filter((editor) =>
+        editor.document.uri.toString() === targetDocument.uri.toString());
 
-  if (matchingTextEditors.length === 0) {
-    const newEditor = await window.showTextDocument(
-      targetDocument,
-      ViewColumn.Beside
-    );
-    return (newEditor);
-  }
-  else {
-    return (matchingTextEditors[0]);
-  }
+    if (matchingTextEditors.length === 0) {
+        const newEditor = await window.showTextDocument(
+            targetDocument,
+            ViewColumn.Beside
+        );
+        return (newEditor);
+    }
+    else {
+        return (matchingTextEditors[0]);
+    }
 }

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -109,11 +109,13 @@ function isQuote(c: string) {
  * @param getEndsInOperator A function that returns whether the given line ends in an operator.
  * @param lineCount The number of lines in the document.
  */
-function getNextChar(p: PositionNeg,
-                     lookingForward: boolean,
-                     getLine: (x: number) => string,
-                     getEndsInOperator: (y: number) => boolean,
-                     lineCount: number) {
+function getNextChar(
+    p: PositionNeg,
+    lookingForward: boolean,
+    getLine: (x: number) => string,
+    getEndsInOperator: (y: number) => boolean,
+    lineCount: number
+){
     const s = getLine(p.line);
     let nextPos: PositionNeg;
     let isEndOfCodeLine = false;
@@ -207,12 +209,13 @@ export function extendSelection(line: number, getLine: (line: number) => string,
     let curChar = '';
     let quoteChar = '';
     while (!flagAbort && !(flagsFinish[0] && flagsFinish[1])) {
-        const { nextChar, nextPos, isEndOfCodeLine, isEndOfFile }
-        = getNextChar(poss[lookingForward ? 1 : 0],
-                      lookingForward,
-                      getLineFromCache,
-                      getEndsInOperatorFromCache,
-                      lineCount);
+        const { nextChar, nextPos, isEndOfCodeLine, isEndOfFile } = getNextChar(
+            poss[lookingForward ? 1 : 0],
+            lookingForward,
+            getLineFromCache,
+            getEndsInOperatorFromCache,
+            lineCount
+        );
         poss[Number(lookingForward)] = nextPos;
         if (quoteChar === '') {
             if (isQuote(nextChar)) {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -259,7 +259,7 @@ export function extendSelection(line: number, getLine: (line: number) => string,
                 flagAbort = true;
             }
         }
-        
+
         curChar = nextChar;
     }
     if (flagAbort) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -268,15 +268,15 @@ function getBrowserHtml(uri: Uri): string {
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
     html, body {
         height: 100%;
         padding: 0;
         overflow: hidden;
     }
-  </style>
+    </style>
 </head>
 <body>
     <iframe src="${uri.toString(true)}" width="100%" height="100%" frameborder="0" />
@@ -384,9 +384,9 @@ export async function getTableHtml(webview: Webview, file: string): Promise<stri
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style media="only screen">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style media="only screen">
     html, body {
         height: 100%;
         width: 100%;
@@ -477,12 +477,12 @@ export async function getTableHtml(webview: Webview, file: string): Promise<stri
     [class*="vscode"] input[class^=ag-] {
         border-color: var(--vscode-notificationCenter-border) !important;
     }
-  </style>
-  <script src="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'ag-grid-community.min.noStyle.js'))))}"></script>
-  <link href="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'ag-grid.min.css'))))}" rel="stylesheet">
-  <link href="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'ag-theme-balham.min.css'))))}" rel="stylesheet">
-  <link href="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'ag-theme-balham-dark.min.css'))))}" rel="stylesheet">
-  <script>
+    </style>
+    <script src="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'ag-grid-community.min.noStyle.js'))))}"></script>
+    <link href="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'ag-grid.min.css'))))}" rel="stylesheet">
+    <link href="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'ag-theme-balham.min.css'))))}" rel="stylesheet">
+    <link href="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'ag-theme-balham-dark.min.css'))))}" rel="stylesheet">
+    <script>
     const dateFilterParams = {
         browserDatePicker: true,
         comparator: function (filterLocalDateAtMidnight, cellValue) {
@@ -555,10 +555,10 @@ export async function getTableHtml(webview: Webview, file: string): Promise<stri
             characterData: false
         });
     }
-  </script>
+    </script>
 </head>
 <body onload='onload()'>
-  <div id="myGrid" style="height: 100%;"></div>
+    <div id="myGrid" style="height: 100%;"></div>
 </body>
 </html>
 `;
@@ -572,12 +572,12 @@ export async function getListHtml(webview: Webview, file: string): Promise<strin
 <!doctype HTML>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script src="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'jquery.min.js'))))}"></script>
-  <script src="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'jquery.json-viewer.js'))))}"></script>
-  <link href="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'jquery.json-viewer.css'))))}" rel="stylesheet">
-  <style type="text/css">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'jquery.min.js'))))}"></script>
+    <script src="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'jquery.json-viewer.js'))))}"></script>
+    <link href="${String(webview.asWebviewUri(Uri.file(path.join(resDir, 'jquery.json-viewer.css'))))}" rel="stylesheet">
+    <style type="text/css">
     body {
         color: var(--vscode-editor-foreground);
         background-color: var(--vscode-editor-background);
@@ -616,8 +616,8 @@ export async function getListHtml(webview: Webview, file: string): Promise<strin
     a.json-placeholder {
         color: var(--vscode-input-placeholderForeground);
     }
-  </style>
-  <script>
+    </style>
+    <script>
     var data = ${String(content)};
     $(document).ready(function() {
       var options = {
@@ -628,10 +628,10 @@ export async function getListHtml(webview: Webview, file: string): Promise<strin
       };
       $("#json-renderer").jsonViewer(data, options);
     });
-  </script>
+    </script>
 </head>
 <body>
-  <pre id="json-renderer"></pre>
+    <pre id="json-renderer"></pre>
 </body>
 </html>
 `;

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -44,7 +44,7 @@ const rtasks: RTaskInfo[] = [
         group: vscode.TaskGroup.Test,
         problemMatchers: '$testthat'
     },
-    
+
     {
         definition: {
             type: TYPE,
@@ -64,7 +64,7 @@ const rtasks: RTaskInfo[] = [
         group: vscode.TaskGroup.Build,
         problemMatchers: []
     },
-    
+
     {
         definition: {
             type: TYPE,
@@ -84,7 +84,7 @@ const rtasks: RTaskInfo[] = [
         group: vscode.TaskGroup.Build,
         problemMatchers: []
     },
-    
+
     {
         definition: {
             type: TYPE,
@@ -113,25 +113,25 @@ function asRTask(rPath: string, folder: vscode.WorkspaceFolder | vscode.TaskScop
         ),
         info.problemMatchers
     );
-    
+
     rtask.group = info.group;
     return rtask;
 }
 
 export class RTaskProvider implements vscode.TaskProvider {
-    
+
     public type = TYPE;
 
-    public async provideTasks(): Promise<vscode.Task[]> {        
+    public async provideTasks(): Promise<vscode.Task[]> {
         const folders = vscode.workspace.workspaceFolders;
-        
+
         if (!folders) {
             return [];
         }
-        
+
         const tasks: vscode.Task[] = [];
         const rPath = await getRpath(false);
-        
+
         for (const folder of folders) {
             const isRPackage = fs.existsSync(path.join(folder.uri.fsPath, 'DESCRIPTION'));
             if (isRPackage) {

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -3,21 +3,21 @@ import * as path from 'path';
 import { runTests } from 'vscode-test';
 
 async function main() {
-	try {
-		// The folder containing the Extension Manifest package.json
-		// Passed to `--extensionDevelopmentPath`
-		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+    try {
+        // The folder containing the Extension Manifest package.json
+        // Passed to `--extensionDevelopmentPath`
+        const extensionDevelopmentPath = path.resolve(__dirname, '../../');
 
-		// The path to the extension test script
-		// Passed to --extensionTestsPath
-		const extensionTestsPath = path.resolve(__dirname, './suite/index');
+        // The path to the extension test script
+        // Passed to --extensionTestsPath
+        const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
-		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
-	} catch (err) {
-		console.error('Failed to run tests');
-		process.exit(1);
-	}
+        // Download VS Code, unzip it and run the integration test
+        await runTests({ extensionDevelopmentPath, extensionTestsPath });
+    } catch (err) {
+        console.error('Failed to run tests');
+        process.exit(1);
+    }
 }
 
 void main();

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -5,35 +5,35 @@ import * as Mocha from 'mocha';
 import * as glob from 'glob';
 
 export function run(): Promise<void> {
-  // Create the mocha test
-  const mocha = new Mocha({
-    ui: 'tdd',
-    color: true
-  });
-
-  const testsRoot = path.resolve(__dirname, '..');
-
-  return new Promise((c, e) => {
-    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
-      if (err) {
-        return e(err);
-      }
-
-      // Add files to the test suite
-      files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
-
-      try {
-        // Run the mocha test
-        mocha.run(failures => {
-          if (failures > 0) {
-            e(new Error(`${failures} tests failed.`));
-          } else {
-            c();
-          }
-        });
-      } catch (err) {
-        e(err);
-      }
+    // Create the mocha test
+    const mocha = new Mocha({
+        ui: 'tdd',
+        color: true
     });
-  });
+
+    const testsRoot = path.resolve(__dirname, '..');
+
+    return new Promise((c, e) => {
+        glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+            if (err) {
+                return e(err);
+            }
+
+            // Add files to the test suite
+            files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+
+            try {
+                // Run the mocha test
+                mocha.run(failures => {
+                    if (failures > 0) {
+                        e(new Error(`${failures} tests failed.`));
+                    } else {
+                        c();
+                    }
+                });
+            } catch (err) {
+                e(err);
+            }
+        });
+    });
 }

--- a/src/test/suite/syntax.test.ts
+++ b/src/test/suite/syntax.test.ts
@@ -19,7 +19,7 @@ interface syntaxFile {
 
 /**
  * Converts a POSIX regular expression string into a format
- * that JavaScript can use. This is because vscode parses 
+ * that JavaScript can use. This is because vscode parses
  * syntax files using POSIX but JavaScript can't support it.
  * @param {string} s - A string to be used as a regular expression
  */
@@ -55,14 +55,14 @@ suite('Syntax Highlighting', () => {
         const match = re.exec(line);
         assert.strictEqual(match[3], 'function');
     });
-    
+
     test('function-declarations - extra spacing', () => {
         const re = new RegExp(function_pattern_fixed);
         const line = 'x <- function  (x) {';
         const match = re.exec(line);
         assert.strictEqual(match[3], 'function');
     });
-    
+
     test('function-declarations - false function', () => {
         const re = new RegExp(function_pattern_fixed);
         const line = 'x <- functions';

--- a/src/util.ts
+++ b/src/util.ts
@@ -333,7 +333,7 @@ export async function executeRCommand(rCommand: string, cwd?: string, fallback?:
         const re = new RegExp(`${lim}(.*)${lim}`, 'ms');
         const match = re.exec(result.stdout);
         if (match.length !== 2) {
-            throw new Error('Could not parse R output.');   
+            throw new Error('Could not parse R output.');
         }
         ret = match[1];
     } catch (e) {

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -241,8 +241,12 @@ export class GlobalEnvItem extends TreeItem {
         }
     }
 
-    private getTooltip(label:string, rClass: string,
-                size: number, treeLevel: number): string {
+    private getTooltip(
+        label:string,
+        rClass: string,
+        size: number,
+        treeLevel: number
+    ): string {
         if (size !== undefined && treeLevel === 0) {
             return `${label} (${rClass}, ${this.getSizeString(size)})`;
         } else if (treeLevel === 1) {

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -9,354 +9,354 @@ import { extensionContext, globalRHelp } from './extension';
 import { PackageNode } from './helpViewer/treeView';
 
 const collapsibleTypes: string[] = [
-	'list',
-	'environment'
+    'list',
+    'environment'
 ];
 
 async function populatePackageNodes(): Promise<void> {
-	const rootNode = globalRHelp?.treeViewWrapper.helpViewProvider.rootItem;
-	if (rootNode) {
-		// ensure the pkgRootNode is populated.
-		await rootNode.getChildren();
-		await rootNode.pkgRootNode.getChildren();
-	}
+    const rootNode = globalRHelp?.treeViewWrapper.helpViewProvider.rootItem;
+    if (rootNode) {
+        // ensure the pkgRootNode is populated.
+        await rootNode.getChildren();
+        await rootNode.pkgRootNode.getChildren();
+    }
 }
 
 function getPackageNode(name: string): PackageNode {
-	const rootNode = globalRHelp?.treeViewWrapper.helpViewProvider.rootItem;
-	if (rootNode) {
-		return rootNode.pkgRootNode.children?.find(node => node.label === name);
-	}
+    const rootNode = globalRHelp?.treeViewWrapper.helpViewProvider.rootItem;
+    if (rootNode) {
+        return rootNode.pkgRootNode.children?.find(node => node.label === name);
+    }
 }
 
 export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
-	private _onDidChangeTreeData: EventEmitter<void> = new EventEmitter();
-	readonly onDidChangeTreeData: Event<void> = this._onDidChangeTreeData.event;
+    private _onDidChangeTreeData: EventEmitter<void> = new EventEmitter();
+    readonly onDidChangeTreeData: Event<void> = this._onDidChangeTreeData.event;
 
-	refresh(): void {
-		this.data = isGuestSession ? guestWorkspace : workspaceData;
-		this._onDidChangeTreeData.fire();
-	}
+    refresh(): void {
+        this.data = isGuestSession ? guestWorkspace : workspaceData;
+        this._onDidChangeTreeData.fire();
+    }
 
-	data: WorkspaceData;
+    data: WorkspaceData;
 
-	private readonly attachedNamespacesRootItem: TreeItem;
-	private readonly loadedNamespacesRootItem: TreeItem;
-	private readonly globalEnvRootItem: TreeItem;
+    private readonly attachedNamespacesRootItem: TreeItem;
+    private readonly loadedNamespacesRootItem: TreeItem;
+    private readonly globalEnvRootItem: TreeItem;
 
-	constructor() {
-		this.attachedNamespacesRootItem = new TreeItem('Attached Namespaces', TreeItemCollapsibleState.Collapsed);
-		this.attachedNamespacesRootItem.id = 'attached-namespaces';
-		this.attachedNamespacesRootItem.iconPath = new ThemeIcon('library');
+    constructor() {
+        this.attachedNamespacesRootItem = new TreeItem('Attached Namespaces', TreeItemCollapsibleState.Collapsed);
+        this.attachedNamespacesRootItem.id = 'attached-namespaces';
+        this.attachedNamespacesRootItem.iconPath = new ThemeIcon('library');
 
-		this.loadedNamespacesRootItem = new TreeItem('Loaded Namespaces', TreeItemCollapsibleState.Collapsed);
-		this.loadedNamespacesRootItem.id = 'loaded-namespaces';
-		this.loadedNamespacesRootItem.iconPath = new ThemeIcon('package');
+        this.loadedNamespacesRootItem = new TreeItem('Loaded Namespaces', TreeItemCollapsibleState.Collapsed);
+        this.loadedNamespacesRootItem.id = 'loaded-namespaces';
+        this.loadedNamespacesRootItem.iconPath = new ThemeIcon('package');
 
-		this.globalEnvRootItem = new TreeItem('Global Environment', TreeItemCollapsibleState.Expanded);
-		this.globalEnvRootItem.id = 'globalenv';
-		this.globalEnvRootItem.iconPath = new ThemeIcon('menu');
+        this.globalEnvRootItem = new TreeItem('Global Environment', TreeItemCollapsibleState.Expanded);
+        this.globalEnvRootItem.id = 'globalenv';
+        this.globalEnvRootItem.iconPath = new ThemeIcon('menu');
 
-		extensionContext.subscriptions.push(
-			vscode.commands.registerCommand(PackageItem.command, async (node: PackageNode) => {
-				await node.showQuickPick();
-			})
-		);
-	}
+        extensionContext.subscriptions.push(
+            vscode.commands.registerCommand(PackageItem.command, async (node: PackageNode) => {
+                await node.showQuickPick();
+            })
+        );
+    }
 
-	getTreeItem(element: TreeItem): TreeItem {
-		return element;
-	}
+    getTreeItem(element: TreeItem): TreeItem {
+        return element;
+    }
 
-	async getChildren(element?: TreeItem): Promise<TreeItem[]> {
-		if (element) {
-			if (this.data === undefined) {
-				return [];
-			}
-			const pkgPrefix = 'package:';
-			if (element.id === 'attached-namespaces') {
-				await populatePackageNodes();
-				return this.data.search.map(name => {
-					if (name.startsWith(pkgPrefix)) {
-						const pkgName = name.substring(pkgPrefix.length);
-						const pkgNode = getPackageNode(pkgName);
-						return new PackageItem(name, pkgName, pkgNode);
-					} else {
-						const item = new TreeItem(name, TreeItemCollapsibleState.None);
-						item.iconPath = new ThemeIcon('symbol-array');
-						return item;
-					}
-				});
-			} else if (element.id === 'loaded-namespaces') {
-				await populatePackageNodes();
-				const attached_packages = this.data.search
-					.filter(name => name.startsWith(pkgPrefix))
-					.map(name => name.substring(pkgPrefix.length));
-				return this.data.loaded_namespaces.map(name => {
-					const pkgNode = getPackageNode(name);
-					const item = new PackageItem(name, name, pkgNode);
-					if (attached_packages.includes(name)) {
-						item.description = 'attached';
-					}
-					return item;
-				});
-			} else if (element.id === 'globalenv') {
-				return this.getGlobalEnvItems(this.data.globalenv);
-			} else if (element instanceof GlobalEnvItem) {
-				return element.str
-					.split('\n')
-					.filter((elem, index) => { return index > 0; })
-					.map(strItem =>
-						new GlobalEnvItem(
-							'',
-							'',
-							strItem.replace(/\s+/g, ' ').trim(),
-							'',
-							0,
-							element.treeLevel + 1
-						)
-					);
-			}
-		} else {
-			const treeItems = [this.attachedNamespacesRootItem, this.loadedNamespacesRootItem];
-			if (config().get<boolean>('session.watchGlobalEnvironment')) {
-				treeItems.push(this.globalEnvRootItem);
-			}
-			return treeItems;
-		}
-	}
+    async getChildren(element?: TreeItem): Promise<TreeItem[]> {
+        if (element) {
+            if (this.data === undefined) {
+                return [];
+            }
+            const pkgPrefix = 'package:';
+            if (element.id === 'attached-namespaces') {
+                await populatePackageNodes();
+                return this.data.search.map(name => {
+                    if (name.startsWith(pkgPrefix)) {
+                        const pkgName = name.substring(pkgPrefix.length);
+                        const pkgNode = getPackageNode(pkgName);
+                        return new PackageItem(name, pkgName, pkgNode);
+                    } else {
+                        const item = new TreeItem(name, TreeItemCollapsibleState.None);
+                        item.iconPath = new ThemeIcon('symbol-array');
+                        return item;
+                    }
+                });
+            } else if (element.id === 'loaded-namespaces') {
+                await populatePackageNodes();
+                const attached_packages = this.data.search
+                    .filter(name => name.startsWith(pkgPrefix))
+                    .map(name => name.substring(pkgPrefix.length));
+                return this.data.loaded_namespaces.map(name => {
+                    const pkgNode = getPackageNode(name);
+                    const item = new PackageItem(name, name, pkgNode);
+                    if (attached_packages.includes(name)) {
+                        item.description = 'attached';
+                    }
+                    return item;
+                });
+            } else if (element.id === 'globalenv') {
+                return this.getGlobalEnvItems(this.data.globalenv);
+            } else if (element instanceof GlobalEnvItem) {
+                return element.str
+                    .split('\n')
+                    .filter((elem, index) => { return index > 0; })
+                    .map(strItem =>
+                        new GlobalEnvItem(
+                            '',
+                            '',
+                            strItem.replace(/\s+/g, ' ').trim(),
+                            '',
+                            0,
+                            element.treeLevel + 1
+                        )
+                    );
+            }
+        } else {
+            const treeItems = [this.attachedNamespacesRootItem, this.loadedNamespacesRootItem];
+            if (config().get<boolean>('session.watchGlobalEnvironment')) {
+                treeItems.push(this.globalEnvRootItem);
+            }
+            return treeItems;
+        }
+    }
 
-	private getGlobalEnvItems(globalenv: GlobalEnv): GlobalEnvItem[] {
-		const toItem = (
-			key: string,
-			rClass: string,
-			str: string,
-			type: string,
-			size?: number,
-			dim?: number[]
-		): GlobalEnvItem => {
-			return new GlobalEnvItem(
-				key,
-				rClass,
-				str,
-				type,
-				size,
-				0,
-				dim,
-			);
-		};
+    private getGlobalEnvItems(globalenv: GlobalEnv): GlobalEnvItem[] {
+        const toItem = (
+            key: string,
+            rClass: string,
+            str: string,
+            type: string,
+            size?: number,
+            dim?: number[]
+        ): GlobalEnvItem => {
+            return new GlobalEnvItem(
+                key,
+                rClass,
+                str,
+                type,
+                size,
+                0,
+                dim,
+            );
+        };
 
-		const items = globalenv ? Object.keys(globalenv).map((key) =>
-			toItem(
-				key,
-				globalenv[key].class[0],
-				globalenv[key].str,
-				globalenv[key].type,
-				globalenv[key].size,
-				globalenv[key].dim,
-			)) : [];
+        const items = globalenv ? Object.keys(globalenv).map((key) =>
+            toItem(
+                key,
+                globalenv[key].class[0],
+                globalenv[key].str,
+                globalenv[key].type,
+                globalenv[key].size,
+                globalenv[key].dim,
+            )) : [];
 
-		function sortItems(a: GlobalEnvItem, b: GlobalEnvItem) {
-			if (a.priority > b.priority) {
-				return -1;
-			} else if (a.priority < b.priority) {
-				return 1;
-			} else {
-				return 0 || a.label.localeCompare(b.label);
-			}
-		}
+        function sortItems(a: GlobalEnvItem, b: GlobalEnvItem) {
+            if (a.priority > b.priority) {
+                return -1;
+            } else if (a.priority < b.priority) {
+                return 1;
+            } else {
+                return 0 || a.label.localeCompare(b.label);
+            }
+        }
 
-		return items.sort((a, b) => sortItems(a, b));
-	}
+        return items.sort((a, b) => sortItems(a, b));
+    }
 }
 
 class PackageItem extends TreeItem {
-	static command : string = 'r.workspaceViewer.package.showQuickPick';
-	label: string;
-	name: string;
-	pkgNode?: PackageNode;
-	constructor(label: string, name: string, pkgNode?: PackageNode) {
-		super(label, TreeItemCollapsibleState.None);
-		this.name = name;
-		this.iconPath = new ThemeIcon('symbol-package');
-		this.pkgNode = pkgNode;
-		if (pkgNode) {
-			this.tooltip = new vscode.MarkdownString(pkgNode.pkg.description);
-			this.command = {
-				command: PackageItem.command,
-				title: 'Show Quick Pick',
-				arguments: [pkgNode]
-			};
-		}
-	}
+    static command : string = 'r.workspaceViewer.package.showQuickPick';
+    label: string;
+    name: string;
+    pkgNode?: PackageNode;
+    constructor(label: string, name: string, pkgNode?: PackageNode) {
+        super(label, TreeItemCollapsibleState.None);
+        this.name = name;
+        this.iconPath = new ThemeIcon('symbol-package');
+        this.pkgNode = pkgNode;
+        if (pkgNode) {
+            this.tooltip = new vscode.MarkdownString(pkgNode.pkg.description);
+            this.command = {
+                command: PackageItem.command,
+                title: 'Show Quick Pick',
+                arguments: [pkgNode]
+            };
+        }
+    }
 }
 
 export class GlobalEnvItem extends TreeItem {
-	label: string;
-	desc: string;
-	str: string;
-	type: string;
-	treeLevel: number;
-	contextValue: string;
-	priority: number;
+    label: string;
+    desc: string;
+    str: string;
+    type: string;
+    treeLevel: number;
+    contextValue: string;
+    priority: number;
 
-	constructor(
-		label: string,
-		rClass: string,
-		str: string,
-		type: string,
-		size: number,
-		treeLevel: number,
-		dim?: number[],
-	) {
-		super(label, GlobalEnvItem.setCollapsibleState(treeLevel, type, str));
-		this.description = this.getDescription(dim, str, rClass, type);
-		this.tooltip = this.getTooltip(label, rClass, size, treeLevel);
-		this.iconPath = this.getIcon(type, dim);
-		this.type = type;
-		this.str = str;
-		this.treeLevel = treeLevel;
-		this.contextValue = treeLevel === 0 ? 'rootNode' : `childNode${treeLevel}`;
-		this.priority = dim ? 1 : 0;
-	}
+    constructor(
+        label: string,
+        rClass: string,
+        str: string,
+        type: string,
+        size: number,
+        treeLevel: number,
+        dim?: number[],
+    ) {
+        super(label, GlobalEnvItem.setCollapsibleState(treeLevel, type, str));
+        this.description = this.getDescription(dim, str, rClass, type);
+        this.tooltip = this.getTooltip(label, rClass, size, treeLevel);
+        this.iconPath = this.getIcon(type, dim);
+        this.type = type;
+        this.str = str;
+        this.treeLevel = treeLevel;
+        this.contextValue = treeLevel === 0 ? 'rootNode' : `childNode${treeLevel}`;
+        this.priority = dim ? 1 : 0;
+    }
 
-	private getDescription(dim: number[], str: string, rClass: string, type: string): string {
-		if (dim && type === 'list') {
-			if (dim[1] === 1) {
-				return `${rClass}: ${dim[0]} obs. of ${dim[1]} variable`;
-			} else {
-				return `${rClass}: ${dim[0]} obs. of ${dim[1]} variables`;
-			}
-		} else {
-			return str;
-		}
-	}
+    private getDescription(dim: number[], str: string, rClass: string, type: string): string {
+        if (dim && type === 'list') {
+            if (dim[1] === 1) {
+                return `${rClass}: ${dim[0]} obs. of ${dim[1]} variable`;
+            } else {
+                return `${rClass}: ${dim[0]} obs. of ${dim[1]} variables`;
+            }
+        } else {
+            return str;
+        }
+    }
 
-	private getSizeString(bytes: number): string {
-		if (bytes < 1024) {
-			return `${bytes} bytes`;
-		} else {
-			const e = Math.floor(Math.log(bytes) / Math.log(1024));
-			return (bytes / Math.pow(1024, e)).toFixed(0) + 'KMGTP'.charAt(e - 1) + 'b';
-		}
-	}
+    private getSizeString(bytes: number): string {
+        if (bytes < 1024) {
+            return `${bytes} bytes`;
+        } else {
+            const e = Math.floor(Math.log(bytes) / Math.log(1024));
+            return (bytes / Math.pow(1024, e)).toFixed(0) + 'KMGTP'.charAt(e - 1) + 'b';
+        }
+    }
 
-	private getTooltip(label:string, rClass: string,
-				size: number, treeLevel: number): string {
-		if (size !== undefined && treeLevel === 0) {
-			return `${label} (${rClass}, ${this.getSizeString(size)})`;
-		} else if (treeLevel === 1) {
-			return null;
-		} else {
-			return `${label} (${rClass})`;
-		}
-	}
+    private getTooltip(label:string, rClass: string,
+                size: number, treeLevel: number): string {
+        if (size !== undefined && treeLevel === 0) {
+            return `${label} (${rClass}, ${this.getSizeString(size)})`;
+        } else if (treeLevel === 1) {
+            return null;
+        } else {
+            return `${label} (${rClass})`;
+        }
+    }
 
-	private getIcon(type: string, dim?: number[]) {
-		let name: string;
-		if (dim) {
-			name = 'symbol-array';
-		} else if (type === 'closure' || type === 'builtin') {
-			name = 'symbol-function';
-		} else if (type === '') {
-			name = 'symbol-variable';
-		} else {
-			name = 'symbol-field';
-		}
-		return new ThemeIcon(name);
-	}
+    private getIcon(type: string, dim?: number[]) {
+        let name: string;
+        if (dim) {
+            name = 'symbol-array';
+        } else if (type === 'closure' || type === 'builtin') {
+            name = 'symbol-function';
+        } else if (type === '') {
+            name = 'symbol-variable';
+        } else {
+            name = 'symbol-field';
+        }
+        return new ThemeIcon(name);
+    }
 
-	/* This logic has to be implemented this way to allow it to be called
-	during the super constructor above. I created it to give full control
-	of what elements can have have 'child' nodes os not. It can be expanded
-	in the futere for more tree levels.*/
+    /* This logic has to be implemented this way to allow it to be called
+    during the super constructor above. I created it to give full control
+    of what elements can have have 'child' nodes os not. It can be expanded
+    in the futere for more tree levels.*/
 
-	private static setCollapsibleState(treeLevel: number, type: string, str: string) {
-		if (treeLevel === 0 && collapsibleTypes.includes(type) && str.includes('\n')){
-			return TreeItemCollapsibleState.Collapsed;
-		} else {
-			return TreeItemCollapsibleState.None;
-		}
-	}
+    private static setCollapsibleState(treeLevel: number, type: string, str: string) {
+        if (treeLevel === 0 && collapsibleTypes.includes(type) && str.includes('\n')){
+            return TreeItemCollapsibleState.Collapsed;
+        } else {
+            return TreeItemCollapsibleState.None;
+        }
+    }
 }
 
 export function clearWorkspace(): void {
-	const removeHiddenItems: boolean = config().get('workspaceViewer.removeHiddenItems');
-	const promptUser: boolean = config().get('workspaceViewer.clearPrompt');
+    const removeHiddenItems: boolean = config().get('workspaceViewer.removeHiddenItems');
+    const promptUser: boolean = config().get('workspaceViewer.clearPrompt');
 
-	if ((isGuestSession ? guestWorkspace : workspaceData) !== undefined) {
-		if (promptUser) {
-			void window.showInformationMessage(
-				'Are you sure you want to clear the workspace? This cannot be reversed.',
-				'Confirm',
-				'Cancel'
-			).then(selection => {
-				if (selection === 'Confirm') {
-					clear();
-				}
-			});
-		} else {
-			clear();
-		}
-	}
+    if ((isGuestSession ? guestWorkspace : workspaceData) !== undefined) {
+        if (promptUser) {
+            void window.showInformationMessage(
+                'Are you sure you want to clear the workspace? This cannot be reversed.',
+                'Confirm',
+                'Cancel'
+            ).then(selection => {
+                if (selection === 'Confirm') {
+                    clear();
+                }
+            });
+        } else {
+            clear();
+        }
+    }
 
-	function clear() {
-		const hiddenText = 'rm(list = ls(all.names = TRUE))';
-		const text = 'rm(list = ls())';
-		if (removeHiddenItems) {
-			void runTextInTerm(`${hiddenText}`);
-		} else {
-			void runTextInTerm(`${text}`);
-		}
-	}
+    function clear() {
+        const hiddenText = 'rm(list = ls(all.names = TRUE))';
+        const text = 'rm(list = ls())';
+        if (removeHiddenItems) {
+            void runTextInTerm(`${hiddenText}`);
+        } else {
+            void runTextInTerm(`${text}`);
+        }
+    }
 }
 
 export function saveWorkspace(): void {
-	if (workspaceData !== undefined) {
-		void window.showSaveDialog({
-			defaultUri: Uri.file(path.join(workingDir, 'workspace.RData')),
-			filters: {
-				'RData': ['RData']
-			},
-			title: 'Save Workspace'
-		}
-		).then(async (uri: Uri | undefined) => {
-			if (uri) {
-				return runTextInTerm(
-					`save.image("${(uri.fsPath.split(path.sep).join(path.posix.sep))}")`
-				);
-			}
-		});
-	}
+    if (workspaceData !== undefined) {
+        void window.showSaveDialog({
+            defaultUri: Uri.file(path.join(workingDir, 'workspace.RData')),
+            filters: {
+                'RData': ['RData']
+            },
+            title: 'Save Workspace'
+        }
+        ).then(async (uri: Uri | undefined) => {
+            if (uri) {
+                return runTextInTerm(
+                    `save.image("${(uri.fsPath.split(path.sep).join(path.posix.sep))}")`
+                );
+            }
+        });
+    }
 }
 
 export function loadWorkspace(): void {
-	if (workspaceData !== undefined) {
-		void window.showOpenDialog({
-			defaultUri: Uri.file(workingDir),
-			filters: {
-				'Data': ['RData'],
-			},
-			title: 'Load workspace'
-		}).then(async (uri: Uri[] | undefined) => {
-			if (uri) {
-				const savePath = uri[0].fsPath.split(path.sep).join(path.posix.sep);
-				return runTextInTerm(
-					`load("${(savePath)}")`
-				);
-			}
-		});
-	}
+    if (workspaceData !== undefined) {
+        void window.showOpenDialog({
+            defaultUri: Uri.file(workingDir),
+            filters: {
+                'Data': ['RData'],
+            },
+            title: 'Load workspace'
+        }).then(async (uri: Uri[] | undefined) => {
+            if (uri) {
+                const savePath = uri[0].fsPath.split(path.sep).join(path.posix.sep);
+                return runTextInTerm(
+                    `load("${(savePath)}")`
+                );
+            }
+        });
+    }
 }
 
 export function viewItem(node: string): void {
-	if (isLiveShare()) {
-		void runTextInTerm(`View(${node}, uuid = ${UUID})`);
-	} else {
-		void runTextInTerm(`View(${node})`);
-	}
+    if (isLiveShare()) {
+        void runTextInTerm(`View(${node}, uuid = ${UUID})`);
+    } else {
+        void runTextInTerm(`View(${node})`);
+    }
 }
 
 export function removeItem(node: string): void {
-	void runTextInTerm(`rm(${node})`);
+    void runTextInTerm(`rm(${node})`);
 }


### PR DESCRIPTION
Converts indentation in all ts files (where necessary) to 4 spaces and adds an eslint rule to enforce this indentation. Approximately 90% of ts files followed this convention anyways, so I assumed this change would be rather uncontroversial.

This PR should not change any actual code behavior.

Enforcing linter rules for e.g. R and json files might also make sense, but should be discussed in a separate issue/PR.