### PR TITLE
Close 1239: More devtools and usethis commands for R package development

### DIFF
--- a/package.json
+++ b/package.json
@@ -447,6 +447,11 @@
         "command": "r.loadAll"
       },
       {
+        "title": "Release",
+        "category": "R Package",
+        "command": "r.release"
+      },
+      {
         "title": "Build",
         "category": "R Package",
         "command": "r.build"
@@ -1767,7 +1772,7 @@
           "default": false,
           "description": "Default boolean value for automatically sharing R browser ports with guests."
         },
-        "r.plot.devArgs" :{
+        "r.plot.devArgs": {
           "type": "object",
           "markdownDescription": "The arguments for the png device to replay user graphics to show in VSCode. Requires `#r.plot.useHttpgd#` to be set to `false`. \n\nChanges the option `vsc.dev.args` in R.",
           "default": {

--- a/package.json
+++ b/package.json
@@ -447,6 +447,11 @@
         "command": "r.loadAll"
       },
       {
+        "title": "Toggle Development Mode",
+        "category": "R Package",
+        "command": "r.devMode"
+      },
+      {
         "title": "Spell check",
         "category": "R Package",
         "command": "r.spellCheck"

--- a/package.json
+++ b/package.json
@@ -467,6 +467,11 @@
         "command": "r.useCranComments"
       },
       {
+        "title": "Build {pkgdown} Web Site",
+        "category": "R Package",
+        "command": "r.pkgdownBuildSite"
+      },
+      {
         "title": "Load All",
         "category": "R Package",
         "command": "r.loadAll"

--- a/package.json
+++ b/package.json
@@ -442,6 +442,11 @@
         "command": "r.previewEnvironment"
       },
       {
+        "title": "Create NEWS",
+        "category": "R Package",
+        "command": "r.useNewsMd"
+      },
+      {
         "title": "Initialise A Git Repository",
         "category": "R Package",
         "command": "r.useGit"

--- a/package.json
+++ b/package.json
@@ -442,6 +442,11 @@
         "command": "r.previewEnvironment"
       },
       {
+        "title": "Initialise A Git Repository",
+        "category": "R Package",
+        "command": "r.useGit"
+      },
+      {
         "title": "Increment Package Version",
         "category": "R Package",
         "command": "r.useVersion"

--- a/package.json
+++ b/package.json
@@ -462,6 +462,11 @@
         "command": "r.checkRhub"
       },
       {
+        "title": "CRAN Checks for Package on Win-Builder",
+        "category": "R Package",
+        "command": "r.checkWinDevel"
+      },
+      {
         "title": "CRAN Release",
         "category": "R Package",
         "command": "r.release"

--- a/package.json
+++ b/package.json
@@ -442,6 +442,11 @@
         "command": "r.previewEnvironment"
       },
       {
+        "title": "Increment Package Version",
+        "category": "R Package",
+        "command": "r.useVersion"
+      },
+      {
         "title": "Load All",
         "category": "R Package",
         "command": "r.loadAll"

--- a/package.json
+++ b/package.json
@@ -452,6 +452,11 @@
         "command": "r.release"
       },
       {
+        "title": "Spell check",
+        "category": "R Package",
+        "command": "r.spellCheck"
+      },
+      {
         "title": "Build",
         "category": "R Package",
         "command": "r.build"

--- a/package.json
+++ b/package.json
@@ -447,14 +447,14 @@
         "command": "r.loadAll"
       },
       {
-        "title": "Release",
-        "category": "R Package",
-        "command": "r.release"
-      },
-      {
         "title": "Spell check",
         "category": "R Package",
         "command": "r.spellCheck"
+      },
+      {
+        "title": "CRAN Release",
+        "category": "R Package",
+        "command": "r.release"
       },
       {
         "title": "Build",

--- a/package.json
+++ b/package.json
@@ -447,6 +447,11 @@
         "command": "r.useGit"
       },
       {
+        "title": "Connect a Local Repo with GitHub",
+        "category": "R Package",
+        "command": "r.useGitHub"
+      },
+      {
         "title": "Increment Package Version",
         "category": "R Package",
         "command": "r.useVersion"

--- a/package.json
+++ b/package.json
@@ -457,6 +457,11 @@
         "command": "r.spellCheck"
       },
       {
+        "title": "CRAN Checks for Package on R-Hub",
+        "category": "R Package",
+        "command": "r.checkRhub"
+      },
+      {
         "title": "CRAN Release",
         "category": "R Package",
         "command": "r.release"

--- a/package.json
+++ b/package.json
@@ -447,6 +447,11 @@
         "command": "r.useVersion"
       },
       {
+        "title": "CRAN Submission Comments",
+        "category": "R Package",
+        "command": "r.useCranComments"
+      },
+      {
         "title": "Load All",
         "category": "R Package",
         "command": "r.loadAll"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.thead': () => rTerminal.runSelectionOrWord(['t', 'head']),
         'r.names': () => rTerminal.runSelectionOrWord(['names']),
         'r.runSource': () => { void rTerminal.runSource(false); },
-        'r.runSelection':  (code?: string) => { code ? void rTerminal.runTextInTerm(code) : void rTerminal.runSelection(); },
+        'r.runSelection': (code?: string) => { code ? void rTerminal.runTextInTerm(code) : void rTerminal.runSelection(); },
         'r.runFromLineToEnd': rTerminal.runFromLineToEnd,
         'r.runFromBeginningToLine': rTerminal.runFromBeginningToLine,
         'r.runSelectionRetainCursor': rTerminal.runSelectionRetainCursor,
@@ -109,13 +109,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
         // file creation (under file submenu)
         'r.rmarkdown.newFileDraft': () => rmarkdown.newDraft(),
-        'r.newFileDocument': () => vscode.workspace.openTextDocument({language: 'r'}).then((v) => vscode.window.showTextDocument(v)),
+        'r.newFileDocument': () => vscode.workspace.openTextDocument({ language: 'r' }).then((v) => vscode.window.showTextDocument(v)),
 
         // editor independent commands
         'r.createGitignore': rGitignore.createGitignore,
         'r.createLintrConfig': lintrConfig.createLintrConfig,
         'r.generateCCppProperties': cppProperties.generateCppProperties,
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
+        'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
         'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,6 +121,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.checkRhub': () => rTerminal.runTextInTerm('devtools::check_rhub()'),
         'r.checkWinDevel': () => rTerminal.runTextInTerm('devtools::check_win_devel()'),
         'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
+        'r.useVersion': () => rTerminal.runTextInTerm('usethis::use_version()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
         'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,6 +116,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.createLintrConfig': lintrConfig.createLintrConfig,
         'r.generateCCppProperties': cppProperties.generateCppProperties,
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
+        'r.devMode': () => rTerminal.runTextInTerm('devtools::dev_mode()'),
         'r.spellCheck': () => rTerminal.runTextInTerm('devtools::spell_check()'),
         'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,6 +126,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.useNewsMd': () => rTerminal.runTextInTerm('usethis::use_news_md()'),
         'r.useGit': () => rTerminal.runTextInTerm('usethis::use_git()'),
         'r.useGitHub': () => rTerminal.runTextInTerm('usethis::use_github()'),
+        'r.pkgdownBuildSite': () => rTerminal.runTextInTerm('pkgdown::build_site()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
         'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,6 +117,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.generateCCppProperties': cppProperties.generateCppProperties,
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
         'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
+        'r.spellCheck': () => rTerminal.runTextInTerm('devtools::spell_check()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
         'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,6 +124,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.useVersion': () => rTerminal.runTextInTerm('usethis::use_version()'),
         'r.useCranComments': () => rTerminal.runTextInTerm('usethis::use_cran_comments()'),
         'r.useGit': () => rTerminal.runTextInTerm('usethis::use_git()'),
+        'r.useGitHub': () => rTerminal.runTextInTerm('usethis::use_github()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
         'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,6 +123,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
         'r.useVersion': () => rTerminal.runTextInTerm('usethis::use_version()'),
         'r.useCranComments': () => rTerminal.runTextInTerm('usethis::use_cran_comments()'),
+        'r.useNewsMd': () => rTerminal.runTextInTerm('usethis::use_news_md()'),
         'r.useGit': () => rTerminal.runTextInTerm('usethis::use_git()'),
         'r.useGitHub': () => rTerminal.runTextInTerm('usethis::use_github()'),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,6 +122,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.checkWinDevel': () => rTerminal.runTextInTerm('devtools::check_win_devel()'),
         'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
         'r.useVersion': () => rTerminal.runTextInTerm('usethis::use_version()'),
+        'r.useCranComments': () => rTerminal.runTextInTerm('usethis::use_cran_comments()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
         'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,6 +123,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
         'r.useVersion': () => rTerminal.runTextInTerm('usethis::use_version()'),
         'r.useCranComments': () => rTerminal.runTextInTerm('usethis::use_cran_comments()'),
+        'r.useGit': () => rTerminal.runTextInTerm('usethis::use_git()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
         'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,6 +119,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.devMode': () => rTerminal.runTextInTerm('devtools::dev_mode()'),
         'r.spellCheck': () => rTerminal.runTextInTerm('devtools::spell_check()'),
         'r.checkRhub': () => rTerminal.runTextInTerm('devtools::check_rhub()'),
+        'r.checkWinDevel': () => rTerminal.runTextInTerm('devtools::check_win_devel()'),
         'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,6 +118,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
         'r.devMode': () => rTerminal.runTextInTerm('devtools::dev_mode()'),
         'r.spellCheck': () => rTerminal.runTextInTerm('devtools::spell_check()'),
+        'r.checkRhub': () => rTerminal.runTextInTerm('devtools::check_rhub()'),
         'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,8 +116,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.createLintrConfig': lintrConfig.createLintrConfig,
         'r.generateCCppProperties': cppProperties.generateCppProperties,
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
-        'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
         'r.spellCheck': () => rTerminal.runTextInTerm('devtools::spell_check()'),
+        'r.release': () => rTerminal.runTextInTerm('devtools::release()'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
         'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),


### PR DESCRIPTION
# What problem did you solve?

I have added the following commands which are frequently used for R package developpment:

- [x] `devtools::dev_mode()`

- [x] `devtools::spell_check()`

- [x] `devtools::check_rhub()`

- [x] `devtools::check_win_devel()`

- [x] `devtools::release()`

- [x] `usethis::use_version()`

- [x] `usethis::use_cran_comments()`

- [x] `usethis::use_news_md()`

- [x] `usethis::use_git()`

- [x] `usethis::use_github()`

- [x] `pkgdown::build_site()`

I did not use task because these commands require interaction.

- [ ] 

## (If you have)Screenshot

N/A

## (If you do not have screenshot) How can I check this pull request?

In the command palette, use the following commands:

* r.devMode
* r.spellCheck
* r.checkRhub
* r.checkWinDevel
* r.release
* r.useVersion
* r.useCranComments
* r.useNewsMd
* r.useGit
* r.useGitHub
* r.pkgdownBuildSite