### PR TITLE
Avoid .R file lock on windows

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,7 @@
       "command": "vsce",
       "args": [
         "package",
+        "--yarn",
         "-o",
         "${workspaceFolderBasename}.vsix"
       ]

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -47,7 +47,10 @@ export class HelpProvider {
 
         // starts the background help server and waits forever to keep the R process running
         const scriptPath = extensionContext.asAbsolutePath('R/help/helpServer.R');
-        const scriptExpression = `"base::source('${scriptPath.replaceAll('\\', '\\\\')}')"`;
+        const scriptExpression = (process.platform === 'win32' ? 
+            `"base::source('${scriptPath.replaceAll('\\', '\\\\')}')"` :
+            `base::source('${scriptPath}')`
+        );
         const args = [
             '--silent',
             '--slave',

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -47,17 +47,15 @@ export class HelpProvider {
 
         // starts the background help server and waits forever to keep the R process running
         const scriptPath = extensionContext.asAbsolutePath('R/help/helpServer.R');
-        const scriptExpression = (process.platform === 'win32' ? 
-            `"base::source('${scriptPath.replaceAll('\\', '\\\\')}')"` :
-            `base::source('${scriptPath}')`
-        );
         const args = [
             '--silent',
             '--slave',
             '--no-save',
             '--no-restore',
             '-e',
-            scriptExpression
+            'base::source(base::commandArgs(TRUE))',
+            '--args',
+            scriptPath
         ];
         const cpOptions = {
             cwd: this.cwd,

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -47,14 +47,14 @@ export class HelpProvider {
 
         // starts the background help server and waits forever to keep the R process running
         const scriptPath = extensionContext.asAbsolutePath('R/help/helpServer.R');
-        // const cmd = `${this.rPath} --silent --slave --no-save --no-restore -f "${scriptPath}"`;
+        const scriptExpression = `"base::source('${scriptPath.replaceAll('\\', '\\\\')}')"`;
         const args = [
             '--silent',
             '--slave',
             '--no-save',
             '--no-restore',
-            '-f',
-            scriptPath
+            '-e',
+            scriptExpression
         ];
         const cpOptions = {
             cwd: this.cwd,

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -79,14 +79,15 @@ export class LanguageService implements Disposable {
         }
 
         const rScriptPath = extensionContext.asAbsolutePath('R/languageServer.R');
+        const scriptExpression = `"base::source('${rScriptPath.replaceAll('\\', '\\\\')}')"`;
         const options = { cwd: cwd, env: env };
         const args = config.get<string[]>('lsp.args').concat(
             '--silent',
             '--slave',
             '--no-save',
             '--no-restore',
-            '-f',
-            rScriptPath
+            '-e',
+            scriptExpression
         );
 
         const tcpServerOptions = () => new Promise<DisposableProcess | StreamInfo>((resolve, reject) => {

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -79,10 +79,6 @@ export class LanguageService implements Disposable {
         }
 
         const rScriptPath = extensionContext.asAbsolutePath('R/languageServer.R');
-        const scriptExpression = (process.platform === 'win32' ? 
-            `"base::source('${rScriptPath.replaceAll('\\', '\\\\')}')"` :
-            `base::source('${rScriptPath}')`
-        );
         const options = { cwd: cwd, env: env };
         const args = config.get<string[]>('lsp.args').concat(
             '--silent',
@@ -90,7 +86,9 @@ export class LanguageService implements Disposable {
             '--no-save',
             '--no-restore',
             '-e',
-            scriptExpression
+            'base::source(base::commandArgs(TRUE))',
+            '--args',
+            rScriptPath
         );
 
         const tcpServerOptions = () => new Promise<DisposableProcess | StreamInfo>((resolve, reject) => {

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -79,7 +79,10 @@ export class LanguageService implements Disposable {
         }
 
         const rScriptPath = extensionContext.asAbsolutePath('R/languageServer.R');
-        const scriptExpression = `"base::source('${rScriptPath.replaceAll('\\', '\\\\')}')"`;
+        const scriptExpression = (process.platform === 'win32' ? 
+            `"base::source('${rScriptPath.replaceAll('\\', '\\\\')}')"` :
+            `base::source('${rScriptPath}')`
+        );
         const options = { cwd: cwd, env: env };
         const args = config.get<string[]>('lsp.args').concat(
             '--silent',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es2018",
+        "target": "ES2021",
         "outDir": "out",
         "lib": [
-            "es2018"
+            "ES2021"
         ],
         "sourceMap": true,
         // "strictNullChecks": true,


### PR DESCRIPTION
This PR avoids a file lock issue (observed on windows, probably not an issue on linux): Sourcing .R file using `R -f xxx.R` locks the file and as a consequence it's impossible to reinstall this extension while it is running. This is particularly annoying when working on the extension itself, since it contains R code and is therefore activated automatically.

This problem is solved by sourcing .R files using `R -e source('xxx.r')`, which does not appear to lock the file.
