### PR TITLE
Reload help pages on help refresh

### DIFF
--- a/html/help/script.js
+++ b/html/help/script.js
@@ -13,21 +13,12 @@ window.onmousedown = (ev) => {
         scrollY: window.scrollY
     });
 };
-// handle back/forward requests from vscode ui
-// simulates a mousclick on key 3 or 4
+// handle requests from vscode ui
 window.addEventListener('message', (ev) => {
     const message = ev.data;
-    if (message.command === 'goBack') {
+    if (message.command === 'getScrollY') {
         vscode.postMessage({
-            message: 'mouseClick',
-            button: 3,
-            scrollY: window.scrollY
-        });
-    }
-    else if (message.command === 'goForward') {
-        vscode.postMessage({
-            message: 'mouseClick',
-            button: 4,
+            message: 'getScrollY',
             scrollY: window.scrollY
         });
     }

--- a/html/help/script.ts
+++ b/html/help/script.ts
@@ -19,20 +19,12 @@ window.onmousedown = (ev) => {
 };
 
 
-// handle back/forward requests from vscode ui
-// simulates a mousclick on key 3 or 4
+// handle requests from vscode ui
 window.addEventListener('message', (ev) => {
     const message = ev.data;
-    if(message.command === 'goBack'){
+    if(message.command === 'getScrollY'){
         vscode.postMessage({
-            message: 'mouseClick',
-            button: 3,
-            scrollY: window.scrollY
-        });
-    } else if(message.command === 'goForward'){
-        vscode.postMessage({
-            message: 'mouseClick',
-            button: 4,
+            message: 'getScrollY',
             scrollY: window.scrollY
         });
     }

--- a/html/help/webviewMessages.d.ts
+++ b/html/help/webviewMessages.d.ts
@@ -33,6 +33,10 @@ interface CodeClickedMessage extends IOutMessage {
         metaKey: boolean,
     }
 }
+interface GetScrollYMessage extends IOutMessage {
+    message: 'getScrollY',
+    scrollY: number
+}
 
-type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage | CodeClickedMessage;
+type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage | CodeClickedMessage | GetScrollYMessage;
 

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -262,6 +262,9 @@ export class RHelp implements api.HelpPanel, vscode.WebviewPanelSerializer<strin
         if (refreshTreeView) {
             this.treeViewWrapper.refreshPackageRootNode();
         }
+        for (const panel of this.helpPanels) {
+            await panel.refresh();
+        }
         return true;
     }
 

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -20,6 +20,7 @@ export interface HelpPanelOptions {
 // internal interface used to store history of help panel
 interface HistoryEntry {
     helpFile: HelpFile;
+    isStale?: boolean; // Used to mark history entries as stale after a refresh
 }
 
 export class HelpPanel {
@@ -42,6 +43,9 @@ export class HelpPanel {
     private currentEntry: HistoryEntry|undefined = undefined;
     private history: HistoryEntry[] = [];
     private forwardHistory: HistoryEntry[] = [];
+    
+    // used to get scrollY position from webview:
+    private scrollYCallback?: (y: number) => void;
 
     constructor(options: HelpPanelOptions, rHelp: RHelp, panel?: vscode.WebviewPanel){
         this.webviewScriptFile = vscode.Uri.file(options.webviewScriptPath);
@@ -58,6 +62,15 @@ export class HelpPanel {
         if(this.panel){
             this.panel.dispose();
         }
+    }
+    
+    public async refresh(): Promise<void> {
+        for (const he of [...this.history, ...this.forwardHistory]) {
+            he.isStale = true;
+        }
+        const newHelpFile = await this.rHelp.getHelpFileForPath(this.currentEntry.helpFile.requestPath);
+        newHelpFile.scrollY = await this.getScrollY();
+        await this.showHelpFile(newHelpFile, false, undefined, undefined, true);
     }
 
     // retrieves the stored webview or creates a new one if the webview was closed
@@ -143,7 +156,7 @@ export class HelpPanel {
         // modify html
         helpFile = this.pimpMyHelp(helpFile, this.webviewStyleUri, this.webviewScriptUri);
 
-        // actually show the hel page
+        // actually show the help page
         webview.html = helpFile.html;
 
         // update history to enable back/forward
@@ -179,8 +192,9 @@ export class HelpPanel {
     }
 
     // go back/forward in the history of the webview:
-    public goBack(): void {
-        void this.panel?.webview.postMessage({command: 'goBack'});
+    public async goBack(): Promise<void> {
+        const scrollY = await this.getScrollY();
+        this._goBack(scrollY);
     }
     private _goBack(currentScrollY = 0): void{
         const entry = this.history.pop();
@@ -189,11 +203,12 @@ export class HelpPanel {
                 this.currentEntry.helpFile.scrollY = currentScrollY;
                 this.forwardHistory.push(this.currentEntry);
             }
-            this.showHistoryEntry(entry);
+            void this.showHistoryEntry(entry);
         }
     }
-    public goForward(): void {
-        void this.panel?.webview.postMessage({command: 'goForward'});
+    public async goForward(): Promise<void> {
+        const scrollY = await this.getScrollY();
+        this._goForward(scrollY);
     }
     private _goForward(currentScrollY = 0): void{
         const entry = this.forwardHistory.pop();
@@ -202,12 +217,33 @@ export class HelpPanel {
                 this.currentEntry.helpFile.scrollY = currentScrollY;
                 this.history.push(this.currentEntry);
             }
-            this.showHistoryEntry(entry);
+            void this.showHistoryEntry(entry);
         }
     }
-    private showHistoryEntry(entry: HistoryEntry){
-        const helpFile = entry.helpFile;
+    private async showHistoryEntry(entry: HistoryEntry){
+        let helpFile: HelpFile;
+        if(entry.isStale){
+            helpFile = await this.rHelp.getHelpFileForPath(entry.helpFile.requestPath);
+            helpFile.scrollY = entry.helpFile.scrollY;
+        } else{
+            helpFile = entry.helpFile;
+        }
         void this.showHelpFile(helpFile, false);
+    }
+
+    // Get current scrollY from webview
+    private async getScrollY(): Promise<number> {
+        this.scrollYCallback?.(0);
+        const scrollYPromise = new Promise<number>((resolve, reject) => {
+            const timeout = setTimeout(() => reject('GetScrollY message timed out after 1s'), 1000);
+            this.scrollYCallback = (y: number) => {
+                clearTimeout(timeout);
+                this.scrollYCallback = undefined;
+                resolve(y);
+            };
+        });
+        this.panel?.webview.postMessage({command: 'getScrollY'});
+        return scrollYPromise;
     }
 
     // handle message produced by javascript inside the help page
@@ -293,6 +329,8 @@ export class HelpPanel {
             if(runCode){
                 void runTextInTerm(msg.code);
             }
+        } else if(msg.message === 'getScrollY'){
+            this.scrollYCallback?.(msg.scrollY || 0);
         } else{
             console.log('Unknown message:', msg);
         }

--- a/src/helpViewer/webviewMessages.d.ts
+++ b/src/helpViewer/webviewMessages.d.ts
@@ -39,7 +39,11 @@ export interface CodeClickedMessage extends IMessage {
         metaKey: boolean,
     }
 }
+export interface GetScrollYMessage extends IMessage {
+    message: 'getScrollY',
+    scrollY: number
+}
 
-export type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage | CodeClickedMessage;
+export type OutMessage = LogMessage | MouseClickMessage | LinkClickedMessage | CodeClickedMessage | GetScrollYMessage;
 
 


### PR DESCRIPTION
This PR adds a `refresh()` method to the `HelpPanel` class that reloads the currently shown help page (and marks cached history entries as stale). This method is now called as part of the `Clear Cache & Restart Help Server` command meaning that is no longer necessary to manually close and re-open help pages after installed packages change.

How to test:
Open a help page for package X, install a different version of X, click `Clear Cache & Restart Help Server` (this might not even be necessary if the code in [helpServer.R](https://github.com/REditorSupport/vscode-R/blob/master/R/help/helpServer.R) notices the change), check that the shown help page updates.

