### PR TITLE
Fix checking `request.viewer`

### DIFF
--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -134,20 +134,20 @@ export async function updateGuestRequest(file: string, force: boolean = false): 
                 break;
             }
             case 'browser': {
-                if (request.url && request.title && request.viewer) {
+                if (request.url && request.title && request.viewer !== undefined) {
                     await showBrowser(request.url, request.title, request.viewer);
                 }
                 break;
             }
             case 'webview': {
-                if (request.file && request.title && request.viewer) {
+                if (request.file && request.title && request.viewer !== undefined) {
                     await showWebView(request.file, request.title, request.viewer);
                 }
                 break;
             }
             case 'dataview': {
                 if (request.source && request.type && request.title && request.file
-                    && request.viewer) {
+                    && request.viewer !== undefined) {
                     await showDataView(request.source,
                         request.type, request.title, request.file, request.viewer);
                 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -778,19 +778,19 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                         break;
                     }
                     case 'browser': {
-                        if (request.url && request.title && request.viewer) {
+                        if (request.url && request.title && request.viewer !== undefined) {
                             await showBrowser(request.url, request.title, request.viewer);
                         }
                         break;
                     }
                     case 'webview': {
-                        if (request.file && request.title && request.viewer) {
+                        if (request.file && request.title && request.viewer !== undefined) {
                             await showWebView(request.file, request.title, request.viewer);
                         }
                         break;
                     }
                     case 'dataview': {
-                        if (request.source && request.type && request.file && request.title && request.viewer) {
+                        if (request.source && request.type && request.file && request.title && request.viewer !== undefined) {
                             await showDataView(request.source,
                                 request.type, request.title, request.file, request.viewer);
                         }


### PR DESCRIPTION
# What problem did you solve?

Closes #1228 

When viewer is disabled, any request that creates a WebView should be handled by opening the file externally (in a web browser). This PR fixes a regression introduced in #1209.

## (If you do not have screenshot) How can I check this pull request?

```r
options(vsc.viewer = FALSE)
gt::gt(iris)
```