### PR TITLE
Refactoring: Strict TypeScript Fix #1208

### DIFF
--- a/html/help/script.ts
+++ b/html/help/script.ts
@@ -1,9 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 declare function acquireVsCodeApi(): VsCode;
 
 const vscode = acquireVsCodeApi();
@@ -20,8 +14,10 @@ window.onmousedown = (ev) => {
 
 
 // handle requests from vscode ui
-window.addEventListener('message', (ev) => {
+window.addEventListener('message', (ev: MessageEvent) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const message = ev.data;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if(message.command === 'getScrollY'){
         vscode.postMessage({
             message: 'getScrollY',

--- a/html/help/tsconfig.json
+++ b/html/help/tsconfig.json
@@ -8,7 +8,10 @@
             "DOM"
         ],
         "sourceMap": false,
-        "strictNullChecks": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "strict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "noFallthroughCasesInSwitch": true
     }
 }

--- a/html/httpgd/index.ts
+++ b/html/httpgd/index.ts
@@ -172,7 +172,7 @@ function togglePreviewPlotLayout(newStyle: PreviewPlotLayout): void {
     smallPlotDiv.classList.add(newStyle);
 }
 
-function toggleFullWindowMode(useFullWindow): void {
+function toggleFullWindowMode(useFullWindow: boolean): void {
     isFullWindow = useFullWindow;
     if(useFullWindow){
         document.body.classList.add('fullWindow');

--- a/html/httpgd/index.ts
+++ b/html/httpgd/index.ts
@@ -30,7 +30,6 @@ const largePlotDiv = document.querySelector('#largePlot') as HTMLDivElement;
 const largeSvg = largePlotDiv.querySelector('svg') as SVGElement;
 const cssLink = document.querySelector('link.overwrites') as HTMLLinkElement;
 const smallPlotDiv = document.querySelector('#smallPlots') as HTMLDivElement;
-const placeholderDiv = document.querySelector('#placeholder') as HTMLDivElement;
 
 
 function getSmallPlots(): HTMLAnchorElement[] {

--- a/html/httpgd/tsconfig.json
+++ b/html/httpgd/tsconfig.json
@@ -8,7 +8,10 @@
             "DOM"
         ],
         "sourceMap": false,
-        "strictNullChecks": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "strict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "noFallthroughCasesInSwitch": true
     }
 }

--- a/package.json
+++ b/package.json
@@ -1915,6 +1915,7 @@
     "@types/ejs": "^3.0.6",
     "@types/express": "^4.17.12",
     "@types/fs-extra": "^9.0.11",
+    "@types/glob": "^8.0.0",
     "@types/js-yaml": "^4.0.2",
     "@types/mocha": "^8.2.2",
     "@types/node": "^16.11.7",

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -30,7 +30,7 @@ const roxygenTagCompletionItems = [
 
 
 export class HoverProvider implements vscode.HoverProvider {
-    provideHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover {
+    provideHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover | null {
         if(!session.workspaceData?.globalenv){
             return null;
         }
@@ -56,7 +56,7 @@ export class HoverProvider implements vscode.HoverProvider {
 }
 
 export class HelpLinkHoverProvider implements vscode.HoverProvider {
-    async provideHover(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.Hover> {
+    async provideHover(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.Hover | null> {
         if(!config().get<boolean>('helpPanel.enableHoverLinks')){
             return null;
         }
@@ -114,7 +114,7 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
         token: vscode.CancellationToken,
         completionContext: vscode.CompletionContext
     ): vscode.CompletionItem[] {
-        const items = [];
+        const items: vscode.CompletionItem[] = [];
         if (token.isCancellationRequested || !session.workspaceData?.globalenv) {
             return items;
         }
@@ -148,7 +148,7 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
             const symbol = document.getText(symbolRange);
             const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
             const obj = session.workspaceData.globalenv[symbol];
-            let names: string[];
+            let names: string[] | undefined;
             if (obj !== undefined) {
                 if (completionContext.triggerCharacter === '$') {
                     names = obj.names;
@@ -187,14 +187,14 @@ function getCompletionItems(names: string[], kind: vscode.CompletionItemKind, de
     });
 }
 
-function getBracketCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken) {
+function getBracketCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.CompletionItem[] {
     const items: vscode.CompletionItem[] = [];
-    let range = new vscode.Range(new vscode.Position(position.line, 0), position);
+    let range: vscode.Range | undefined = new vscode.Range(new vscode.Position(position.line, 0), position);
     let expectOpenBrackets = 0;
-    let symbol: string;
+    let symbol: string | undefined = undefined;
 
     while (range) {
-        if (token.isCancellationRequested) { return; }
+        if (token.isCancellationRequested) { return []; }
         const text = document.getText(range);
         for (let i = text.length - 1; i >= 0; i -= 1) {
             const chr = text.charAt(i);
@@ -212,7 +212,7 @@ function getBracketCompletionItems(document: vscode.TextDocument, position: vsco
                 }
             }
         }
-        if (range?.start.line > 0) {
+        if (range?.start?.line !== undefined && range.start.line > 0) {
             range = document.lineAt(range.start.line - 1).range; // check previous line
         } else {
             range = undefined;
@@ -229,10 +229,10 @@ function getBracketCompletionItems(document: vscode.TextDocument, position: vsco
     return items;
 }
 
-function getPipelineCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken) {
+function getPipelineCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.CompletionItem[] {
     const items: vscode.CompletionItem[] = [];
     const range = extendSelection(position.line, (x) => document.lineAt(x).text, document.lineCount);
-    let symbol: string;
+    let symbol: string | undefined = undefined;
 
     for (let i = range.startLine; i <= range.endLine; i++) {
         if (token.isCancellationRequested) {

--- a/src/cppProperties.ts
+++ b/src/cppProperties.ts
@@ -38,6 +38,9 @@ function platformChoose<A, B, C>(win32: A, darwin: B, other: C): A | B | C {
 // See: https://code.visualstudio.com/docs/cpp/c-cpp-properties-schema-reference
 async function generateCppPropertiesProc(workspaceFolder: string) {
     const rPath = await getRpath();
+    if (!rPath) {
+        return;
+    }
 
     // Collect information from running the compiler
     const configureFile = platformChoose('configure.win', 'configure', 'configure');
@@ -64,10 +67,10 @@ async function generateCppPropertiesProc(workspaceFolder: string) {
     const compileStdCpp = extractCompilerStd(compileOutputCpp);
     const compileStdC = extractCompilerStd(compileOutputC);
     const compileCall = extractCompilerCall(compileOutputCpp);
-    const compilerPath = await executeRCommand(`cat(Sys.which("${compileCall}"))`, workspaceFolder, (e: Error) => {
+    const compilerPath = compileCall ? await executeRCommand(`cat(Sys.which("${compileCall}"))`, workspaceFolder, (e: Error) => {
         void window.showErrorMessage(e.message);
         return '';
-    });
+    }) : '';
 
     const intelliSensePlatform = platformChoose('windows', 'macos', 'linux');
     const intelliSenseComp = compileCall ? (compileCall.includes('clang') ? 'clang' : 'gcc') : 'gcc';

--- a/src/cppProperties.ts
+++ b/src/cppProperties.ts
@@ -1,10 +1,9 @@
 'use strict';
 
-import { randomBytes } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { window } from 'vscode';
-import { getRpath, getCurrentWorkspaceFolder, executeRCommand } from './util';
+import { getRpath, getCurrentWorkspaceFolder, executeRCommand, createTempDir } from './util';
 import { execSync } from 'child_process';
 import { extensionContext } from './extension';
 
@@ -176,13 +175,6 @@ function extractCompilerCall(compileOutput: string): string | undefined {
 
     const m = ccalls[1].match(rxComp);
     return m?.[1];
-}
-
-function createTempDir(root: string): string {
-    let tempDir: string;
-    while (fs.existsSync(tempDir = path.join(root, `___temp_${randomBytes(8).toString('hex')}`))) { /* Name clash */ }
-    fs.mkdirSync(tempDir);
-    return tempDir;
 }
 
 function collectCompilerOutput(rPath: string, workspaceFolder: string, testExtension: 'cpp' | 'c') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,7 @@ export const tmpDir = (): string => util.getDir(path.join(homeExtDir(), 'tmp'));
 export let rWorkspace: workspaceViewer.WorkspaceDataProvider | undefined = undefined;
 export let globalRHelp: rHelp.RHelp | undefined = undefined;
 export let extensionContext: vscode.ExtensionContext;
-export let enableSessionWatcher: boolean = undefined;
+export let enableSessionWatcher: boolean | undefined = undefined;
 export let globalHttpgdManager: httpgdViewer.HttpgdManager | undefined = undefined;
 export let rmdPreviewManager: rmarkdown.RMarkdownPreviewManager | undefined = undefined;
 export let rmdKnitManager: rmarkdown.RMarkdownKnitManager | undefined = undefined;
@@ -80,10 +80,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.runSourcewithEcho': () => { void rTerminal.runSource(true); },
 
         // rmd related
-        'r.knitRmd': () => { void rmdKnitManager.knitRmd(false, undefined); },
-        'r.knitRmdToPdf': () => { void rmdKnitManager.knitRmd(false, 'pdf_document'); },
-        'r.knitRmdToHtml': () => { void rmdKnitManager.knitRmd(false, 'html_document'); },
-        'r.knitRmdToAll': () => { void rmdKnitManager.knitRmd(false, 'all'); },
+        'r.knitRmd': () => { void rmdKnitManager?.knitRmd(false, undefined); },
+        'r.knitRmdToPdf': () => { void rmdKnitManager?.knitRmd(false, 'pdf_document'); },
+        'r.knitRmdToHtml': () => { void rmdKnitManager?.knitRmd(false, 'html_document'); },
+        'r.knitRmdToAll': () => { void rmdKnitManager?.knitRmd(false, 'all'); },
         'r.selectCurrentChunk': rmarkdown.selectCurrentChunk,
         'r.runCurrentChunk': rmarkdown.runCurrentChunk,
         'r.runPreviousChunk': rmarkdown.runPreviousChunk,
@@ -97,15 +97,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.runChunks': rTerminal.runChunksInTerm,
 
         'r.rmarkdown.newDraft': () => rmarkdown.newDraft(),
-        'r.rmarkdown.setKnitDirectory': () => rmdKnitManager.setKnitDir(),
-        'r.rmarkdown.showPreviewToSide': () => rmdPreviewManager.previewRmd(vscode.ViewColumn.Beside),
-        'r.rmarkdown.showPreview': (uri: vscode.Uri) => rmdPreviewManager.previewRmd(vscode.ViewColumn.Active, uri),
-        'r.rmarkdown.preview.refresh': () => rmdPreviewManager.updatePreview(),
-        'r.rmarkdown.preview.openExternal': () => void rmdPreviewManager.openExternalBrowser(),
-        'r.rmarkdown.preview.showSource': () => rmdPreviewManager.showSource(),
-        'r.rmarkdown.preview.toggleStyle': () => rmdPreviewManager.toggleTheme(),
-        'r.rmarkdown.preview.enableAutoRefresh': () => rmdPreviewManager.enableAutoRefresh(),
-        'r.rmarkdown.preview.disableAutoRefresh': () => rmdPreviewManager.disableAutoRefresh(),
+        'r.rmarkdown.setKnitDirectory': () => rmdKnitManager?.setKnitDir(),
+        'r.rmarkdown.showPreviewToSide': () => rmdPreviewManager?.previewRmd(vscode.ViewColumn.Beside),
+        'r.rmarkdown.showPreview': (uri: vscode.Uri) => rmdPreviewManager?.previewRmd(vscode.ViewColumn.Active, uri),
+        'r.rmarkdown.preview.refresh': () => rmdPreviewManager?.updatePreview(),
+        'r.rmarkdown.preview.openExternal': () => void rmdPreviewManager?.openExternalBrowser(),
+        'r.rmarkdown.preview.showSource': () => rmdPreviewManager?.showSource(),
+        'r.rmarkdown.preview.toggleStyle': () => rmdPreviewManager?.toggleTheme(),
+        'r.rmarkdown.preview.enableAutoRefresh': () => rmdPreviewManager?.enableAutoRefresh(),
+        'r.rmarkdown.preview.disableAutoRefresh': () => rmdPreviewManager?.disableAutoRefresh(),
 
         // file creation (under file submenu)
         'r.rmarkdown.newFileDraft': () => rmarkdown.newDraft(),
@@ -145,9 +145,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
         // (help related commands are registered in rHelp.initializeHelp)
     };
-    for (const key in commands) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        context.subscriptions.push(vscode.commands.registerCommand(key, commands[key]));
+    for (const [key, value] of Object.entries(commands)) {
+        context.subscriptions.push(vscode.commands.registerCommand(key, value));
     }
 
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,8 +133,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
         // workspace viewer
         'r.workspaceViewer.refreshEntry': () => rWorkspace?.refresh(),
-        'r.workspaceViewer.view': (node: workspaceViewer.GlobalEnvItem) => workspaceViewer.viewItem(node.label),
-        'r.workspaceViewer.remove': (node: workspaceViewer.GlobalEnvItem) => workspaceViewer.removeItem(node.label),
+        'r.workspaceViewer.view': (node: workspaceViewer.GlobalEnvItem) => node.label && workspaceViewer.viewItem(node.label),
+        'r.workspaceViewer.remove': (node: workspaceViewer.GlobalEnvItem) => node.label && workspaceViewer.removeItem(node.label),
         'r.workspaceViewer.clear': workspaceViewer.clearWorkspace,
         'r.workspaceViewer.load': workspaceViewer.loadWorkspace,
         'r.workspaceViewer.save': workspaceViewer.saveWorkspace,

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -4,7 +4,7 @@ import * as cp from 'child_process';
 
 import * as rHelp from '.';
 import { extensionContext } from '../extension';
-import { DisposableProcess, getRLibPaths, spawn, spawnAsync } from '../util';
+import { catchAsError, DisposableProcess, getRLibPaths, spawn, spawnAsync } from '../util';
 
 export interface RHelpProviderOptions {
     // path of the R executable
@@ -305,7 +305,7 @@ export class AliasProvider {
             return <AllPackageAliases>JSON.parse(json) || {};
         } catch (e) {
             console.log(e);
-            void window.showErrorMessage((<{ message: string }>e).message);
+            void window.showErrorMessage(catchAsError(e).message);
         }
     }
 }

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -298,7 +298,7 @@ export class AliasProvider {
             }
             const re = new RegExp(`${lim}(.*)${lim}`, 'ms');
             const match = re.exec(result.stdout);
-            if (match.length !== 2) {
+            if (match?.length !== 2) {
                 throw new Error('Could not parse R output.');
             }
             const json = match[1];

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -519,7 +519,7 @@ export class RHelp implements api.HelpPanel, vscode.WebviewPanelSerializer<strin
                 ? await this.helpProvider.getHelpFileFromRequestPath(
                     requestPath,
                 )
-                : await rGuestService.requestHelpContent(requestPath);
+                : await rGuestService?.requestHelpContent(requestPath);
             this.cachedHelpFiles.set(requestPath, helpFile);
         }
 

--- a/src/helpViewer/packages.ts
+++ b/src/helpViewer/packages.ts
@@ -3,8 +3,7 @@ import * as cheerio from 'cheerio';
 import * as vscode from 'vscode';
 
 import { RHelp } from '.';
-import { getRpath, getConfirmation, executeAsTask, doWithProgress, getCranUrl } from '../util';
-import { AliasProvider } from './helpProvider';
+import { getConfirmation, executeAsTask, doWithProgress, getCranUrl } from '../util';
 import { getPackagesFromCran } from './cran';
 
 
@@ -81,8 +80,6 @@ export interface PackageManagerOptions {
 export class PackageManager {
 
     readonly rHelp: RHelp;
-
-    readonly aliasProvider: AliasProvider;
 
     readonly state: vscode.Memento;
 
@@ -195,7 +192,7 @@ export class PackageManager {
 
     // remove a specified package. The packagename is selected e.g. in the help tree-view
     public async removePackage(pkgName: string): Promise<boolean> {
-        const rPath = await getRpath();
+        const rPath = this.rHelp.rPath;
         const args = ['--silent', '--slave', '--no-save', '--no-restore', '-e', `remove.packages('${pkgName}')`];
         const cmd = `${rPath} ${args.join(' ')}`;
         const confirmation = 'Yes, remove package!';
@@ -212,7 +209,7 @@ export class PackageManager {
     // actually install packages
     // confirmation can be skipped (e.g. if the user has confimred before)
     public async installPackages(pkgNames: string[], skipConfirmation: boolean = false): Promise<boolean> {
-        const rPath = await getRpath();
+        const rPath = this.rHelp.rPath;
         const cranUrl = await getCranUrl('', this.cwd);
         const args = [`--silent`, '--slave', `-e`, `install.packages(c(${pkgNames.map(v => `'${v}'`).join(',')}),repos='${cranUrl}')`];
         const cmd = `${rPath} ${args.join(' ')}`;
@@ -228,7 +225,7 @@ export class PackageManager {
     }
 
     public async updatePackages(skipConfirmation: boolean = false): Promise<boolean> {
-        const rPath = await getRpath();
+        const rPath = this.rHelp.rPath;
         const cranUrl = await getCranUrl('', this.cwd);
         const args = ['--silent', '--slave', '--no-save', '--no-restore', '-e', `update.packages(ask=FALSE,repos='${cranUrl}')`];
         const cmd = `${rPath} ${args.join(' ')}`;

--- a/src/lineCache.ts
+++ b/src/lineCache.ts
@@ -14,29 +14,27 @@ export class LineCache {
         this.lineCache = new Map<number, string>();
         this.endsInOperatorCache = new Map<number, boolean>();
     }
-    public addLineToCache(line: number): void {
+    // Returns [Line, EndsInOperator]
+    public addLineToCache(line: number): [string, boolean] {
         const cleaned = cleanLine(this.getLine(line));
         const endsInOperator = doesLineEndInOperator(cleaned);
         this.lineCache.set(line, cleaned);
         this.endsInOperatorCache.set(line, endsInOperator);
+        return [cleaned, endsInOperator];
     }
     public getEndsInOperatorFromCache(line: number): boolean {
-        const lineInCache = this.lineCache.has(line);
-        if (!lineInCache) {
-            this.addLineToCache(line);
+        const lineInCache = this.endsInOperatorCache.get(line);
+        if (lineInCache === undefined) {
+            return this.addLineToCache(line)[1];
         }
-        const s = this.endsInOperatorCache.get(line);
-
-        return (s);
+        return lineInCache;
     }
     public getLineFromCache(line: number): string {
-        const lineInCache = this.lineCache.has(line);
-        if (!lineInCache) {
-            this.addLineToCache(line);
+        const lineInCache = this.lineCache.get(line);
+        if (lineInCache === undefined) {
+            return this.addLineToCache(line)[0];
         }
-        const s = this.lineCache.get(line);
-
-        return (s);
+        return lineInCache;
     }
 }
 

--- a/src/lintrConfig.ts
+++ b/src/lintrConfig.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { window } from 'vscode';
 import { executeRCommand, getCurrentWorkspaceFolder } from './util';
 
-export async function createLintrConfig(): Promise<string> {
+export async function createLintrConfig(): Promise<string | undefined> {
     const currentWorkspaceFolder = getCurrentWorkspaceFolder()?.uri.fsPath;
     if (currentWorkspaceFolder === undefined) {
         void window.showWarningMessage('Please open a workspace folder to create .lintr');

--- a/src/liveShare/index.ts
+++ b/src/liveShare/index.ts
@@ -18,15 +18,15 @@ import { WorkspaceData, workspaceData } from '../session';
 import { config } from '../util';
 
 /// LiveShare
-export let rHostService: HostService = undefined;
-export let rGuestService: GuestService = undefined;
+export let rHostService: HostService | undefined = undefined;
+export let rGuestService: GuestService | undefined = undefined;
 export let liveSession: vsls.LiveShare;
 export let isGuestSession: boolean;
 export let _sessionStatusBarItem: vscode.StatusBarItem;
 
 // service vars
 export const ShareProviderName = 'vscode-r';
-export let service: vsls.SharedServiceProxy | vsls.SharedService | null = undefined;
+export let service: vsls.SharedServiceProxy | vsls.SharedService | null = null;
 
 // random number to fake a UUID for differentiating between
 // host calls and guest calls (specifically for the workspace
@@ -144,11 +144,11 @@ export async function LiveSessionListener(): Promise<void> {
                 break;
             case vsls.Role.Guest:
                 console.log('[LiveSessionListener] guest event');
-                await rGuestService.startService();
+                await rGuestService?.startService();
                 break;
             case vsls.Role.Host:
                 console.log('[LiveSessionListener] host event');
-                await rHostService.startService();
+                await rHostService?.startService();
                 rLiveShareProvider.refresh();
                 break;
             default:
@@ -305,7 +305,7 @@ export class GuestService {
     // of having their own /tmp/ files
     public async requestFileContent(file: fs.PathLike | number): Promise<Buffer>;
     public async requestFileContent(file: fs.PathLike | number, encoding: string): Promise<string>;
-    public async requestFileContent(file: fs.PathLike | number, encoding?: string): Promise<string | Buffer> {
+    public async requestFileContent(file: fs.PathLike | number, encoding?: string): Promise<string | Buffer | undefined> {
         if (this._isStarted) {
             if (encoding !== undefined) {
                 const content: string | unknown = await liveShareRequest(Callback.GetFileContent, file, encoding);
@@ -325,7 +325,7 @@ export class GuestService {
         }
     }
 
-    public async requestHelpContent(file: string): Promise<HelpFile> {
+    public async requestHelpContent(file: string): Promise<HelpFile | undefined> {
         const content: string | null | unknown = await liveShareRequest(Callback.GetHelpFileContent, file);
         if (content) {
             return content as HelpFile;
@@ -341,7 +341,7 @@ export class GuestService {
 // This is used instead of relying on context disposables,
 // as an R session can continue even when liveshare is ended
 async function sessionCleanup(): Promise<void> {
-    if (rHostService.isStarted()) {
+    if (rHostService?.isStarted()) {
         console.log('[HostService] stopping service');
         await rHostService.stopService();
         for (const [key, item] of browserDisposables.entries()) {

--- a/src/liveShare/shareCommands.ts
+++ b/src/liveShare/shareCommands.ts
@@ -62,7 +62,7 @@ export const Commands: ICommands = {
         // Command arguments are sent from the guest to the host,
         // and then the host sends the arguments to the console
         [Callback.RequestAttachGuest]: (): void => {
-            if (shareWorkspace) {
+            if (shareWorkspace && rHostService) {
                 void rHostService.notifyRequest(requestFile, true);
             } else {
                 void liveShareRequest(Callback.NotifyMessage, 'The host has not enabled guest attach.', MessageType.warning);
@@ -76,8 +76,8 @@ export const Commands: ICommands = {
             }
 
         },
-        [Callback.GetHelpFileContent]: (args: [text: string]): Promise<HelpFile | null> => {
-            return globalRHelp.getHelpFileForPath(args[0]);
+        [Callback.GetHelpFileContent]: (args: [text: string]): Promise<HelpFile | undefined> | undefined => {
+            return globalRHelp?.getHelpFileForPath(args[0]);
         },
         /// File Handling ///
         // Host reads content from file, then passes the content

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -19,7 +19,7 @@ let info: IRequest['info'];
 // Used to keep track of shared browsers
 export const browserDisposables: { Disposable: vscode.Disposable, url: string, name: string }[] = [];
 
-interface IRequest {
+export interface IRequest {
     command: string;
     time?: string;
     pid?: string;

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -2,7 +2,7 @@ import path = require('path');
 import * as vscode from 'vscode';
 
 import { extensionContext, globalHttpgdManager, globalRHelp, rWorkspace } from '../extension';
-import { config, readContent } from '../util';
+import { asViewColumn, config, readContent } from '../util';
 import { showBrowser, showDataView, showWebView, WorkspaceData } from '../session';
 import { liveSession, UUID, rGuestService, _sessionStatusBarItem as sessionStatusBarItem } from '.';
 import { autoShareBrowser } from './shareTree';
@@ -10,7 +10,7 @@ import { docProvider, docScheme } from './virtualDocs';
 
 // Workspace Vars
 let guestPid: string;
-export let guestWorkspace: WorkspaceData;
+export let guestWorkspace: WorkspaceData | undefined;
 export let guestResDir: string;
 let rVer: string;
 let info: IRequest['info'];
@@ -57,7 +57,7 @@ export function initGuest(context: vscode.ExtensionContext): void {
         sessionStatusBarItem,
         vscode.workspace.registerTextDocumentContentProvider(docScheme, docProvider)
     );
-    rGuestService.setStatusBarItem(sessionStatusBarItem);
+    rGuestService?.setStatusBarItem(sessionStatusBarItem);
     guestResDir = path.join(context.extensionPath, 'dist', 'resources');
 }
 
@@ -70,9 +70,9 @@ export function detachGuest(): void {
 }
 
 export function attachActiveGuest(): void {
-    if (config().get<boolean>('sessionWatcher')) {
+    if (config().get<boolean>('sessionWatcher', false)) {
         console.info('[attachActiveGuest]');
-        void rGuestService.requestAttach();
+        void rGuestService?.requestAttach();
     } else {
         void vscode.window.showInformationMessage('This command requires that r.sessionWatcher be enabled.');
     }
@@ -107,7 +107,9 @@ export async function updateGuestRequest(file: string, force: boolean = false): 
             case 'help': {
                 if (globalRHelp) {
                     console.log(request.requestPath);
-                    await globalRHelp.showHelpForPath(request.requestPath, request.viewer);
+                    if (request.requestPath) {
+                        await globalRHelp.showHelpForPath(request.requestPath, request.viewer);
+                    }
                 }
                 break;
             }
@@ -123,21 +125,29 @@ export async function updateGuestRequest(file: string, force: boolean = false): 
                 info = request.info;
                 console.info(`[updateGuestRequest] attach PID: ${guestPid}`);
                 sessionStatusBarItem.text = `Guest R ${rVer}: ${guestPid}`;
-                sessionStatusBarItem.tooltip = `${info.version}\nProcess ID: ${guestPid}\nCommand: ${info.command}\nStart time: ${info.start_time}\nClick to attach to host terminal.`;
+                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+                sessionStatusBarItem.tooltip = `${info?.version || 'unknown version'}\nProcess ID: ${guestPid}\nCommand: ${info?.command}\nStart time: ${info?.start_time}\nClick to attach to host terminal.`;
                 sessionStatusBarItem.show();
                 break;
             }
             case 'browser': {
-                await showBrowser(request.url, request.title, request.viewer);
+                if (request.url && request.title && request.viewer) {
+                    await showBrowser(request.url, request.title, request.viewer);
+                }
                 break;
             }
             case 'webview': {
-                await showWebView(request.file, request.title, request.viewer);
+                if (request.file && request.title && request.viewer) {
+                    await showWebView(request.file, request.title, request.viewer);
+                }
                 break;
             }
             case 'dataview': {
-                await showDataView(request.source,
-                    request.type, request.title, request.file, request.viewer);
+                if (request.source && request.type && request.title && request.file
+                    && request.viewer) {
+                    await showDataView(request.source,
+                        request.type, request.title, request.file, request.viewer);
+                }
                 break;
             }
             case 'rstudioapi': {
@@ -162,11 +172,12 @@ export function updateGuestWorkspace(hostWorkspace: WorkspaceData): void {
 
 // Instead of creating a file, we pass the base64 of the plot image
 // to the guest, and read that into an html page
-let panel: vscode.WebviewPanel = undefined;
+let panel: vscode.WebviewPanel | undefined = undefined;
 export async function updateGuestPlot(file: string): Promise<void> {
     const plotContent = await readContent(file, 'base64');
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const guestPlotView: vscode.ViewColumn = vscode.ViewColumn[config().get<string>('session.viewers.viewColumn.plot')];
+    
+    const guestPlotView: vscode.ViewColumn = asViewColumn(config().get<string>('session.viewers.viewColumn.plot'), vscode.ViewColumn.Two);
     if (plotContent) {
         if (panel) {
             panel.webview.html = getGuestImageHtml(plotContent);

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -70,7 +70,7 @@ export function detachGuest(): void {
 }
 
 export function attachActiveGuest(): void {
-    if (config().get<boolean>('sessionWatcher', false)) {
+    if (config().get<boolean>('sessionWatcher', true)) {
         console.info('[attachActiveGuest]');
         void rGuestService?.requestAttach();
     } else {

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -82,7 +82,10 @@ export function attachActiveGuest(): void {
 // as this is handled by the session.ts variant
 // the force parameter is used for ensuring that the 'attach' case is appropriately called on guest join
 export async function updateGuestRequest(file: string, force: boolean = false): Promise<void> {
-    const requestContent: string = await readContent(file, 'utf8');
+    const requestContent: string | undefined = await readContent(file, 'utf8');
+    if (!requestContent) {
+        return;
+    }
     console.info(`[updateGuestRequest] request: ${requestContent}`);
     if (typeof (requestContent) !== 'string') {
         return;

--- a/src/liveShare/shareTree.ts
+++ b/src/liveShare/shareTree.ts
@@ -11,9 +11,9 @@ export let rLiveShareProvider: LiveShareTreeProvider;
 
 export function initTreeView(): void {
     // get default bool values from settings
-    shareWorkspace = config().get('liveShare.defaults.shareWorkspace');
-    forwardCommands = config().get('liveShare.defaults.commandForward');
-    autoShareBrowser = config().get('liveShare.defaults.shareBrowser');
+    shareWorkspace = config().get('liveShare.defaults.shareWorkspace', true);
+    forwardCommands = config().get('liveShare.defaults.commandForward', false);
+    autoShareBrowser = config().get('liveShare.defaults.shareBrowser', false);
 
     // create tree view for host controls
     rLiveShareProvider = new LiveShareTreeProvider();
@@ -37,7 +37,7 @@ export class LiveShareTreeProvider implements vscode.TreeDataProvider<Node> {
 
     // If a node needs to be collapsible,
     // change the element condition & return value
-    getChildren(element?: Node): Node[] {
+    getChildren(element?: Node): Node[] | undefined {
         if (element) {
             return;
         } else {
@@ -48,8 +48,8 @@ export class LiveShareTreeProvider implements vscode.TreeDataProvider<Node> {
     // To add a tree item to the LiveShare R view,
     // write a class object that extends Node and
     // add it to the list of nodes here
-    private getNodes(): Node[] {
-        let items: Node[] = undefined;
+    private getNodes(): Node[] | undefined {
+        let items: Node[] | undefined = undefined;
         if (isLiveShare()) {
             items = [
                 new ShareNode(),
@@ -64,12 +64,12 @@ export class LiveShareTreeProvider implements vscode.TreeDataProvider<Node> {
 
 // Base class for adding to
 abstract class Node extends vscode.TreeItem {
-    public label: string;
-    public tooltip: string;
-    public contextValue: string;
-    public description: string;
-    public iconPath: vscode.ThemeIcon;
-    public collapsibleState: vscode.TreeItemCollapsibleState;
+    public label?: string;
+    public tooltip?: string;
+    public contextValue?: string;
+    public description?: string;
+    public iconPath?: vscode.ThemeIcon;
+    public collapsibleState?: vscode.TreeItemCollapsibleState;
 
     constructor() {
         super('');
@@ -82,12 +82,12 @@ abstract class Node extends vscode.TreeItem {
 // If a toggle is not required, extend a different Node type.
 export abstract class ToggleNode extends Node {
     public toggle(treeProvider: LiveShareTreeProvider): void { treeProvider.refresh(); }
-    public label: string;
-    public tooltip: string;
-    public contextValue: string;
-    public description: string;
-    public iconPath: vscode.ThemeIcon;
-    public collapsibleState: vscode.TreeItemCollapsibleState;
+    public label?: string;
+    public tooltip?: string;
+    public contextValue?: string;
+    public description?: string;
+    public iconPath?: vscode.ThemeIcon;
+    public collapsibleState?: vscode.TreeItemCollapsibleState;
 
     constructor(bool: boolean) {
         super();
@@ -102,9 +102,9 @@ class ShareNode extends ToggleNode {
         shareWorkspace = !shareWorkspace;
         this.description = shareWorkspace === true ? 'Enabled' : 'Disabled';
         if (shareWorkspace) {
-            void rHostService.notifyRequest(requestFile, true);
+            void rHostService?.notifyRequest(requestFile, true);
         } else {
-            void rHostService.orderGuestDetach();
+            void rHostService?.orderGuestDetach();
         }
         treeProvider.refresh();
     }
@@ -112,7 +112,7 @@ class ShareNode extends ToggleNode {
     public label: string = 'Share R Workspace';
     public tooltip: string = 'Whether guests can access the current R session and its workspace';
     public contextValue: string = 'shareNode';
-    public description: string;
+    public description?: string;
     public iconPath: vscode.ThemeIcon = new vscode.ThemeIcon('broadcast');
     public collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.None;
 

--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as ejs from 'ejs';
 
-import { config, setContext, UriIcon } from '../util';
+import { asViewColumn, config, setContext, UriIcon } from '../util';
 
 import { extensionContext } from '../extension';
 
@@ -286,12 +286,12 @@ export class HttpgdViewer implements IHttpgdViewer {
     customOverwriteCssPath?: string;
 
     // Size of the view area:
-    viewHeight: number;
-    viewWidth: number;
+    viewHeight: number = 600;
+    viewWidth: number = 800;
 
     // Size of the shown plot (as computed):
-    plotHeight: number;
-    plotWidth: number;
+    plotHeight: number = 600;
+    plotWidth: number = 800;
 
     readonly zoom0: number = 1;
     zoom: number = this.zoom0;
@@ -358,7 +358,7 @@ export class HttpgdViewer implements IHttpgdViewer {
         this.htmlTemplate = fs.readFileSync(path.join(this.htmlRoot, 'index.ejs'), 'utf-8');
         this.smallPlotTemplate = fs.readFileSync(path.join(this.htmlRoot, 'smallPlot.ejs'), 'utf-8');
         this.showOptions = {
-            viewColumn: options.viewColumn ?? vscode.ViewColumn[conf.get<string>('session.viewers.viewColumn.plot') || 'Two'],
+            viewColumn: options.viewColumn ?? asViewColumn(conf.get<string>('session.viewers.viewColumn.plot'), vscode.ViewColumn.Two),
             preserveFocus: !!options.preserveFocus
         };
         this.webviewOptions = {
@@ -843,7 +843,7 @@ export class HttpgdViewer implements IHttpgdViewer {
             `Export failed: ${err.message}`
         ));
         dest.on('close', () => void vscode.window.showInformationMessage(
-            `Export done: ${outFile}`
+            `Export done: ${outFile || ''}`
         ));
         void plt.body.pipe(dest);
     }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -36,7 +36,7 @@ export async function previewEnvironment(): Promise<void> {
 export async function previewDataframe(): Promise<boolean | undefined> {
     if (config().get('sessionWatcher')) {
         const symbol = getWordOrSelection();
-        await runTextInTerm(`View(${symbol})`);
+        await runTextInTerm(`View(${symbol || 'undefined'})`);
     } else {
         if (!checkcsv()) {
             return;
@@ -47,6 +47,9 @@ export async function previewDataframe(): Promise<boolean | undefined> {
         }
 
         const dataframeName = getWordOrSelection();
+        if (!dataframeName) {
+            return;
+        }
 
         if (!checkForSpecialCharacters(dataframeName)) {
             void window.showInformationMessage('This does not appear to be a dataframe.');

--- a/src/rGitignore.ts
+++ b/src/rGitignore.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { window } from 'vscode';
 import { extensionContext } from './extension';
-import { getCurrentWorkspaceFolder } from './util';
+import { catchAsError, getCurrentWorkspaceFolder } from './util';
 
 export async function createGitignore(): Promise<void> {
     // .gitignore template from "https://github.com/github/gitignore/blob/main/R.gitignore"
@@ -34,7 +34,7 @@ export async function createGitignore(): Promise<void> {
                 void window.showErrorMessage(err.name);
             }
         } catch (e) {
-            void window.showErrorMessage(e);
+            void window.showErrorMessage(catchAsError(e).message);
         }
     });
 }

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -267,7 +267,7 @@ export async function runChunksInTerm(chunks: vscode.Range[]): Promise<void> {
 
 export async function runTextInTerm(text: string, execute: boolean = true): Promise<void> {
     if (isGuestSession) {
-        rGuestService.requestRunTextInTerm(text);
+        rGuestService?.requestRunTextInTerm(text);
     } else {
         const term = await chooseTerminal();
         if (term === undefined) {

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -13,16 +13,22 @@ import { removeSessionFiles } from './session';
 import { config, delay, getRterm } from './util';
 import { rGuestService, isGuestSession } from './liveShare';
 import * as fs from 'fs';
-export let rTerm: vscode.Terminal;
+export let rTerm: vscode.Terminal | undefined = undefined;
 
 export async function runSource(echo: boolean): Promise<void>  {
     const wad = vscode.window.activeTextEditor?.document;
+    if (!wad) {
+        return;
+    }
     const isSaved = await util.saveDocument(wad);
     if (!isSaved) {
         return;
     }
     let rPath: string = util.ToRStringLiteral(wad.fileName, '"');
     let encodingParam = util.config().get<string>('source.encoding');
+    if (encodingParam === undefined) {
+        return;
+    }
     encodingParam = `encoding = "${encodingParam}"`;
     rPath = [rPath, encodingParam].join(', ');
     if (echo) {
@@ -52,7 +58,11 @@ export async function runCommandWithSelectionOrWord(rCommand: string): Promise<v
 }
 
 export async function runCommandWithEditorPath(rCommand: string): Promise<void>  {
-    const wad: vscode.TextDocument = vscode.window.activeTextEditor.document;
+    const textEditor = vscode.window.activeTextEditor;
+    if (!textEditor) {
+        return;
+    }
+    const wad: vscode.TextDocument = textEditor.document;
     const isSaved = await util.saveDocument(wad);
     if (isSaved) {
         const rPath = util.ToRStringLiteral(wad.fileName, '');
@@ -66,26 +76,37 @@ export async function runCommand(rCommand: string): Promise<void>  {
 }
 
 export async function runFromBeginningToLine(): Promise<void>  {
-    const endLine = vscode.window.activeTextEditor.selection.end.line;
-    const charactersOnLine = vscode.window.activeTextEditor.document.lineAt(endLine).text.length;
+    const textEditor = vscode.window.activeTextEditor;
+    if (!textEditor) {
+        return;
+    }
+    const endLine = textEditor.selection.end.line;
+    const charactersOnLine = textEditor.document.lineAt(endLine).text.length;
     const endPos = new vscode.Position(endLine, charactersOnLine);
     const range = new vscode.Range(new vscode.Position(0, 0), endPos);
-    const text = vscode.window.activeTextEditor.document.getText(range);
+    const text = textEditor.document.getText(range);
+    if (text === undefined) {
+        return;
+    }
     await runTextInTerm(text);
 }
 
 export async function runFromLineToEnd(): Promise<void>  {
-    const startLine = vscode.window.activeTextEditor.selection.start.line;
+    const textEditor = vscode.window.activeTextEditor;
+    if (!textEditor) {
+        return;
+    }
+    const startLine = textEditor.selection.start.line;
     const startPos = new vscode.Position(startLine, 0);
-    const endLine = vscode.window.activeTextEditor.document.lineCount;
+    const endLine = textEditor.document.lineCount;
     const range = new vscode.Range(startPos, new vscode.Position(endLine, 0));
-    const text = vscode.window.activeTextEditor.document.getText(range);
+    const text = textEditor.document.getText(range);
     await runTextInTerm(text);
 }
 
 export async function makeTerminalOptions(): Promise<vscode.TerminalOptions> {
     const termPath = await getRterm();
-    const shellArgs: string[] = config().get('rterm.option');
+    const shellArgs: string[] = config().get('rterm.option') || [];
     const termOptions: vscode.TerminalOptions = {
         name: 'R Interactive',
         shellPath: termPath,
@@ -136,7 +157,7 @@ export function deleteTerminal(term: vscode.Terminal): void {
     }
 }
 
-export async function chooseTerminal(): Promise<vscode.Terminal> {
+export async function chooseTerminal(): Promise<vscode.Terminal | undefined> {
     if (config().get('alwaysUseActiveTerminal')) {
         if (vscode.window.terminals.length < 1) {
             void vscode.window.showInformationMessage('There are no open terminals.');
@@ -202,10 +223,14 @@ export async function chooseTerminal(): Promise<vscode.Terminal> {
 export async function runSelectionInTerm(moveCursor: boolean, useRepl = true): Promise<void> {
     const selection = getSelection();
     if (moveCursor && selection.linesDownToMoveCursor > 0) {
-        const lineCount = vscode.window.activeTextEditor.document.lineCount;
-        if (selection.linesDownToMoveCursor + vscode.window.activeTextEditor.selection.end.line === lineCount) {
-            const endPos = new vscode.Position(lineCount, vscode.window.activeTextEditor.document.lineAt(lineCount - 1).text.length);
-            await vscode.window.activeTextEditor.edit(e => e.insert(endPos, '\n'));
+        const textEditor = vscode.window.activeTextEditor;
+        if (!textEditor) {
+            return;
+        }
+        const lineCount = textEditor.document.lineCount;
+        if (selection.linesDownToMoveCursor + textEditor.selection.end.line === lineCount) {
+            const endPos = new vscode.Position(lineCount, textEditor.document.lineAt(lineCount - 1).text.length);
+            await textEditor.edit(e => e.insert(endPos, '\n'));
         }
         await vscode.commands.executeCommand('cursorMove', { to: 'down', value: selection.linesDownToMoveCursor });
         await vscode.commands.executeCommand('cursorMove', { to: 'wrappedLineFirstNonWhitespaceCharacter' });
@@ -218,8 +243,12 @@ export async function runSelectionInTerm(moveCursor: boolean, useRepl = true): P
 }
 
 export async function runChunksInTerm(chunks: vscode.Range[]): Promise<void> {
+    const textEditor = vscode.window.activeTextEditor;
+    if (!textEditor) {
+        return;
+    }
     const text = chunks
-        .map((chunk) => vscode.window.activeTextEditor.document.getText(chunk).trim())
+        .map((chunk) => textEditor.document.getText(chunk).trim())
         .filter((chunk) => chunk.length > 0)
         .join('\n');
     if (text.length > 0) {
@@ -242,7 +271,7 @@ export async function runTextInTerm(text: string, execute: boolean = true): Prom
             }
             term.sendText(text, execute);
         } else {
-            const rtermSendDelay: number = config().get('rtermSendDelay');
+            const rtermSendDelay: number = config().get('rtermSendDelay') || 8;
             const split = text.split('\n');
             const last_split = split.length - 1;
             for (const [count, line] of split.entries()) {
@@ -265,7 +294,7 @@ export async function runTextInTerm(text: string, execute: boolean = true): Prom
 }
 
 function setFocus(term: vscode.Terminal) {
-    const focus: string = config().get('source.focus');
+    const focus: string = config().get('source.focus') || 'editor';
     if (focus !== 'none') {
         term.show(focus !== 'terminal');
     }
@@ -273,6 +302,9 @@ function setFocus(term: vscode.Terminal) {
 
 export async function sendRangeToRepl(rng: vscode.Range): Promise<void> {
     const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        return;
+    }
     const sel0 = editor.selections;
     let sel1 = new vscode.Selection(rng.start, rng.end);
     while(/^[\r\n]/.exec(editor.document.getText(sel1))){

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -47,12 +47,18 @@ export async function runSelectionRetainCursor(): Promise<void> {
 
 export async function runSelectionOrWord(rFunctionName: string[]): Promise<void> {
     const text = selection.getWordOrSelection();
+    if (!text) {
+        return;
+    }
     const wrappedText = selection.surroundSelection(text, rFunctionName);
     await runTextInTerm(wrappedText);
 }
 
 export async function runCommandWithSelectionOrWord(rCommand: string): Promise<void>  {
     const text = selection.getWordOrSelection();
+    if (!text) {
+        return;
+    }
     const call = rCommand.replace(/\$\$/g, text);
     await runTextInTerm(call);
 }
@@ -222,6 +228,9 @@ export async function chooseTerminal(): Promise<vscode.Terminal | undefined> {
 
 export async function runSelectionInTerm(moveCursor: boolean, useRepl = true): Promise<void> {
     const selection = getSelection();
+    if (!selection) {
+        return;
+    }
     if (moveCursor && selection.linesDownToMoveCursor > 0) {
         const textEditor = vscode.window.activeTextEditor;
         if (!textEditor) {

--- a/src/rmarkdown/draft.ts
+++ b/src/rmarkdown/draft.ts
@@ -1,6 +1,6 @@
 import { QuickPickItem, QuickPickOptions, Uri, window, workspace, env } from 'vscode';
 import { extensionContext } from '../extension';
-import { executeRCommand, getCurrentWorkspaceFolder, getRpath, ToRStringLiteral, spawnAsync, getConfirmation } from '../util';
+import { executeRCommand, getCurrentWorkspaceFolder, getRpath, ToRStringLiteral, spawnAsync, getConfirmation, catchAsError } from '../util';
 import * as cp from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -64,7 +64,7 @@ async function getTemplateItems(cwd: string): Promise<TemplateItem[]> {
         return items;
     } catch (e) {
         console.log(e);
-        void window.showErrorMessage((<{ message: string }>e).message);
+        void window.showErrorMessage(catchAsError(e).message);
         return undefined;
     }
 }

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -73,7 +73,7 @@ export class RMarkdownCodeLensProvider implements vscode.CodeLensProvider {
             chunkRanges.push(chunkRange);
 
             // Enable/disable only CodeLens, without affecting chunk background color.
-            if (config().get<boolean>('rmarkdown.enableCodeLens', false) && (chunk.language === 'r') || isRDocument(document)) {
+            if (config().get<boolean>('rmarkdown.enableCodeLens', true) && (chunk.language === 'r') || isRDocument(document)) {
                 if (token.isCancellationRequested) {
                     break;
                 }

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -60,17 +60,20 @@ export class RMarkdownCodeLensProvider implements vscode.CodeLensProvider {
         this.codeLenses = [];
         const chunks = getChunks(document);
         const chunkRanges: vscode.Range[] = [];
-        const rmdCodeLensCommands: string[] = config().get('rmarkdown.codeLensCommands');
+        const rmdCodeLensCommands: string[] = config().get('rmarkdown.codeLensCommands', []);
 
         // Iterate through all code chunks for getting chunk information for both CodeLens and chunk background color (set by `editor.setDecorations`)
         for (let i = 1; i <= chunks.length; i++) {
             const chunk = chunks.find(e => e.id === i);
+            if (!chunk) {
+                continue;
+            }
             const chunkRange = chunk.chunkRange;
             const line = chunk.startLine;
             chunkRanges.push(chunkRange);
 
             // Enable/disable only CodeLens, without affecting chunk background color.
-            if (config().get<boolean>('rmarkdown.enableCodeLens') && (chunk.language === 'r') || isRDocument(document)) {
+            if (config().get<boolean>('rmarkdown.enableCodeLens', false) && (chunk.language === 'r') || isRDocument(document)) {
                 if (token.isCancellationRequested) {
                     break;
                 }
@@ -148,8 +151,9 @@ export class RMarkdownCodeLensProvider implements vscode.CodeLensProvider {
         // For default options, both options and sort order are based on options specified in package.json.
         // For user-specified options, both options and sort order are based on options specified in settings UI or settings.json.
         return this.codeLenses.
-            filter(e => rmdCodeLensCommands.includes(e.command.command)).
+            filter(e => e.command && rmdCodeLensCommands.includes(e.command.command)).
             sort(function (a, b) {
+                if (!a.command || !b.command) { return 0; }
                 const sorted = rmdCodeLensCommands.indexOf(a.command.command) -
                     rmdCodeLensCommands.indexOf(b.command.command);
                 return sorted;
@@ -164,9 +168,9 @@ interface RMarkdownChunk {
     id: number;
     startLine: number;
     endLine: number;
-    language: string;
-    options: string;
-    eval: boolean;
+    language: string | undefined;
+    options: string | undefined;
+    eval: boolean | undefined;
     chunkRange: vscode.Range;
     codeRange: vscode.Range;
 }
@@ -178,11 +182,11 @@ export function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
 
     let line = 0;
     let chunkId = 0;  // One-based index
-    let chunkStartLine: number = undefined;
-    let chunkEndLine: number = undefined;
-    let chunkLanguage: string = undefined;
-    let chunkOptions: string = undefined;
-    let chunkEval: boolean = undefined;
+    let chunkStartLine: number | undefined = undefined;
+    let chunkEndLine: number | undefined = undefined;
+    let chunkLanguage: string | undefined = undefined;
+    let chunkOptions: string | undefined = undefined;
+    let chunkEval: boolean | undefined = undefined;
     const isRDoc = isRDocument(document);
 
     while (line < lines.length) {
@@ -226,14 +230,20 @@ export function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
     return chunks;
 }
 
-function getCurrentChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
-    const lines = vscode.window.activeTextEditor.document.getText().split(/\r?\n/);
+function getCurrentChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk | undefined {
+    const textEditor = vscode.window.activeTextEditor;
+    if (!textEditor) {
+        void vscode.window.showWarningMessage('No text editor active.');
+        return;
+    }
+
+    const lines = textEditor.document.getText().split(/\r?\n/);
 
     let chunkStartLineAtOrAbove = line;
     // `- 1` to cover edge case when cursor is at 'chunk end line'
     let chunkEndLineAbove = line - 1;
 
-    const isRDoc = isRDocument(vscode.window.activeTextEditor.document);
+    const isRDoc = isRDocument(textEditor.document);
 
     while (chunkStartLineAtOrAbove >= 0 && !isChunkStartLine(lines[chunkStartLineAtOrAbove], isRDoc)) {
         chunkStartLineAtOrAbove--;
@@ -261,12 +271,15 @@ function getCurrentChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk
 // Alternative `getCurrentChunk` for cases:
 // - commands (e.g. `selectCurrentChunk`) only make sense when cursor is within chunk
 // - when cursor is outside of chunk, no response is triggered for chunk navigation commands (e.g. `goToPreviousChunk`) and chunk running commands (e.g. `runAboveChunks`)
-function getCurrentChunk__CursorWithinChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
+function getCurrentChunk__CursorWithinChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk | undefined {
     return chunks.find(i => i.startLine <= line && i.endLine >= line);
 }
 
-function getPreviousChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
+function getPreviousChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk | undefined {
     const currentChunk = getCurrentChunk(chunks, line);
+    if (!currentChunk) {
+        return undefined;
+    }
     if (currentChunk.id !== 1) {
         // When cursor is below the last 'chunk end line', the definition of the previous chunk is the last chunk
         const previousChunkId = currentChunk.endLine < line ? currentChunk.id : currentChunk.id - 1;
@@ -277,8 +290,11 @@ function getPreviousChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChun
     }
 }
 
-function getNextChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
+function getNextChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk | undefined {
     const currentChunk = getCurrentChunk(chunks, line);
+    if (!currentChunk) {
+        return undefined;
+    }
     if (currentChunk.id !== chunks.length) {
         // When cursor is above the first 'chunk start line', the definition of the next chunk is the first chunk
         const nextChunkId = line < currentChunk.startLine ? currentChunk.id : currentChunk.id + 1;
@@ -291,17 +307,27 @@ function getNextChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
 }
 
 // Helpers
-function _getChunks() {
-    return getChunks(vscode.window.activeTextEditor.document);
+function _getChunks(): RMarkdownChunk[] {
+    const textEditor = vscode.window.activeTextEditor;
+    if (!textEditor) {
+        return [];
+    }
+    return getChunks(textEditor.document);
 }
-function _getStartLine() {
-    return vscode.window.activeTextEditor.selection.start.line;
+function _getStartLine(): number {
+    const textEditor = vscode.window.activeTextEditor;
+    if (!textEditor) {
+        return 0;
+    }
+    return textEditor.selection.start.line;
 }
 
 export async function runCurrentChunk(chunks: RMarkdownChunk[] = _getChunks(),
     line: number = _getStartLine()): Promise<void> {
     const currentChunk = getCurrentChunk(chunks, line);
-    await runChunksInTerm([currentChunk.codeRange]);
+    if (currentChunk) {
+        await runChunksInTerm([currentChunk.codeRange]);
+    }
 }
 
 export async function runPreviousChunk(chunks: RMarkdownChunk[] = _getChunks(),
@@ -309,7 +335,7 @@ export async function runPreviousChunk(chunks: RMarkdownChunk[] = _getChunks(),
     const currentChunk = getCurrentChunk(chunks, line);
     const previousChunk = getPreviousChunk(chunks, line);
 
-    if (previousChunk !== currentChunk) {
+    if (previousChunk && previousChunk !== currentChunk) {
         await runChunksInTerm([previousChunk.codeRange]);
     }
 
@@ -320,7 +346,7 @@ export async function runNextChunk(chunks: RMarkdownChunk[] = _getChunks(),
     const currentChunk = getCurrentChunk(chunks, line);
     const nextChunk = getNextChunk(chunks, line);
 
-    if (nextChunk !== currentChunk) {
+    if (nextChunk && nextChunk !== currentChunk) {
         await runChunksInTerm([nextChunk.codeRange]);
     }
 }
@@ -329,6 +355,9 @@ export async function runAboveChunks(chunks: RMarkdownChunk[] = _getChunks(),
     line: number = _getStartLine()): Promise<void> {
     const currentChunk = getCurrentChunk(chunks, line);
     const previousChunk = getPreviousChunk(chunks, line);
+    if (!currentChunk || !previousChunk) {
+        return;
+    }
     const firstChunkId = 1;
     const previousChunkId = previousChunk.id;
 
@@ -337,7 +366,7 @@ export async function runAboveChunks(chunks: RMarkdownChunk[] = _getChunks(),
     if (previousChunk !== currentChunk) {
         for (let i = firstChunkId; i <= previousChunkId; i++) {
             const chunk = chunks.find(e => e.id === i);
-            if (chunk.eval) {
+            if (chunk?.eval) {
                 codeRanges.push(chunk.codeRange);
             }
         }
@@ -350,6 +379,9 @@ export async function runBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
 
     const currentChunk = getCurrentChunk(chunks, line);
     const nextChunk = getNextChunk(chunks, line);
+    if (!currentChunk || !nextChunk) {
+        return;
+    }
     const nextChunkId = nextChunk.id;
     const lastChunkId = chunks.length;
 
@@ -357,7 +389,7 @@ export async function runBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
     if (nextChunk !== currentChunk) {
         for (let i = nextChunkId; i <= lastChunkId; i++) {
             const chunk = chunks.find(e => e.id === i);
-            if (chunk.eval) {
+            if (chunk?.eval) {
                 codeRanges.push(chunk.codeRange);
             }
         }
@@ -368,6 +400,9 @@ export async function runBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
 export async function runCurrentAndBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
     line: number = _getStartLine()): Promise<void> {
     const currentChunk = getCurrentChunk(chunks, line);
+    if (!currentChunk) {
+        return;
+    }
     const currentChunkId = currentChunk.id;
     const lastChunkId = chunks.length;
 
@@ -375,7 +410,9 @@ export async function runCurrentAndBelowChunks(chunks: RMarkdownChunk[] = _getCh
 
     for (let i = currentChunkId; i <= lastChunkId; i++) {
         const chunk = chunks.find(e => e.id === i);
-        codeRanges.push(chunk.codeRange);
+        if (chunk) {
+            codeRanges.push(chunk.codeRange);
+        }
     }
     await runChunksInTerm(codeRanges);
 }
@@ -389,7 +426,7 @@ export async function runAllChunks(chunks: RMarkdownChunk[] = _getChunks()): Pro
 
     for (let i = firstChunkId; i <= lastChunkId; i++) {
         const chunk = chunks.find(e => e.id === i);
-        if (chunk.eval) {
+        if (chunk?.eval) {
             codeRanges.push(chunk.codeRange);
         }
     }
@@ -399,26 +436,37 @@ export async function runAllChunks(chunks: RMarkdownChunk[] = _getChunks()): Pro
 async function goToChunk(chunk: RMarkdownChunk) {
     // Move cursor 1 line below 'chunk start line'
     const line = chunk.startLine + 1;
-    vscode.window.activeTextEditor.selection = new vscode.Selection(line, 0, line, 0);
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        return;
+    }
+    editor.selection = new vscode.Selection(line, 0, line, 0);
     await vscode.commands.executeCommand('revealLine', { lineNumber: line, at: 'center' });
 }
 
 export function goToPreviousChunk(chunks: RMarkdownChunk[] = _getChunks(),
     line: number = _getStartLine()): void {
     const previousChunk = getPreviousChunk(chunks, line);
-    void goToChunk(previousChunk);
+    if (previousChunk) {
+        void goToChunk(previousChunk);
+    }
 }
 
 export function goToNextChunk(chunks: RMarkdownChunk[] = _getChunks(),
     line: number = _getStartLine()): void {
     const nextChunk = getNextChunk(chunks, line);
-    void goToChunk(nextChunk);
+    if (nextChunk) {
+        void goToChunk(nextChunk);
+    }
 }
 
 export function selectCurrentChunk(chunks: RMarkdownChunk[] = _getChunks(),
     line: number = _getStartLine()): void {
     const editor = vscode.window.activeTextEditor;
     const currentChunk = getCurrentChunk__CursorWithinChunk(chunks, line);
+    if (!editor || !currentChunk) {
+        return;
+    }
     const lines = editor.document.getText().split(/\r?\n/);
 
     editor.selection = new vscode.Selection(
@@ -451,7 +499,7 @@ export class RMarkdownCompletionItemProvider implements vscode.CompletionItemPro
         });
     }
 
-    public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position): vscode.CompletionItem[] {
+    public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position): vscode.CompletionItem[] | undefined {
         const line = document.lineAt(position).text;
         if (isChunkStartLine(line, false) && getChunkLanguage(line) === 'r') {
             return this.chunkOptionCompletionItems;

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -13,17 +13,17 @@ import { RMarkdownManager } from './manager';
 
 class RMarkdownPreview extends vscode.Disposable {
     title: string;
-    cp: DisposableProcess;
+    cp: DisposableProcess | undefined;
     panel: vscode.WebviewPanel;
     resourceViewColumn: vscode.ViewColumn;
     outputUri: vscode.Uri;
-    htmlDarkContent: string;
-    htmlLightContent: string;
-    fileWatcher: fs.FSWatcher;
+    htmlDarkContent: string | undefined;
+    htmlLightContent: string | undefined;
+    fileWatcher: fs.FSWatcher | undefined;
     autoRefresh: boolean;
     mtime: number;
 
-    constructor(title: string, cp: DisposableProcess, panel: vscode.WebviewPanel,
+    constructor(title: string, cp: DisposableProcess | undefined, panel: vscode.WebviewPanel,
         resourceViewColumn: vscode.ViewColumn, outputUri: vscode.Uri, filePath: string,
         RMarkdownPreviewManager: RMarkdownPreviewManager, useCodeTheme: boolean, autoRefresh: boolean) {
         super(() => {
@@ -46,9 +46,9 @@ class RMarkdownPreview extends vscode.Disposable {
 
     public styleHtml(useCodeTheme: boolean) {
         if (useCodeTheme) {
-            this.panel.webview.html = this.htmlDarkContent;
+            this.panel.webview.html = this.htmlDarkContent ?? '';
         } else {
-            this.panel.webview.html = this.htmlLightContent;
+            this.panel.webview.html = this.htmlLightContent ?? '';
         }
     }
 
@@ -58,7 +58,7 @@ class RMarkdownPreview extends vscode.Disposable {
     }
 
     private startFileWatcher(RMarkdownPreviewManager: RMarkdownPreviewManager, filePath: string) {
-        let fsTimeout: NodeJS.Timeout;
+        let fsTimeout: NodeJS.Timeout | null;
         const fileWatcher = fs.watch(filePath, {}, () => {
             const mtime = fs.statSync(filePath).mtime.getTime();
             if (this.autoRefresh && !fsTimeout && mtime !== this.mtime) {
@@ -91,7 +91,11 @@ class RMarkdownPreview extends vscode.Disposable {
         if (chunkCol) {
             const colReg = /[0-9.]+/g;
             const regOut = chunkCol.match(colReg);
-            outCol = `rgba(${regOut[0] ?? 128}, ${regOut[1] ?? 128}, ${regOut[2] ?? 128}, ${Math.max(0, Number(regOut[3] ?? 0.1) - 0.05)})`;
+            if (regOut) {
+                outCol = `rgba(${regOut[0] ?? 128}, ${regOut[1] ?? 128}, ${regOut[2] ?? 128}, ${Math.max(0, Number(regOut[3] ?? 0.1) - 0.05)})`;
+            } else {
+                outCol = 'rgba(128, 128, 128, 0.05)';
+            }
         } else {
             chunkCol = 'rgba(128, 128, 128, 0.1)';
             outCol = 'rgba(128, 128, 128, 0.05)';
@@ -146,15 +150,15 @@ class RMarkdownPreviewStore extends vscode.Disposable {
 
     // dispose child and remove it from set
     public delete(filePath: string): boolean {
-        this.store.get(filePath).dispose();
+        this.store.get(filePath)?.dispose();
         return this.store.delete(filePath);
     }
 
-    public get(filePath: string): RMarkdownPreview {
+    public get(filePath: string): RMarkdownPreview | undefined {
         return this.store.get(filePath);
     }
 
-    public getFilePath(preview: RMarkdownPreview): string {
+    public getFilePath(preview: RMarkdownPreview): string | undefined {
         for (const _preview of this.store) {
             if (_preview[1] === preview) {
                 return _preview[0];
@@ -174,7 +178,7 @@ class RMarkdownPreviewStore extends vscode.Disposable {
 
 export class RMarkdownPreviewManager extends RMarkdownManager {
     // the currently selected RMarkdown preview
-    private activePreview: { filePath: string, preview: RMarkdownPreview, title: string } = { filePath: null, preview: null, title: null };
+    private activePreview: { filePath: string | null, preview: RMarkdownPreview | null, title: string | null } = { filePath: null, preview: null, title: null };
     // store of all open RMarkdown previews
     private previewStore: RMarkdownPreviewStore = new RMarkdownPreviewStore;
     private useCodeTheme = true;
@@ -186,15 +190,21 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
 
 
     public async previewRmd(viewer: vscode.ViewColumn, uri?: vscode.Uri): Promise<void> {
-        const filePath = uri ? uri.fsPath : vscode.window.activeTextEditor.document.uri.fsPath;
+        const textEditor = vscode.window.activeTextEditor;
+        if (!textEditor) {
+            void vscode.window.showErrorMessage('No text editor active.');
+            return;
+        }
+
+        const filePath = uri ? uri.fsPath : textEditor.document.uri.fsPath;
         const fileName = path.basename(filePath);
         const currentViewColumn: vscode.ViewColumn = vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.Active ?? vscode.ViewColumn.One;
 
         // handle untitled rmd files
-        if (!uri && vscode.window.activeTextEditor.document.isUntitled) {
+        if (!uri && textEditor.document.isUntitled) {
             void vscode.window.showWarningMessage('Cannot knit an untitled file. Please save the document.');
             await vscode.commands.executeCommand('workbench.action.files.save').then(() => {
-                if (!vscode.window.activeTextEditor.document.isUntitled) {
+                if (!textEditor.document.isUntitled) {
                     void this.previewRmd(viewer);
                 }
             });
@@ -203,7 +213,7 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
 
         const isSaved = uri ?
             true :
-            await saveDocument(vscode.window.activeTextEditor.document);
+            await saveDocument(textEditor.document);
 
         if (!isSaved) {
             return;
@@ -264,17 +274,17 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
     }
 
     public async openExternalBrowser(): Promise<void> {
-        if (this.activePreview) {
-            await vscode.env.openExternal(this.activePreview?.preview?.outputUri);
+        if (this.activePreview.preview) {
+            await vscode.env.openExternal(this.activePreview.preview.outputUri);
         }
     }
 
     public async updatePreview(preview?: RMarkdownPreview): Promise<void> {
-        const toUpdate = preview ?? this.activePreview?.preview;
-        const previewUri = this.previewStore?.getFilePath(toUpdate);
+        const toUpdate = preview ?? this.activePreview.preview;
+        const previewUri = toUpdate ? this.previewStore.getFilePath(toUpdate) : undefined;
         toUpdate?.cp?.dispose();
 
-        if (toUpdate) {
+        if (toUpdate && previewUri) {
             const childProcess: DisposableProcess | void = await this.previewDocument(previewUri, toUpdate.title).catch(() => {
                 void vscode.window.showErrorMessage('There was an error in knitting the document. Please check the R Markdown output stream.');
                 this.rMarkdownOutput.show(true);
@@ -290,7 +300,7 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
 
     }
 
-    private async previewDocument(filePath: string, fileName?: string, viewer?: vscode.ViewColumn, currentViewColumn?: vscode.ViewColumn): Promise<DisposableProcess> {
+    private async previewDocument(filePath: string, fileName?: string, viewer?: vscode.ViewColumn, currentViewColumn?: vscode.ViewColumn): Promise<DisposableProcess | undefined> {
         const knitWorkingDir = this.getKnitDir(knitDir, filePath);
         const knitWorkingDirText = knitWorkingDir ? `${knitWorkingDir}` : '';
         this.rPath = await getRpath();
@@ -307,18 +317,18 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
         };
 
 
-        const callback = (dat: string, childProcess: DisposableProcess) => {
+        const callback = (dat: string, childProcess?: DisposableProcess) => {
             const outputUrl = re.exec(dat)?.[0]?.replace(re, '$1');
             if (outputUrl) {
-                if (viewer !== undefined) {
-                    const autoRefresh = config().get<boolean>('rmarkdown.preview.autoRefresh');
+                if (viewer !== undefined && fileName) {
+                    const autoRefresh = config().get<boolean>('rmarkdown.preview.autoRefresh', false);
                     void this.openPreview(
                         vscode.Uri.file(outputUrl),
                         filePath,
                         fileName,
                         childProcess,
                         viewer,
-                        currentViewColumn,
+                        currentViewColumn ?? vscode.ViewColumn.Active,
                         autoRefresh
                     );
                 }
@@ -333,21 +343,23 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
             }
         };
 
-        return await this.knitWithProgress(
-            {
-                workingDirectory: knitWorkingDir,
-                fileName: fileName,
-                filePath: filePath,
-                scriptPath: extensionContext.asAbsolutePath('R/rmarkdown/preview.R'),
-                scriptArgs: scriptValues,
-                rOutputFormat: 'html preview',
-                callback: callback,
-                onRejection: onRejected
-            }
-        );
+        if (knitWorkingDir && fileName) {
+            return await this.knitWithProgress(
+                {
+                    workingDirectory: knitWorkingDir,
+                    fileName: fileName,
+                    filePath: filePath,
+                    scriptPath: extensionContext.asAbsolutePath('R/rmarkdown/preview.R'),
+                    scriptArgs: scriptValues,
+                    rOutputFormat: 'html preview',
+                    callback: callback,
+                    onRejection: onRejected
+                }
+            );
+        }
     }
 
-    private openPreview(outputUri: vscode.Uri, filePath: string, title: string, cp: DisposableProcess, viewer: vscode.ViewColumn, resourceViewColumn: vscode.ViewColumn, autoRefresh: boolean): void {
+    private openPreview(outputUri: vscode.Uri, filePath: string, title: string, cp: DisposableProcess | undefined, viewer: vscode.ViewColumn, resourceViewColumn: vscode.ViewColumn, autoRefresh: boolean): void {
 
         const panel = vscode.window.createWebviewPanel(
             'previewRmd',

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -53,7 +53,7 @@ class RMarkdownPreview extends vscode.Disposable {
     }
 
     public async refreshContent(useCodeTheme: boolean) {
-        this.getHtmlContent(await readContent(this.outputUri.fsPath, 'utf8'));
+        this.getHtmlContent(await readContent(this.outputUri.fsPath, 'utf8') ?? '');
         this.styleHtml(useCodeTheme);
     }
 

--- a/src/rstudioapi.ts
+++ b/src/rstudioapi.ts
@@ -116,7 +116,7 @@ export async function documentContext(id: string) {
     };
 }
 
-export async function insertOrModifyText(query: any[], id: string = null) {
+export async function insertOrModifyText(query: any[], id: string | null = null) {
 
 
     const target = findTargetUri(id);
@@ -218,7 +218,8 @@ export async function documentSaveAll(): Promise<void> {
     await workspace.saveAll();
 }
 
-export function projectPath(): { path: string; } {
+// TODO: very similar to ./utils.getCurrentWorkspaceFolder()
+export function projectPath(): { path: string | undefined; } {
 
     if (typeof workspace.workspaceFolders !== 'undefined') {
         // Is there a root folder open?
@@ -253,7 +254,11 @@ export function projectPath(): { path: string; } {
 }
 
 export async function documentNew(text: string, type: string, position: number[]): Promise<void> {
-    const documentUri = Uri.parse('untitled:' + path.join(projectPath().path, 'new_document.' + type));
+    const currentProjectPath = projectPath().path; 
+    if (!currentProjectPath) {
+        return; // TODO: Report failure
+    }
+    const documentUri = Uri.parse('untitled:' + path.join(currentProjectPath, 'new_document.' + type));
     const targetDocument = await workspace.openTextDocument(documentUri);
     const edit = new WorkspaceEdit();
     const docLines = targetDocument.lineCount;
@@ -280,7 +285,7 @@ interface AddinItem extends QuickPickItem {
     package: string;
 }
 
-let addinQuickPicks: AddinItem[] = undefined;
+let addinQuickPicks: AddinItem[] | undefined = undefined;
 
 export async function getAddinPickerItems(): Promise<AddinItem[]> {
 
@@ -334,7 +339,7 @@ export async function launchAddinPicker(): Promise<void> {
         placeHolder: '',
         onDidSelectItem: undefined
     };
-    const addinSelection: AddinItem =
+    const addinSelection: AddinItem | undefined =
         await window.showQuickPick<AddinItem>(getAddinPickerItems(), addinPickerOptions);
 
     if (!(typeof addinSelection === 'undefined')) {
@@ -438,7 +443,7 @@ function getLastActiveTextEditor() {
         lastActiveTextEditor : window.activeTextEditor);
 }
 
-function findTargetUri(id: string) {
+function findTargetUri(id: string | null) {
     return (id === null ?
         getLastActiveTextEditor().document.uri : Uri.parse(id));
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -43,6 +43,7 @@ export let sessionDir: string;
 export let workingDir: string;
 let rVer: string;
 let pid: string;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let info: any;
 export let workspaceFile: string;
 let workspaceLockFile: string;

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -101,7 +101,7 @@ function asRTask(rPath: string, folder: vscode.WorkspaceFolder | vscode.TaskScop
     const rtask: vscode.Task = new vscode.Task(
         info.definition,
         folder,
-        info.name,
+        info.name ?? 'Unnamed',
         info.definition.type,
         new vscode.ProcessExecution(
             rPath,
@@ -131,6 +131,9 @@ export class RTaskProvider implements vscode.TaskProvider {
 
         const tasks: vscode.Task[] = [];
         const rPath = await getRpath(false);
+        if (!rPath) {
+            return [];
+        }
 
         for (const folder of folders) {
             const isRPackage = fs.existsSync(path.join(folder.uri.fsPath, 'DESCRIPTION'));
@@ -151,6 +154,9 @@ export class RTaskProvider implements vscode.TaskProvider {
             name: task.name
         };
         const rPath = await getRpath(false);
+        if (!rPath) {
+            throw 'R path not set.';
+        }
         return asRTask(rPath, vscode.TaskScope.Workspace, taskInfo);
     }
 }

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,7 +1,10 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+
 import * as path from 'path';
 import * as Mocha from 'mocha';
+// @ts-ignore: all
 import * as glob from 'glob';
 
 export function run(): Promise<void> {
@@ -14,6 +17,7 @@ export function run(): Promise<void> {
     const testsRoot = path.resolve(__dirname, '..');
 
     return new Promise((c, e) => {
+        // @ts-ignore: all
         glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
             if (err) {
                 return e(err);

--- a/src/test/suite/syntax.test.ts
+++ b/src/test/suite/syntax.test.ts
@@ -53,6 +53,7 @@ suite('Syntax Highlighting', () => {
         const re = new RegExp(function_pattern_fixed);
         const line = 'x <- function(x) {';
         const match = re.exec(line);
+        assert.ok(match);
         assert.strictEqual(match[3], 'function');
     });
 
@@ -60,6 +61,7 @@ suite('Syntax Highlighting', () => {
         const re = new RegExp(function_pattern_fixed);
         const line = 'x <- function  (x) {';
         const match = re.exec(line);
+        assert.ok(match);
         assert.strictEqual(match[3], 'function');
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,7 +22,7 @@ function getRfromEnvPath(platform: string) {
         fileExtension = '.exe';
     }
 
-    const os_paths: string[] | string = process.env.PATH.split(splitChar);
+    const os_paths: string[] | string = process.env.PATH ? process.env.PATH.split(splitChar) : [];
     for (const os_path of os_paths) {
         const os_r_path: string = path.join(os_path, 'R' + fileExtension);
         if (fs.existsSync(os_r_path)) {
@@ -67,8 +67,8 @@ export function getRPathConfigEntry(term: boolean = false): string {
     return `${trunc}.${platform}`;
 }
 
-export async function getRpath(quote = false, overwriteConfig?: string): Promise<string> {
-    let rpath = '';
+export async function getRpath(quote = false, overwriteConfig?: string): Promise<string | undefined> {
+    let rpath: string | undefined = '';
 
     // try the config entry specified in the function arg:
     if (overwriteConfig) {
@@ -146,7 +146,7 @@ export function checkIfFileExists(filePath: string): boolean {
     return existsSync(filePath);
 }
 
-export function getCurrentWorkspaceFolder(): vscode.WorkspaceFolder {
+export function getCurrentWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
     if (vscode.workspace.workspaceFolders !== undefined) {
         if (vscode.workspace.workspaceFolders.length === 1) {
             return vscode.workspace.workspaceFolders[0];
@@ -223,16 +223,20 @@ export async function executeAsTask(name: string, cmdOrProcess: string, args?: s
     let taskExecution: vscode.ShellExecution | vscode.ProcessExecution;
     if(asProcess){
         taskDefinition = { type: 'process'};
-        taskExecution = new vscode.ProcessExecution(
+        taskExecution = args ? new vscode.ProcessExecution(
             cmdOrProcess,
             args
+        ) : new vscode.ProcessExecution(
+            cmdOrProcess
         );
-    } else{
+    } else {
         taskDefinition = { type: 'shell' };
-        const quotedArgs = args.map<vscode.ShellQuotedString>(arg => { return { value: arg, quoting: vscode.ShellQuoting.Weak }; });
-        taskExecution = new vscode.ShellExecution(
+        const quotedArgs = args && args.map<vscode.ShellQuotedString>(arg => { return { value: arg, quoting: vscode.ShellQuoting.Weak }; });
+        taskExecution = quotedArgs ? new vscode.ShellExecution(
             cmdOrProcess,
             quotedArgs
+        ) : new vscode.ShellExecution(
+            cmdOrProcess
         );
     }
     const task = new vscode.Task(
@@ -259,22 +263,19 @@ export async function executeAsTask(name: string, cmdOrProcess: string, args?: s
 // executes a callback and shows a 'busy' progress bar during the execution
 // synchronous callbacks are converted to async to properly render the progress bar
 // default location is in the help pages tree view
-export async function doWithProgress<T>(cb: (token?: vscode.CancellationToken, progress?: vscode.Progress<T>) => T | Promise<T>, location: (string | vscode.ProgressLocation) = vscode.ProgressLocation.Window, title?: string, cancellable?: boolean): Promise<T> {
+export async function doWithProgress<T>(cb: (token?: vscode.CancellationToken, progress?: vscode.Progress<{ message?: string; increment?: number }>) => T | Promise<T>, location: (string | vscode.ProgressLocation) = vscode.ProgressLocation.Window, title?: string, cancellable?: boolean): Promise<T> {
     const location2 = (typeof location === 'string' ? { viewId: location } : location);
     const options: vscode.ProgressOptions = {
         location: location2,
         cancellable: cancellable ?? false,
         title: title
     };
-    let ret: T;
-    await vscode.window.withProgress(options, async (progress, token) => {
-        const retPromise = new Promise<T>((resolve) => setTimeout(() => {
+    return await vscode.window.withProgress(options, async (progress, token) => {
+        return await new Promise<T>((resolve) => setTimeout(() => {
             const ret = cb(token, progress);
             resolve(ret);
         }));
-        ret = await retPromise;
     });
-    return ret;
 }
 
 // get the URL of a CRAN website
@@ -294,8 +295,8 @@ export async function getCranUrl(path: string = '', cwd?: string | URL): Promise
     return url;
 }
 
-export function getRLibPaths(): string {
-    return config().get<string[]>('libPaths').join('\n');
+export function getRLibPaths(): string | undefined {
+    return config().get<string[]>('libPaths')?.join('\n');
 }
 
 // executes an R command returns its output to stdout
@@ -307,6 +308,9 @@ export function getRLibPaths(): string {
 //
 export async function executeRCommand(rCommand: string, cwd?: string | URL, fallback?: string | ((e: Error) => string)): Promise<string | undefined> {
     const rPath = await getRpath();
+    if (!rPath) {
+        return undefined;
+    }
 
     const options: cp.CommonOptions = {
         cwd: cwd,
@@ -323,7 +327,7 @@ export async function executeRCommand(rCommand: string, cwd?: string | URL, fall
         '-e', `cat('${lim}')`
     ];
 
-    let ret: string = undefined;
+    let ret: string | undefined = undefined;
 
     try {
         const result = await spawnAsync(rPath, args, options);
@@ -332,13 +336,13 @@ export async function executeRCommand(rCommand: string, cwd?: string | URL, fall
         }
         const re = new RegExp(`${lim}(.*)${lim}`, 'ms');
         const match = re.exec(result.stdout);
-        if (match.length !== 2) {
+        if (!match || match.length !== 2) {
             throw new Error('Could not parse R output.');
         }
         ret = match[1];
     } catch (e) {
         if (fallback) {
-            ret = (typeof fallback === 'function' ? fallback((e instanceof Error) ? e : undefined) : fallback);
+            ret = (typeof fallback === 'function' ? fallback((e instanceof Error) ? e : Error('Undefined error')) : fallback);
         } else {
             console.warn(e);
         }
@@ -429,19 +433,21 @@ export function asDisposable<T>(toDispose: T, disposeFunction: (...args: unknown
 export type DisposableProcess = cp.ChildProcessWithoutNullStreams & vscode.Disposable;
 export function spawn(command: string, args?: ReadonlyArray<string>, options?: cp.CommonOptions, onDisposed?: () => unknown): DisposableProcess {
     const proc = cp.spawn(command, args, options);
-    console.log(`Process ${proc.pid} spawned`);
+    console.log(proc.pid ? `Process ${proc.pid} spawned` : 'Process failed to spawn');
     let running = true;
     const exitHandler = () => {
         running = false;
-        console.log(`Process ${proc.pid} exited`);
+        console.log(`Process ${proc.pid || ''} exited`);
     };
     proc.on('exit', exitHandler);
     proc.on('error', exitHandler);
     const disposable = asDisposable(proc, () => {
         if (running) {
-            console.log(`Process ${proc.pid} terminating`);
+            console.log(`Process ${proc.pid || ''} terminating`);
             if (process.platform === 'win32') {
-                cp.spawnSync('taskkill', ['/pid', proc.pid.toString(), '/f', '/t']);
+                if (proc.pid !== undefined) {
+                    cp.spawnSync('taskkill', ['/pid', proc.pid.toString(), '/f', '/t']);
+                }
             } else {
                 proc.kill('SIGKILL');
             }
@@ -455,18 +461,22 @@ export function spawn(command: string, args?: ReadonlyArray<string>, options?: c
 
 export async function spawnAsync(command: string, args?: ReadonlyArray<string>, options?: cp.CommonOptions, onDisposed?: () => unknown): Promise<cp.SpawnSyncReturns<string>> {
     return new Promise((resolve) => {
+
         const result: cp.SpawnSyncReturns<string> = {
             error: undefined,
-            pid: undefined,
-            output: undefined,
+            pid: -1,
+            output: [],
             stdout: '',
             stderr: '',
-            status: undefined,
-            signal: undefined
+            status: null,
+            signal: null
         };
+        
         try {
             const childProcess = spawn(command, args, options, onDisposed);
-            result.pid = childProcess.pid;
+            if (childProcess.pid !== undefined) {
+                result.pid = childProcess.pid;
+            }
             childProcess.stdout?.on('data', (chunk: Buffer) => {
                 result.stdout += chunk.toString();
             });
@@ -508,6 +518,10 @@ export async function promptToInstallRPackage(name: string, section: string, cwd
             if (select === 'Yes') {
                 const repo = await getCranUrl('', cwd);
                 const rPath = await getRpath();
+                if (!rPath) {
+                    void vscode.window.showErrorMessage('R path not set', 'OK');
+                    return;
+                }
                 const args = ['--silent', '--slave', '--no-save', '--no-restore', '-e', `install.packages('${name}', repos='${repo}')`];
                 void executeAsTask('Install Package', rPath, args, true);
                 if (postInstallMsg) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -567,3 +567,23 @@ export function createTempDir(root: string, hidden?: boolean): string {
 export function catchAsError(err: unknown, fallbackMessage?: string): Error {
     return (err instanceof Error) ? err : Error(fallbackMessage ?? 'Unknown error');
 }
+
+
+
+export function asViewColumn(s: string | undefined | vscode.ViewColumn): vscode.ViewColumn | undefined;
+export function asViewColumn(s: string | undefined | vscode.ViewColumn, fallback: vscode.ViewColumn): vscode.ViewColumn;
+export function asViewColumn(s: string | undefined | vscode.ViewColumn, fallback?: vscode.ViewColumn): vscode.ViewColumn | undefined {
+    if(!s){
+        return fallback;
+    }
+    if(typeof s !== 'string'){
+        // s is already ViewColumn:
+        return s;
+    }
+    if(Object.keys(vscode.ViewColumn).includes(s)){
+        const sKey = s as keyof typeof vscode.ViewColumn;
+        return(vscode.ViewColumn[sKey]);
+    }
+    return fallback;
+}
+

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import { rGuestService, isGuestSession } from './liveShare';
 import { extensionContext } from './extension';
+import { randomBytes } from 'crypto';
 
 export function config(): vscode.WorkspaceConfiguration {
     return vscode.workspace.getConfiguration('r');
@@ -531,4 +532,19 @@ export async function promptToInstallRPackage(name: string, section: string, cwd
                 void _config.update(section, false);
             }
         });
+}
+
+/**
+ * Create temporary directory. Will avoid name clashes. Caller must delete directory after use.
+ * 
+ * @param root Parent folder.
+ * @param hidden If set to true, directory will be prefixed with a '.' (ignored on windows).
+ * @returns Path to the temporary directory.
+ */
+export function createTempDir(root: string, hidden?: boolean): string {
+    const hidePrefix = (!hidden || process.platform === 'win32') ? '' : '.';
+    let tempDir: string;
+    while (fs.existsSync(tempDir = path.join(root, `${hidePrefix}___temp_${randomBytes(8).toString('hex')}`))) { /* Name clash */ }
+    fs.mkdirSync(tempDir);
+    return tempDir;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -570,19 +570,20 @@ export function catchAsError(err: unknown, fallbackMessage?: string): Error {
 
 
 
+const VIEW_COLUMN_KEYS = Object.keys(vscode.ViewColumn).filter(x => isNaN(parseInt(x)));
+
 export function asViewColumn(s: string | undefined | vscode.ViewColumn): vscode.ViewColumn | undefined;
 export function asViewColumn(s: string | undefined | vscode.ViewColumn, fallback: vscode.ViewColumn): vscode.ViewColumn;
 export function asViewColumn(s: string | undefined | vscode.ViewColumn, fallback?: vscode.ViewColumn): vscode.ViewColumn | undefined {
-    if(!s){
+    if (!s) {
         return fallback;
     }
-    if(typeof s !== 'string'){
+    if (typeof s !== 'string') {
         // s is already ViewColumn:
         return s;
     }
-    if(Object.keys(vscode.ViewColumn).includes(s)){
-        const sKey = s as keyof typeof vscode.ViewColumn;
-        return(vscode.ViewColumn[sKey]);
+    if (VIEW_COLUMN_KEYS.includes(s)) {
+        return vscode.ViewColumn[s as keyof typeof vscode.ViewColumn];
     }
     return fallback;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -343,7 +343,7 @@ export async function executeRCommand(rCommand: string, cwd?: string | URL, fall
         ret = match[1];
     } catch (e) {
         if (fallback) {
-            ret = (typeof fallback === 'function' ? fallback((e instanceof Error) ? e : Error('Undefined error')) : fallback);
+            ret = (typeof fallback === 'function' ? fallback(catchAsError(e)) : fallback);
         } else {
             console.warn(e);
         }
@@ -547,4 +547,23 @@ export function createTempDir(root: string, hidden?: boolean): string {
     while (fs.existsSync(tempDir = path.join(root, `${hidePrefix}___temp_${randomBytes(8).toString('hex')}`))) { /* Name clash */ }
     fs.mkdirSync(tempDir);
     return tempDir;
+}
+
+/**
+ * Utility function for converting 'unknown' types to errors.
+ * 
+ * Usage:
+ * 
+ * ```ts
+ * try { ... } 
+ * catch (e) { 
+ *  const err: Error = catchAsError(e); 
+ * }
+ * ```
+ * @param err 
+ * @param fallbackMessage 
+ * @returns 
+ */
+export function catchAsError(err: unknown, fallbackMessage?: string): Error {
+    return (err instanceof Error) ? err : Error(fallbackMessage ?? 'Unknown error');
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -169,11 +169,11 @@ export function getCurrentWorkspaceFolder(): vscode.WorkspaceFolder | undefined 
 //
 // If it is a guest, the guest service requests the host
 // to read the file, and pass back its contents to the guest
-export function readContent(file: PathLike | number): Promise<Buffer>;
-export function readContent(file: PathLike | number, encoding: string): Promise<string>;
-export function readContent(file: PathLike | number, encoding?: string): Promise<string | Buffer> {
+export function readContent(file: PathLike | number): Promise<Buffer> | undefined;
+export function readContent(file: PathLike | number, encoding: string): Promise<string> | undefined;
+export function readContent(file: PathLike | number, encoding?: string): Promise<string | Buffer> | undefined {
     if (isGuestSession) {
-        return encoding === undefined ? rGuestService.requestFileContent(file) : rGuestService.requestFileContent(file, encoding);
+        return encoding === undefined ? rGuestService?.requestFileContent(file) : rGuestService?.requestFileContent(file, encoding);
     } else {
         return encoding === undefined ? readFile(file) : readFile(file, encoding);
     }

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -18,14 +18,14 @@ async function populatePackageNodes(): Promise<void> {
     if (rootNode) {
         // ensure the pkgRootNode is populated.
         await rootNode.getChildren();
-        await rootNode.pkgRootNode.getChildren();
+        await rootNode?.pkgRootNode?.getChildren();
     }
 }
 
 function getPackageNode(name: string): PackageNode | undefined {
     const rootNode = globalRHelp?.treeViewWrapper.helpViewProvider.rootItem;
     if (rootNode) {
-        return rootNode.pkgRootNode.children?.find(node => node.label === name);
+        return rootNode?.pkgRootNode?.children?.find(node => node.label === name);
     }
 }
 

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -36,7 +36,7 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
     private _onDidChangeTreeData: EventEmitter<void> = new EventEmitter();
 
     public readonly onDidChangeTreeData: Event<void> = this._onDidChangeTreeData.event;
-    public data: WorkspaceData;
+    public data: WorkspaceData | undefined;
 
     public refresh(): void {
         this.data = isGuestSession ? guestWorkspace : workspaceData;
@@ -115,6 +115,8 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
                             element.treeLevel + 1
                         )
                     );
+            } else {
+                return [];
             }
         } else {
             const treeItems = [this.attachedNamespacesRootItem, this.loadedNamespacesRootItem];
@@ -161,7 +163,7 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
             } else if (a.priority < b.priority) {
                 return 1;
             } else {
-                return a.label.localeCompare(b.label);
+                return (a.label && b.label) ? a.label.localeCompare(b.label) : 0;
             }
         }
 
@@ -171,7 +173,7 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 
 class PackageItem extends TreeItem {
     public static command : string = 'r.workspaceViewer.package.showQuickPick';
-    public label: string;
+    public label?: string;
     public name: string;
     public pkgNode?: PackageNode;
     public constructor(label: string, name: string, pkgNode?: PackageNode) {
@@ -197,8 +199,8 @@ enum TreeLevel {
 }
 
 export class GlobalEnvItem extends TreeItem {
-    public label: string;
-    public desc: string;
+    public label?: string;
+    public desc?: string;
     public str: string;
     public type: string;
     public treeLevel: number;
@@ -234,7 +236,7 @@ export class GlobalEnvItem extends TreeItem {
         this.contextValue = treeLevel === 0 ? 'rootNode' : `childNode${this.treeLevel}`;
     }
 
-    private getDescription(dim: number[], str: string, rClass: string, type: string): string {
+    private getDescription(dim: number[] | undefined, str: string, rClass: string, type: string): string {
         if (dim && type === 'list') {
             if (dim[1] === 1) {
                 return `${rClass}: ${dim[0]} obs. of ${dim[1]} variable`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,11 @@
             "ES2021"
         ],
         "sourceMap": true,
-        // "strictNullChecks": true,
-        "rootDir": "src"
+        "rootDir": "src",
+        "strict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "noFallthroughCasesInSwitch": true
     },
     "exclude": [
         "html",

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,6 +227,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/glob@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.0.0.tgz#321607e9cbaec54f687a0792b2d1d370739455d2"
+  integrity sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/js-yaml@^4.0.2":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.3.tgz#9f33cd6fbf0d5ec575dc8c8fc69c7fec1b4eb200"
@@ -246,6 +254,11 @@
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/mocha@^8.2.2":
   version "8.2.2"


### PR DESCRIPTION
# What problem did you solve?

WIP PR to refactor the entire TypeScript codebase to use stricter type checks. See https://github.com/REditorSupport/vscode-R/issues/1208

We should work bottom-up and fix files with many dependents earlier as null-checks may propagate.

## TODO

Rough checklist to track progress:

- [x] html\help\script.ts
- [x] html\help\webviewMessages.d.ts
- [x] html\httpgd\index.ts
- [x] html\httpgd\webviewMessages.d.ts
- [x] src\api.d.ts
- [x] src\apiImplementation.ts
- [x] src\completions.ts
- [x] src\cppProperties.ts
- [x] src\extension.ts
- [x] src\languageService.ts
- [x] src\lineCache.ts
- [x] src\lintrConfig.ts
- [x] src\preview.ts
- [x] src\rGitignore.ts
- [x] src\rstudioapi.ts
- [x] src\rTerminal.ts
- [x] src\selection.ts
- [x] src\session.ts
- [x] src\tasks.ts
- [x] src\util.ts
- [x] src\workspaceViewer.ts
- [x] src\helpViewer\cran.ts
- [x] src\helpViewer\helpProvider.ts
- [x] src\helpViewer\index.ts
- [x] src\helpViewer\packages.ts
- [x] src\helpViewer\panel.ts
- [x] src\helpViewer\treeView.ts
- [x] src\helpViewer\webviewMessages.d.ts
- [x] src\liveShare\index.ts
- [x] src\liveShare\shareCommands.ts
- [x] src\liveShare\shareSession.ts
- [x] src\liveShare\shareTree.ts
- [x] src\liveShare\virtualDocs.ts
- [x] src\plotViewer\httpgdTypes.d.ts
- [x] src\plotViewer\index.ts
- [x] src\plotViewer\webviewMessages.d.ts
- [x] src\rmarkdown\draft.ts
- [x] src\rmarkdown\index.ts
- [x] src\rmarkdown\knit.ts
- [x] src\rmarkdown\manager.ts
- [x] src\rmarkdown\preview.ts
- [x] src\test\runTest.ts
- [x] src\test\suite\extendSelection.test.ts
- [x] src\test\suite\index.ts
- [x] src\test\suite\lineCache.test.ts
- [x] src\test\suite\syntax.test.ts