### PR TITLE
Remove encoding param from knitting

### DIFF
--- a/src/rmarkdown/knit.ts
+++ b/src/rmarkdown/knit.ts
@@ -241,9 +241,7 @@ export class RMarkdownKnitManager extends RMarkdownManager {
             return;
         }
         let rDocumentPath = util.ToRStringLiteral(wad.fileName, '"');
-        let encodingParam = util.config().get<string>('source.encoding');
-        encodingParam = `encoding = "${encodingParam}"`;
-        rDocumentPath = [rDocumentPath, encodingParam].join(', ');
+
         if (echo) {
             rDocumentPath = [rDocumentPath, 'echo = TRUE'].join(', ');
         }


### PR DESCRIPTION
# What problem did you solve?

Solves #1166. We currently pass an encoding param to the knitting render process, which can cause issues when a given renderer does not have an encoding parameter. The [encoding parameter of `rmarkdown::render` is also ignored by rmarkdown](https://pkgs.rstudio.com/rmarkdown/reference/render.html) anyway, meaning that there is no point to passing the parameter.

## How can I check this pull request?

Knitting the following will fail on the live version of vscode-r

``````
---
title: Test
knit: quarto::quarto_render
---

Test.

``````
