### PR TITLE
Fix empty code examples

### DIFF
--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -583,7 +583,7 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
         const codeSections = $('pre');
         codeSections.each((i, section) => {
             const innerHtml = $(section).html();
-            const newPres = innerHtml.split('\n\n').map(s => `<pre>${s}</pre>`);
+            const newPres = innerHtml.split('\n\n').map(s => s && `<pre>${s}</pre>`);
             const newHtml = '<div class="preDiv">' + newPres.join('\n') + '</div>';
             $(section).replaceWith(newHtml);
         });


### PR DESCRIPTION
This PR fixes a small issue with help pages where an empty line at the end of code would be highlighted as if it was a clickable example.