### PR TITLE
Support KaTeX in help page viewer

### DIFF
--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -355,17 +355,25 @@ export class HelpPanel {
         $('body').attr('scrollyto', `${helpFile.scrollY ?? -1}`);
 
         const url = new URL(helpFile.url);
-        $('head link,script').each(function () {
-            if ($(this).attr('href')) {
-                if ($(this).attr('href').match(/katex/)) {
-                    $(this).attr('href', url.origin + $(this).attr('href'));
+
+        // replace katex css urls with http://localhost:<port>/ origin
+        $('head link').each(function () {
+            const linkUrl = $(this).attr('href');
+            if (linkUrl) {
+                if (linkUrl.match(/katex/)) {
+                    $(this).attr('href', url.origin + linkUrl);
                 } else {
                     $(this).remove();
                 }
             }
-            if ($(this).attr('src')) {
-                if ($(this).attr('src').match(/katex/)) {
-                    $(this).attr('src', url.origin + $(this).attr('src'));
+        });
+
+        // replace katex js urls with http://localhost:<port>/ origin
+        $('head script').each(function () {
+            const scriptUrl = $(this).attr('src');
+            if (scriptUrl) {
+                if (scriptUrl.match(/katex/)) {
+                    $(this).attr('src', url.origin + scriptUrl);
                 } else {
                     $(this).remove();
                 }

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -354,11 +354,29 @@ export class HelpPanel {
         $('body').attr('relpath', relPath);
         $('body').attr('scrollyto', `${helpFile.scrollY ?? -1}`);
 
+        const url = new URL(helpFile.url);
+        $('head link,script').each(function () {
+            if ($(this).attr('href')) {
+                if ($(this).attr('href').match(/katex/)) {
+                    $(this).attr('href', url.origin + $(this).attr('href'));
+                } else {
+                    $(this).remove();
+                }
+            }
+            if ($(this).attr('src')) {
+                if ($(this).attr('src').match(/katex/)) {
+                    $(this).attr('src', url.origin + $(this).attr('src'));
+                } else {
+                    $(this).remove();
+                }
+            }
+        });
+
         if (styleUri) {
-            $('body').append(`\n<link rel="stylesheet" href="${styleUri.toString()}"></link>`);
+            $('body').append(`\n<link rel="stylesheet" href="${styleUri.toString(true)}"></link>`);
         }
         if (scriptUri) {
-            $('body').append(`\n<script src=${scriptUri.toString()}></script>`);
+            $('body').append(`\n<script src=${scriptUri.toString(true)}></script>`);
         }
 
 

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -361,7 +361,7 @@ export class HelpPanel {
             const linkUrl = $(this).attr('href');
             if (linkUrl) {
                 if (linkUrl.match(/katex/)) {
-                    const newUrl = new URL(linkUrl, url.origin).toString();
+                    const newUrl = new URL(linkUrl, url.origin);
                     $(this).attr('href', newUrl.toString());
                 } else {
                     $(this).remove();
@@ -374,7 +374,7 @@ export class HelpPanel {
             const scriptUrl = $(this).attr('src');
             if (scriptUrl) {
                 if (scriptUrl.match(/katex/)) {
-                    const newUrl = new URL(scriptUrl, url.origin).toString();
+                    const newUrl = new URL(scriptUrl, url.origin);
                     $(this).attr('src', newUrl.toString());
                 } else {
                     $(this).remove();

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -354,13 +354,14 @@ export class HelpPanel {
         $('body').attr('relpath', relPath);
         $('body').attr('scrollyto', `${helpFile.scrollY ?? -1}`);
 
+        // replace katex js/css urls with http://localhost:<port>/ origin
+        // and remove others.
         const url = new URL(helpFile.url);
 
-        // replace katex css urls with http://localhost:<port>/ origin
-        $('head link').each(function () {
+        $('link').each(function () {
             const linkUrl = $(this).attr('href');
             if (linkUrl) {
-                if (linkUrl.match(/katex/)) {
+                if (linkUrl.includes('katex')) {
                     const newUrl = new URL(linkUrl, url.origin);
                     $(this).attr('href', newUrl.toString());
                 } else {
@@ -369,11 +370,10 @@ export class HelpPanel {
             }
         });
 
-        // replace katex js urls with http://localhost:<port>/ origin
-        $('head script').each(function () {
+        $('script').each(function () {
             const scriptUrl = $(this).attr('src');
             if (scriptUrl) {
-                if (scriptUrl.match(/katex/)) {
+                if (scriptUrl.includes('katex')) {
                     const newUrl = new URL(scriptUrl, url.origin);
                     $(this).attr('src', newUrl.toString());
                 } else {

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -361,7 +361,8 @@ export class HelpPanel {
             const linkUrl = $(this).attr('href');
             if (linkUrl) {
                 if (linkUrl.match(/katex/)) {
-                    $(this).attr('href', url.origin + linkUrl);
+                    const newUrl = new URL(linkUrl, url.origin).toString();
+                    $(this).attr('href', newUrl.toString());
                 } else {
                     $(this).remove();
                 }
@@ -373,7 +374,8 @@ export class HelpPanel {
             const scriptUrl = $(this).attr('src');
             if (scriptUrl) {
                 if (scriptUrl.match(/katex/)) {
-                    $(this).attr('src', url.origin + scriptUrl);
+                    const newUrl = new URL(scriptUrl, url.origin).toString();
+                    $(this).attr('src', newUrl.toString());
                 } else {
                     $(this).remove();
                 }


### PR DESCRIPTION
# What problem did you solve?

Closes #1207 

In the HTML of R help pages, the katex JS/CSS resource urls are transformed so that they can be properly loaded in the webview:

```html
<link rel="stylesheet" href="/doc/html/katex/katex.css">
<script type="text/javascript" src="/doc/html/katex-config.js"></script>
<script defer="" src="/doc/html/katex/katex.js" onload="processMathHTML();"></script>
```

these are replaced with

```html
<link rel="stylesheet" href="http://localhost:<port>/doc/html/katex/katex.css">
<script type="text/javascript" src="http://localhost:<port>/doc/html/katex-config.js"></script>
<script defer="" src="http://localhost:<port>/doc/html/katex/katex.js" onload="processMathHTML();"></script>
```

where `http://localhost:<port>` is provided by the R help server running in the background.

## (If you have)Screenshot

<img width="756" alt="image" src="https://user-images.githubusercontent.com/4662568/194448898-96cb003d-6234-4179-9a3d-e69db8c6342b.png">

## (If you do not have screenshot) How can I check this pull request?

Open a help page and see if the katex formulas are properly rendered.

```r
?dt
```
