### PR TITLE
Implement help preview for local package(s)

### DIFF
--- a/html/help/00Index.ejs
+++ b/html/help/00Index.ejs
@@ -1,0 +1,42 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <title>
+        <%= packageTitle %>
+    </title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+</head>
+
+<body>
+    <div class="container">
+        <h1>
+            <%= packageTitle %>
+        </h1>
+        <hr />
+        <h2>Documentation for package &lsquo;<%= packageName %> &rsquo; version <%= packageVersion %>
+        </h2>
+
+        <ul>
+            <li><a href="../DESCRIPTION">DESCRIPTION file</a>.</li>
+        </ul>
+
+        <h2>Help Pages</h2>
+
+        <table width="100%">
+            <% topics.forEach((topic)=> { %>
+                <tr>
+                    <td style="width: 25%;"><a href="<%= topic.href %>">
+                            <%= topic.name %>
+                        </a></td>
+                    <td>
+                        <%= topic.title %>
+                    </td>
+                </tr>
+            <% }) %>
+        </table>
+    </div>
+</body>
+
+</html>

--- a/html/help/00Index.ejs
+++ b/html/help/00Index.ejs
@@ -27,12 +27,8 @@
         <table width="100%">
             <% topics.forEach((topic)=> { %>
                 <tr>
-                    <td style="width: 25%;"><a href="<%= topic.href %>">
-                            <%= topic.name %>
-                        </a></td>
-                    <td>
-                        <%= topic.title %>
-                    </td>
+                    <td style="width: 25%;"><a href="<%= topic.href %>"><%= topic.name %></a></td>
+                    <td><%= topic.title %></td>
                 </tr>
             <% }) %>
         </table>

--- a/html/help/00Index_row.ejs
+++ b/html/help/00Index_row.ejs
@@ -1,0 +1,4 @@
+<tr>
+    <td style="width: 25%;"><a href="<%= topicHref() %>"> <%= topicName() %> </a></td>
+    <td><%= topicTitle() %> </td>
+</tr>

--- a/html/help/00Index_row.ejs
+++ b/html/help/00Index_row.ejs
@@ -1,4 +1,0 @@
-<tr>
-    <td style="width: 25%;"><a href="<%= topicHref() %>"> <%= topicName() %> </a></td>
-    <td><%= topicTitle() %> </td>
-</tr>

--- a/html/help/theme.css
+++ b/html/help/theme.css
@@ -25,6 +25,26 @@ a ~ div.header {
   display: none;
 }
 
+/* Styling for preview info box */
+.previewInfo {
+  position: relative;
+  left: -20px;
+  width: calc(100% + 40px);
+  background-color: var(--vscode-list-inactiveSelectionBackground);
+  box-sizing: border-box;
+  text-align: center;
+
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  padding-left: calc(0.5em + 20px);
+  padding-right: calc(0.5em + 20px);
+  /* margin-top: 1.5em; */
+  margin-bottom: 1em;
+
+  font-family: var(--vscode-editor-font-family);
+  font-size: var(--vscode-editor-font-size);
+}
+
 /* Styling for clickable code sections */
 pre, code {
   font-family: var(--vscode-editor-font-family);
@@ -40,7 +60,7 @@ pre, code {
 .preHoverPointer .preDiv:hover {
   cursor: pointer;
 }
-.preClickable pre:hover {
+.preClickable .preCodeExample:hover {
   background-color: var(--vscode-list-hoverBackground);
 }
 

--- a/package.json
+++ b/package.json
@@ -1464,6 +1464,14 @@
           ],
           "default": "None"
         },
+        "r.helpPanel.previewLocalPackages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["."],
+          "markdownDescription": "Which local directories to try for local help pages previewer. Set to `[]` to disable."
+        },
         "r.helpPanel.rpath": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -660,6 +660,7 @@
         "command": "r.helpPanel.openExternal",
         "title": "Open in external browser",
         "category": "R Help Panel",
+        "enablement": "r.helpPanel.canOpenExternal",
         "icon": "$(link-external)"
       },
       {

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -74,8 +74,8 @@ export class HelpLinkHoverProvider implements vscode.HoverProvider {
         const token = document.getText(wordRange);
         const aliases = await globalRHelp?.getMatchingAliases(token) || [];
         const mds = aliases.map(a => {
-            const cmdText = `${a.package}::${a.name}`;
-            const args = [`/library/${a.package}/html/${a.alias}.html`];
+            const cmdText = `${a.package}::${a.alias}`;
+            const args = [`/library/${a.package}/html/${a.name}.html`];
             const encodedArgs = encodeURIComponent(JSON.stringify(args));
             const cmd = 'command:r.helpPanel.openForPath';
             const cmdUri = vscode.Uri.parse(`${cmd}?${encodedArgs}`);

--- a/src/helpViewer/helpPreviewer.ts
+++ b/src/helpViewer/helpPreviewer.ts
@@ -9,33 +9,49 @@ import { isDirSafe, isFileSafe, readFileSyncSafe, config } from '../util';
 import { Topic, TopicType } from './packages';
 
 
+// Information from the corresponding fields in DESCRIPION
 interface LocalPackageInfo {
     name?: string;
     version?: string;
     title?: string;
 }
 
-interface EjsTopic {
+// Used to create a preview of 00Index.html
+interface IndexEjsTopic {
     name: string;
     href: string;
     title: string;
 }
-interface EjsData {
+interface IndexEjsData {
     packageTitle: string;
     packageName: string;
     packageVersion: string;
-    topics: EjsTopic[];
+    topics: IndexEjsTopic[];
 }
 
+interface RdAlias {
+    // path of .Rd file
+    filepath: string;
+    // (unique) name of the topic
+    name: string;
+    // title of the topic
+    title?: string;
+    // (possibly multiple) aliases of the topic
+    aliases: string[];
+}
 
-
-export type PreviewListener = (previewer: RLocalHelpPreviewer) => void;
+interface AliasExtra extends rHelp.Alias {
+    // title of the topic
+    title?: string;
+    // filepath of the corresponding .Rd file
+    rdPath?: string;
+}
 
 export interface RHelpPreviewerOptions {
     // path of the R executable
     rPath: string;
     // listener to notify when package-files change
-    previewListener?: PreviewListener;
+    previewListener?: (previewer: RLocalHelpPreviewer) => void;
     // path to .ejs file to be used as 00Index.html in previewed packages
     indexTemplatePath: string;
 }
@@ -72,15 +88,15 @@ export class RLocalHelpPreviewer {
     private readonly manDir: string;
     private readonly rPath: string;
     private readonly indexTemplate: string;
-    private previewListener: () => void;
-    
+    private callPreviewListener: () => void;
+
     public isPackageDir: boolean = false;
     public isDisposed: boolean = false;
-    
+
     private readonly fileWatchers: fs.FSWatcher[] = [];
     private cachedRdAliases?: Map<string, RdAlias>;
     private cachedPackageInfo?: LocalPackageInfo;
-    
+
     private readonly dummyPackageName: string;
 
     constructor(options: RHelpPreviewerOptions, packageDir: string, unnamedId: number = 1){
@@ -88,14 +104,14 @@ export class RLocalHelpPreviewer {
         this.descriptionPath = path.join(this.packageDir, 'DESCRIPTION');
         this.manDir = path.join(this.packageDir, 'man');
         this.rPath = options.rPath;
-        this.previewListener = () => options.previewListener?.(this);
+        this.callPreviewListener = () => options.previewListener?.(this);
         this.isPackageDir = this.watchFiles();
-        this.dummyPackageName = `<UNNAMED_PACKAGE_${unnamedId}>`;
+        this.dummyPackageName = `UnnamedPackage${unnamedId}`;
         this.indexTemplate = fs.readFileSync(options.indexTemplatePath, 'utf-8');
     }
 
     public refresh(): void {
-        // pass
+        // nothing to do, since file watchers keep everything updated
     }
     public dispose(callListener = false): void {
         this.isPackageDir = false;
@@ -104,33 +120,37 @@ export class RLocalHelpPreviewer {
         }
         this.isDisposed = true;
         if(callListener){
-            this.previewListener();
+            this.callPreviewListener();
         }
     }
 
+    // Is only called once as part of the constructor
+    // It is expected that this instance will be disposed if this method returns false
     private watchFiles(): boolean {
-        
+        // Only watch any files, if both man dir and DESCRIPTION exist
+        if(!isFileSafe(this.descriptionPath) || !isDirSafe(this.manDir)){
+            return false;
+        }
+
+        // Prepare listeners
         const errorListener = () => {
-            console.log('Filewatcher error!');
             console.log(`Disposing previewer for pkgDir: ${this.packageDir}`);
             void this.dispose(true);
         };
-
-        const descriptionListener: fs.WatchListener<string> = (event: fs.WatchEventType, filename: string) => {
-            console.log(`Event: ${event} --- filename: ${filename}`);
+        const descriptionListener: fs.WatchListener<string> = () => {
             this.cachedPackageInfo = undefined;
-            this.previewListener();
+            this.callPreviewListener();
         };
-
         const manDirListener: fs.WatchListener<string> = (event: fs.WatchEventType, filename: string) => {
             if(this.isDisposed){
                 return;
             }
             if(!isDirSafe(this.manDir)){
                 this.dispose(true);
+                return;
             }
-            console.log(`Event: ${event} --- filename: ${filename}`);
             const fullPath = path.join(this.manDir, filename);
+            // The cache is only initialized when it is needed for the first time:
             if(this.cachedRdAliases){
                 const rdAlias = getRdAlias(fullPath);
                 if(rdAlias){
@@ -139,43 +159,21 @@ export class RLocalHelpPreviewer {
                     this.cachedRdAliases.delete(fullPath);
                 }
             }
-            this.previewListener();
+            this.callPreviewListener();
         };
 
-        if(!isFileSafe(this.descriptionPath)){
-            return false;
-        }
-        const descWatcher =fs.watch(this.descriptionPath, {encoding: 'utf-8'});
+        // Watch man dir/DESCRIPTION
+        const descWatcher = fs.watch(this.descriptionPath, {encoding: 'utf-8'});
         descWatcher.on('change', descriptionListener);
         descWatcher.on('error', errorListener);
-        descWatcher.on('close', () => console.log('Event: descFile close'));
         this.fileWatchers.push(descWatcher);
 
-        if(!isDirSafe(this.manDir)){
-            return false;
-        }
         const manDirWatcher = fs.watch(this.manDir, {encoding: 'utf-8'});
         manDirWatcher.on('change', manDirListener);
         manDirWatcher.on('error', errorListener);
-        manDirWatcher.on('close', () => console.log('Event: manDir close'));
         this.fileWatchers.push(manDirWatcher);
 
         return true;
-    }
-    
-    private getRdAliases(): Map<string, RdAlias> | undefined {
-        if(this.cachedRdAliases){
-            this.cachedRdAliases;
-        }
-        const rdAliases = getRdAliases(this.manDir);
-        if(!rdAliases){
-            return undefined;
-        }
-        this.cachedRdAliases = new Map();
-        for (const rdAlias of rdAliases) {
-            this.cachedRdAliases.set(rdAlias.filepath, rdAlias);
-        }
-        return this.cachedRdAliases;
     }
 
     public getPackageInfo(): LocalPackageInfo | undefined {
@@ -196,72 +194,44 @@ export class RLocalHelpPreviewer {
         this.cachedPackageInfo = packageInfo;
         return packageInfo;
     }
-    
+
     public getPackageName(safe?: boolean): string {
         let ret = this.getPackageInfo()?.name || this.dummyPackageName;
         if(safe){
             ret = ret.replaceAll(/[^a-zA-Z0-9.]/g, '');
-            if(ret.match(/^[0-9.]/) || ret.length < 2){
-                ret = 'XX' + ret;
-            }
-            if(ret.match(/\.$/)){
-                ret = ret + 'XX';
+            if(ret.match(/^[0-9.]/) || ret.length < 2 || ret.match(/\.$/)){
+                ret = this.dummyPackageName;
             }
         }
         return ret;
     }
-    
-    public getRdPathForTopic(topic: string): string | undefined {
-        const rdAliases = this.getRdAliases();
-        if(!rdAliases){
-            return undefined;
-        }
-        for(const [fullPath, rdAlias] of rdAliases){
-            if(rdAlias.aliases.includes(topic)){
-                return fullPath;
-            }
-        }
-        return undefined;
-    }
 
+    // Methods that imitate the HelpProvider
     public getHelpFileFromRequestPath(requestPath: string): undefined | rHelp.HelpFile {
         if(this.isDisposed){
             return undefined;
         }
-
-        console.log(`Trying path: ${requestPath}`);
         const {pkg, topic} = parseRequestPath(requestPath);
-
-        if(!pkg || !topic){
-            console.log(`Invalid path: ${requestPath}`);
-            return undefined;
-        } else if(pkg !== this.getPackageName()){
-            console.log(`Package name does not match description file: ${pkg}`);
+        if(!topic || !pkg || (pkg !== this.getPackageName() && pkg !== this.getPackageName(true))){
             return undefined;
         }
-
-        console.log(`Identified topic: ${topic}`);
         if(topic === '00Index'){
-            return this.getHelpForIndexPath(requestPath);
-        } else if(topic === 'DESCRIPTION'){
+            return this.getHelpForIndex(requestPath);
+        }
+        if(topic === 'DESCRIPTION'){
             return this.getHelpForDescription(requestPath);
-        } else{
-            return this.getHelpForTopic(topic, requestPath);
         }
+        return this.getHelpForTopic(topic, requestPath);
     }
-    
+
     private getHelpForTopic(topic: string, requestPath: string): undefined | rHelp.HelpFile {
+        // Make sure the topic has a valid .Rd file
         const rdFileName = this.getRdPathForTopic(topic);
-        if(!rdFileName){
-            console.log('No matching .Rd file found.');
-            return undefined;
-        } else if(!fs.existsSync(rdFileName)){
-            console.log(`.Rd file does not exist: ${rdFileName}`);
+        if(!rdFileName || !isFileSafe(rdFileName)){
             return undefined;
         }
-        
-        const packageInfo = this.getPackageInfo();
 
+        // Convert .Rd to HTML
         const args = [
             '--silent',
             '--slave',
@@ -272,11 +242,9 @@ export class RLocalHelpPreviewer {
             '--args',
             rdFileName,
             this.getPackageName(true),
-            packageInfo?.version || DUMMY_TOPIC_VERSION
+            this.getPackageInfo()?.version || DUMMY_TOPIC_VERSION
         ];
-        
         const spawnRet = cp.spawnSync(this.rPath, args, {encoding: 'utf-8'});
-        
         if(spawnRet.status){
             console.log(`Failed to convert .Rd file ${rdFileName} (status: ${spawnRet.status})`);
             console.log(spawnRet.stderr);
@@ -284,6 +252,7 @@ export class RLocalHelpPreviewer {
             return undefined;
         }
 
+        // Prepare HelpFile
         const helpFile: rHelp.HelpFile = {
             html: spawnRet.stdout,
             requestPath: requestPath,
@@ -292,33 +261,110 @@ export class RLocalHelpPreviewer {
             packageDir: this.packageDir
         };
 
+        // Add path of .R containing Roxygen documentation
         const rdTxt = fs.readFileSync(rdFileName, 'utf-8').replaceAll(/\r/g, '');
         const rFileMatch = rdTxt.match(/^% Please edit documentation in (.*\.R)$/m);
         if(rFileMatch){
             helpFile.rPath = path.join(this.packageDir, rFileMatch?.[1]);
         }
-        
         return helpFile;
     }
 
-    public getAliases(): AliasExtra[] | undefined {
-        const rdAliases = this.getRdAliases()?.values();
-        if(!rdAliases){
+    private getRdPathForTopic(topic: string): string | undefined {
+        const rdAliases = this.getRdAliases();
+        for(const [fullPath, rdAlias] of rdAliases){
+            if(rdAlias.aliases.includes(topic)){
+                return fullPath;
+            }
+        }
+        return undefined;
+    }
+
+    private getHelpForDescription(requestPath: string): rHelp.HelpFile | undefined {
+        const desc = readFileSyncSafe(this.descriptionPath);
+        if(!desc){
             return undefined;
         }
+        // might need to be handled differently if the handling in index.ts changes:
+        const helpFile: rHelp.HelpFile = {
+            html: desc,
+            requestPath: requestPath,
+            isPreview: true,
+            rdPath: this.descriptionPath,
+            packageDir: this.packageDir
+        };
+        return helpFile;
+    }
+
+    private getHelpForIndex(requestPath: string): rHelp.HelpFile | undefined {
+        const html = this.makeIndexHtml();
+        if(!html){
+            return undefined;
+        }
+        const helpFile: rHelp.HelpFile = {
+            html: html,
+            requestPath: requestPath,
+            isPreview: true,
+            isIndex: true,
+            rdPath: undefined,
+            packageDir: this.packageDir
+        };
+
+        return helpFile;
+    }
+
+    private makeIndexHtml(): string | undefined {
+        const pkgInfo = this.getPackageInfo();
+        if(!pkgInfo){
+            return undefined;
+        }
+        const aliases = this.getAliases();
+        const topics = aliases.map(alias => ({
+            name: alias.name,
+            title: alias.title || DUMMY_TOPIC_TITLE,
+            href: `${alias.name}.html`
+        }));
+        const ejsData: IndexEjsData = {
+            packageName: pkgInfo.name || this.dummyPackageName,
+            packageTitle: pkgInfo.title || DUMMY_PACKAGE_TITLE,
+            packageVersion: pkgInfo.version || DUMMY_TOPIC_VERSION,
+            topics: topics
+        };
+        const html = ejs.render(this.indexTemplate, ejsData);
+        return html;
+    }
+
+    // Method that imitates the AliasProvider
+    public getAliases(): AliasExtra[]  {
+        const rdAliases = this.getRdAliases().values();
         const pkgName = this.getPackageName();
         const aliases = [...rdAliases].flatMap(rdAlias => rdAliasToAliases(rdAlias, pkgName));
         return aliases;
     }
 
+    private getRdAliases(): Map<string, RdAlias> {
+        // Return cache if exists (is updated by file watchers)
+        if(this.cachedRdAliases){
+            return this.cachedRdAliases;
+        }
+        // Else, initialize and populate cache
+        const rdAliases = getRdAliases(this.manDir);
+        this.cachedRdAliases = new Map();
+        for (const rdAlias of rdAliases) {
+            this.cachedRdAliases.set(rdAlias.filepath, rdAlias);
+        }
+        return this.cachedRdAliases;
+    }
+
+    // Method that imitates the PackageManager
     public getTreeViewTopics(summarize: boolean = false): Topic[] {
-        const pkgName = this.getPackageName();
+        const pkgName = this.getPackageName(true);
         let topics: Topic[];
         if(summarize){
-            const rdAliases = getRdAliases(this.manDir) || [];
+            const rdAliases = getRdAliases(this.manDir);
             topics = rdAliases.map(rdAlias => rdAliasToTreeViewTopic(rdAlias, pkgName));
         } else{
-            const aliases = this.getAliases() || [];
+            const aliases = this.getAliases();
             topics = aliases.map(alias => {
                 const helpPath = `/library/${pkgName}/html/${alias.alias}.html`;
                 const topic: Topic = {
@@ -347,62 +393,15 @@ export class RLocalHelpPreviewer {
         topics.unshift(indexTopic, descriptionTopic);
         return topics;
     }
-    
-    private getHelpForDescription(requestPath: string): rHelp.HelpFile | undefined {
-        const desc = readFileSyncSafe(this.descriptionPath);
-        if(!desc){
-            return undefined;
-        }
-        const helpFile: rHelp.HelpFile = {
-            html: desc,
-            requestPath: requestPath,
-            isPreview: true,
-            rdPath: this.descriptionPath, // might need to be handled separately if info-text changes
-            packageDir: this.packageDir
-        };
-        return helpFile;
-    }
-    
-    private getHelpForIndexPath(requestPath: string): rHelp.HelpFile | undefined {
-        const html = this.makeIndexHtml();
-        if(!html){
-            return undefined;
-        }
 
-        const helpFile: rHelp.HelpFile = {
-            html: html,
-            requestPath: requestPath,
-            isPreview: true,
-            isIndex: true,
-            rdPath: undefined,
-            packageDir: this.packageDir
-        };
-
-        return helpFile;
-    }
-    
-    private makeIndexHtml(): string | undefined {
-        const pkgInfo = this.getPackageInfo();
-        if(!pkgInfo){
-            return undefined;
-        }
-        const aliases = this.getAliases() || [];
-        const topics = aliases.map(alias => ({
-            name: alias.name,
-            title: alias.title || DUMMY_TOPIC_TITLE,
-            href: `${alias.name}.html`
-        }));
-        const ejsData: EjsData = {
-            packageName: pkgInfo.name || this.dummyPackageName,
-            packageTitle: pkgInfo.title || DUMMY_PACKAGE_TITLE,
-            packageVersion: pkgInfo.version || DUMMY_TOPIC_VERSION,
-            topics: topics
-        };
-        const html = ejs.render(this.indexTemplate, ejsData);
-        return html;
-    }
 }
 
+// Helper function to parse a request path
+// Accepts e.g. paths of the forms
+// - library/PKG/html/TOPIC
+// - library/PKG/help/TOPIC
+// - library/PKG/help/TOPIC.html/....
+// - library/PKG/TOPIC
 function parseRequestPath(requestPath: string): {
     pkg?: string,
     topic?: string
@@ -415,28 +414,20 @@ function parseRequestPath(requestPath: string): {
     };
 }
 
-interface RdAlias {
-    filepath: string;
-    name: string;
-    title?: string;
-    aliases: string[];
-}
-
-interface AliasExtra extends rHelp.Alias {
-    title?: string;
-    rdPath?: string;
-}
-
+// Convert a single rdAlias to a (summarized) tree view topic entry
 function rdAliasToTreeViewTopic(rdAlias: RdAlias, pkgName: string): Topic {
     const ret: Topic = {
         helpPath: `/library/${pkgName}/html/${rdAlias.name}.html`,
         name: rdAlias.title || rdAlias.name || DUMMY_TOPIC_TITLE,
         type: TopicType.NORMAL,
-        aliases: rdAlias.aliases || [],
+        aliases: rdAlias.aliases,
         description: rdAlias.title || DUMMY_TOPIC_TITLE
     };
     return ret;
 }
+
+
+// Helper functions to read/convert rdAliases and aliases
 
 function rdAliasToAliases(rdAlias: RdAlias, pkgName: string): AliasExtra[] {
     return rdAlias.aliases.map(alias => ({
@@ -450,9 +441,11 @@ function rdAliasToAliases(rdAlias: RdAlias, pkgName: string): AliasExtra[] {
 
 function getRdAliases(manDir: string): RdAlias[] {
     const manFiles = fs.readdirSync(manDir) || [];
-    const rdFiles = manFiles.filter(fn => fn.match(/\.[Rr][Dd]$/));
     const aliases: RdAlias[] = [];
-    rdFiles.forEach(filename => {
+    manFiles.forEach(filename => {
+        if(!filename.match(/\.[Rr][Dd]$/)){
+            return;
+        }
         const fullPath = path.join(manDir, filename);
         const rdAlias = getRdAlias(fullPath);
         if(rdAlias){

--- a/src/helpViewer/helpPreviewer.ts
+++ b/src/helpViewer/helpPreviewer.ts
@@ -243,6 +243,8 @@ export class RLocalHelpPreviewer {
         console.log(`Identified topic: ${topic}`);
         if(topic === '00Index'){
             return this.getHelpForIndexPath(requestPath);
+        } else if(topic === 'DESCRIPTION'){
+            return this.getHelpForDescription(requestPath);
         } else{
             return this.getHelpForTopic(topic, requestPath);
         }
@@ -328,14 +330,37 @@ export class RLocalHelpPreviewer {
                 return topic;
             });
         }
+
+        const descriptionTopic: Topic = {
+            name: 'DESCRIPTION',
+            description: '',
+            helpPath: `/library/${pkgName}/DESCRIPTION`,
+            type: TopicType.META
+        };
+
         const indexTopic: Topic = {
             name: 'Index',
             description: '',
             helpPath: `/library/${pkgName}/html/00Index.html`,
             type: TopicType.INDEX
         };
-        topics.unshift(indexTopic);
+        topics.unshift(indexTopic, descriptionTopic);
         return topics;
+    }
+    
+    private getHelpForDescription(requestPath: string): rHelp.HelpFile | undefined {
+        const desc = readFileSyncSafe(this.descriptionPath);
+        if(!desc){
+            return undefined;
+        }
+        const helpFile: rHelp.HelpFile = {
+            html: desc,
+            requestPath: requestPath,
+            isPreview: true,
+            rdPath: this.descriptionPath, // might need to be handled separately if info-text changes
+            packageDir: this.packageDir
+        };
+        return helpFile;
     }
     
     private getHelpForIndexPath(requestPath: string): rHelp.HelpFile | undefined {
@@ -382,7 +407,7 @@ function parseRequestPath(requestPath: string): {
     pkg?: string,
     topic?: string
 } {
-    const re = /^\/?library\/([^/]*)\/(?:html|help)\/([^/]*?)(?:\.html.*)?$/;
+    const re = /^\/?library\/([^/]*)\/(?:html|help)?\/?([^/]*?)(?:\.html.*)?$/;
     const m = re.exec(requestPath);
     return {
         pkg: m?.[1],

--- a/src/helpViewer/helpPreviewer.ts
+++ b/src/helpViewer/helpPreviewer.ts
@@ -265,7 +265,8 @@ export class RLocalHelpPreviewer {
         const rdTxt = fs.readFileSync(rdFileName, 'utf-8').replaceAll(/\r/g, '');
         const rFileMatch = rdTxt.match(/^% Please edit documentation in (.*\.R)$/m);
         if(rFileMatch){
-            helpFile.rPath = path.join(this.packageDir, rFileMatch?.[1]);
+            const localRPaths = rFileMatch?.[1].split(',').map(s => s.trim());
+            helpFile.rPaths = localRPaths.map(p => path.join(this.packageDir, p));
         }
         return helpFile;
     }

--- a/src/helpViewer/helpPreviewer.ts
+++ b/src/helpViewer/helpPreviewer.ts
@@ -318,7 +318,7 @@ export class RLocalHelpPreviewer {
         }
         const aliases = this.getAliases();
         const topics = aliases.map(alias => ({
-            name: alias.name,
+            name: alias.alias,
             title: alias.title || DUMMY_TOPIC_TITLE,
             href: `${alias.name}.html`
         }));

--- a/src/helpViewer/helpPreviewer.ts
+++ b/src/helpViewer/helpPreviewer.ts
@@ -263,7 +263,7 @@ export class RLocalHelpPreviewer {
 
         // Add path of .R containing Roxygen documentation
         const rdTxt = fs.readFileSync(rdFileName, 'utf-8').replaceAll(/\r/g, '');
-        const rFileMatch = rdTxt.match(/^% Please edit documentation in (.*\.R)$/m);
+        const rFileMatch = rdTxt.match(/^% Please edit documentation in (.*)$/m);
         if(rFileMatch){
             const localRPaths = rFileMatch?.[1].split(',').map(s => s.trim());
             helpFile.rPaths = localRPaths.map(p => path.join(this.packageDir, p));

--- a/src/helpViewer/helpPreviewer.ts
+++ b/src/helpViewer/helpPreviewer.ts
@@ -1,0 +1,373 @@
+
+import * as cp from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+import * as rHelp from './index';
+import { isDirSafe, isFileSafe, readFileSyncSafe, config } from '../util';
+import { Topic, TopicType } from './packages';
+
+
+interface LocalPackageInfo {
+    name?: string;
+    version?: string;
+    title?: string;
+}
+
+
+export type PreviewListener = (previewer: RLocalHelpPreviewer) => void;
+
+export interface RHelpPreviewerOptions {
+    // path of the R executable
+    rPath: string;
+    // listener to notify when package-files change
+    previewListener?: PreviewListener;
+}
+
+export function makePreviewerList(options: RHelpPreviewerOptions): RLocalHelpPreviewer[] {
+    const subDirs = config().get<string[]>('helpPanel.previewLocalPackages', []);
+    const workspaces = vscode.workspace.workspaceFolders || [];
+    const ret: RLocalHelpPreviewer[] = [];
+    let previewCounter = 1;
+    for (const workspace of workspaces) {
+        for(const subDir of subDirs){
+            const dir = vscode.Uri.joinPath(workspace.uri, subDir);
+            const dirPath = dir.fsPath;
+            const tmpPreviewer = new RLocalHelpPreviewer(options, dirPath, previewCounter);
+            if(tmpPreviewer.isPackageDir){
+                ret.push(tmpPreviewer);
+                previewCounter = previewCounter + 1;
+            } else{
+                tmpPreviewer.dispose();
+            }
+        }
+    }
+    return ret;
+}
+
+const DUMMY_TOPIC_TITLE = '<UNNAMED TOPIC>';
+
+export class RLocalHelpPreviewer {
+
+    public readonly packageDir: string;
+    private readonly descriptionPath: string;
+    private readonly manDir: string;
+    private readonly rPath: string;
+    private previewListener: () => void;
+    
+    public isPackageDir: boolean = false;
+    public isDisposed: boolean = false;
+    
+    private readonly fileWatchers: fs.FSWatcher[] = [];
+    private cachedRdAliases?: Map<string, RdAlias>;
+    private cachedPackageInfo?: LocalPackageInfo;
+    
+    private readonly dummyPackageName: string;
+
+    constructor(options: RHelpPreviewerOptions, packageDir: string, unnamedId: number = 1){
+        this.packageDir = packageDir;
+        this.descriptionPath = path.join(this.packageDir, 'DESCRIPTION');
+        this.manDir = path.join(this.packageDir, 'man');
+        this.rPath = options.rPath;
+        this.previewListener = () => options.previewListener?.(this);
+        this.isPackageDir = this.watchFiles();
+        this.dummyPackageName = `<UNNAMED_PACKAGE_${unnamedId}>`;
+    }
+
+    public refresh(): void {
+        // pass
+    }
+    public dispose(callListener = false): void {
+        this.isPackageDir = false;
+        while(this.fileWatchers.length){
+            this.fileWatchers.pop()?.close();
+        }
+        this.isDisposed = true;
+        if(callListener){
+            this.previewListener();
+        }
+    }
+
+    private watchFiles(): boolean {
+        
+        const errorListener = () => {
+            console.log('Filewatcher error!');
+            console.log(`Disposing previewer for pkgDir: ${this.packageDir}`);
+            void this.dispose(true);
+        };
+
+        const descriptionListener: fs.WatchListener<string> = (event: fs.WatchEventType, filename: string) => {
+            console.log(`Event: ${event} --- filename: ${filename}`);
+            this.cachedPackageInfo = undefined;
+            this.previewListener();
+        };
+
+        const manDirListener: fs.WatchListener<string> = (event: fs.WatchEventType, filename: string) => {
+            if(this.isDisposed){
+                return;
+            }
+            if(!isDirSafe(this.manDir)){
+                this.dispose(true);
+            }
+            console.log(`Event: ${event} --- filename: ${filename}`);
+            const fullPath = path.join(this.manDir, filename);
+            if(this.cachedRdAliases){
+                const rdAlias = getRdAlias(fullPath);
+                if(rdAlias){
+                    this.cachedRdAliases.set(fullPath, rdAlias);
+                } else{
+                    this.cachedRdAliases.delete(fullPath);
+                }
+            }
+            this.previewListener();
+        };
+
+        if(!isFileSafe(this.descriptionPath)){
+            return false;
+        }
+        const descWatcher =fs.watch(this.descriptionPath, {encoding: 'utf-8'});
+        descWatcher.on('change', descriptionListener);
+        descWatcher.on('error', errorListener);
+        descWatcher.on('close', () => console.log('Event: descFile close'));
+        this.fileWatchers.push(descWatcher);
+
+        if(!isDirSafe(this.manDir)){
+            return false;
+        }
+        const manDirWatcher = fs.watch(this.manDir, {encoding: 'utf-8'});
+        manDirWatcher.on('change', manDirListener);
+        manDirWatcher.on('error', errorListener);
+        manDirWatcher.on('close', () => console.log('Event: manDir close'));
+        this.fileWatchers.push(manDirWatcher);
+
+        return true;
+    }
+    
+    private getRdAliases(): Map<string, RdAlias> | undefined {
+        if(this.cachedRdAliases){
+            this.cachedRdAliases;
+        }
+        const rdAliases = getRdAliases(this.manDir);
+        if(!rdAliases){
+            return undefined;
+        }
+        this.cachedRdAliases = new Map();
+        for (const rdAlias of rdAliases) {
+            this.cachedRdAliases.set(rdAlias.filepath, rdAlias);
+        }
+        return this.cachedRdAliases;
+    }
+
+    public getPackageInfo(): LocalPackageInfo | undefined {
+        if(this.cachedPackageInfo){
+            return this.cachedPackageInfo;
+        }
+        const desc = readFileSyncSafe(this.descriptionPath, 'utf-8');
+        if(!desc){
+            return undefined;
+        }
+        const packageInfo: LocalPackageInfo = {};
+        const nameMatch = /^Package:\s*(.*?)\s*$/m.exec(desc);
+        packageInfo.name = nameMatch?.[1];
+        const versionMatch = /^Version:\s*(.*?)\s*$/m.exec(desc);
+        packageInfo.version = versionMatch?.[1];
+        const titleMatch = /^Title:\s*(.*?)\s*$/m.exec(desc);
+        packageInfo.title = titleMatch?.[1];
+        this.cachedPackageInfo = packageInfo;
+        return packageInfo;
+    }
+    
+    public getPackageName(): string {
+        return this.getPackageInfo()?.name || this.dummyPackageName;
+    }
+    
+    public getRdPathForTopic(topic: string): string | undefined {
+        const rdAliases = this.getRdAliases();
+        if(!rdAliases){
+            return undefined;
+        }
+        for(const [fullPath, rdAlias] of rdAliases){
+            if(rdAlias.aliases.includes(topic)){
+                return fullPath;
+            }
+        }
+        return undefined;
+    }
+
+    public getHelpFileFromRequestPath(requestPath: string): undefined | rHelp.HelpFile {
+        if(this.isDisposed){
+            return undefined;
+        }
+
+        console.log(`Trying path: ${requestPath}`);
+
+        const re = /^\/?library\/([^/]*)\/(?:html|help)\/([^/]*?)(?:\.html.*)?$/;
+        const m = re.exec(requestPath);
+        const pkg = m?.[1];
+        const topic = m?.[2].replace(/^dot-/, '.');
+
+        const packageInfo = this.getPackageInfo();
+
+        if(!pkg || !topic){
+            console.log(`Invalid path: ${requestPath}`);
+            return undefined;
+        } else if(pkg !== packageInfo?.name){
+            console.log(`Package name does not match description file: ${pkg}`);
+            return undefined;
+        }
+
+        console.log(`Identified topic: ${topic}`);
+        const rdFileName = this.getRdPathForTopic(topic);
+        if(!rdFileName){
+            console.log('No matching .Rd file found.');
+            return undefined;
+        } else if(!fs.existsSync(rdFileName)){
+            console.log(`.Rd file does not exist: ${rdFileName}`);
+            return undefined;
+        }
+
+        const args = [
+            '--silent',
+            '--slave',
+            '--no-save',
+            '--no-restore',
+            '-e',
+            'tools::Rd2HTML(base::commandArgs(TRUE)[1],package=base::commandArgs(TRUE)[2:3],dynamic=TRUE)',
+            '--args',
+            rdFileName,
+            packageInfo.name || '',
+            packageInfo.version || ''
+        ];
+        
+        const spawnRet = cp.spawnSync(this.rPath, args, {encoding: 'utf-8'});
+        
+        if(spawnRet.status){
+            console.log(`Failed to convert .Rd file ${rdFileName} (status: ${spawnRet.status})`);
+            console.log(spawnRet.stderr);
+            console.log(spawnRet.error);
+            return undefined;
+        }
+
+        const helpFile: rHelp.HelpFile = {
+            html: spawnRet.stdout,
+            requestPath: requestPath,
+            isPreview: true,
+            rdPath: rdFileName,
+            packageDir: this.packageDir
+        };
+
+        const rdTxt = fs.readFileSync(rdFileName, 'utf-8').replaceAll(/\r/g, '');
+        const rFileMatch = rdTxt.match(/^% Please edit documentation in (.*\.R)$/m);
+        if(rFileMatch){
+            helpFile.rPath = path.join(this.packageDir, rFileMatch?.[1]);
+        }
+
+        fs.writeFileSync(path.join(this.packageDir, 'test.html'), helpFile.html);
+
+        return helpFile;
+    }
+
+    public getAliases(): AliasExtra[] | undefined {
+        const rdAliases = this.getRdAliases()?.values();
+        if(!rdAliases){
+            return undefined;
+        }
+        const pkgName = this.getPackageName();
+        const aliases = [...rdAliases].flatMap(rdAlias => rdAliasToAliases(rdAlias, pkgName));
+        return aliases;
+    }
+
+    public getTreeViewTopics(summarize: boolean = false): Topic[] {
+        const pkgName = this.getPackageName();
+        let topics: Topic[];
+        if(summarize){
+            const rdAliases = getRdAliases(this.manDir) || [];
+            topics = rdAliases.map(rdAlias => rdAliasToTreeViewTopic(rdAlias, pkgName));
+        } else{
+            const aliases = this.getAliases() || [];
+            topics = aliases.map(alias => {
+                const helpPath = `/library/${pkgName}/html/${alias.alias}.html`;
+                const topic: Topic = {
+                    name: alias.alias,
+                    description: alias.title || DUMMY_TOPIC_TITLE,
+                    type: TopicType.NORMAL,
+                    helpPath: helpPath
+                };
+                return topic;
+            });
+        }
+        return topics;
+    }
+}
+
+
+interface RdAlias {
+    filepath: string;
+    name: string;
+    title?: string;
+    aliases: string[];
+}
+
+interface AliasExtra extends rHelp.Alias {
+    title?: string;
+    rdPath?: string;
+}
+
+function rdAliasToTreeViewTopic(rdAlias: RdAlias, pkgName: string): Topic {
+    const ret: Topic = {
+        helpPath: `/library/${pkgName}/html/${rdAlias.name}.html`,
+        name: rdAlias.title || rdAlias.name || DUMMY_TOPIC_TITLE,
+        type: TopicType.NORMAL,
+        aliases: rdAlias.aliases || [],
+        description: rdAlias.title || DUMMY_TOPIC_TITLE
+    };
+    return ret;
+}
+
+function rdAliasToAliases(rdAlias: RdAlias, pkgName: string): AliasExtra[] {
+    return rdAlias.aliases.map(alias => ({
+        package: pkgName,
+        name: rdAlias.name,
+        alias: alias,
+        title: rdAlias.title,
+        rdPath: rdAlias.filepath
+    }));
+}
+
+function getRdAliases(manDir: string): RdAlias[] {
+    const manFiles = fs.readdirSync(manDir) || [];
+    const rdFiles = manFiles.filter(fn => fn.match(/\.[Rr][Dd]$/));
+    const aliases: RdAlias[] = [];
+    rdFiles.forEach(filename => {
+        const fullPath = path.join(manDir, filename);
+        const rdAlias = getRdAlias(fullPath);
+        if(rdAlias){
+            aliases.push(rdAlias);
+        }
+    });
+    return aliases;
+}
+
+function getRdAlias(rdFile: string): RdAlias | undefined {
+    const txt = readFileSyncSafe(rdFile, 'utf-8');
+    if(!txt){
+        return undefined;
+    }
+    const nameMatch = txt.match(/\\name\{(.*)\}/);
+    const name = nameMatch?.[1];
+    if(!name){
+        return undefined;
+    }
+    const ret: RdAlias = {
+        filepath: rdFile,
+        name: name,
+        aliases: []
+    };
+    const titleMatch = txt.match(/\\title\{(.*)\}/);
+    ret.title = titleMatch?.[1];
+    const aliasMatches = txt.matchAll(/\\alias\{(.*)\}/g);
+    for (const m of aliasMatches) {
+        ret.aliases.push(m[1]);
+    }
+    return ret;
+}

--- a/src/helpViewer/helpPreviewer.ts
+++ b/src/helpViewer/helpPreviewer.ts
@@ -262,8 +262,6 @@ export class RLocalHelpPreviewer {
             helpFile.rPath = path.join(this.packageDir, rFileMatch?.[1]);
         }
 
-        fs.writeFileSync(path.join(this.packageDir, 'test.html'), helpFile.html);
-
         return helpFile;
     }
 

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -125,9 +125,12 @@ export class HelpProvider {
         }
         const html = await rep.text();
 
+        // read "corrected" request path, that was forwarded to
+        const requestPath1 = rep.url.replace(/^http:\/\/localhost:[0-9]*\//, '');
+
         // return help file
         const ret: rHelp.HelpFile = {
-            requestPath: requestPath,
+            requestPath: requestPath1,
             html: html,
             isRealFile: false,
             url: url

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -1,5 +1,5 @@
 import { Memento, window } from 'vscode';
-import * as http from 'http';
+import * as nodeFetch from 'node-fetch';
 import * as cp from 'child_process';
 
 import * as rHelp from '.';
@@ -114,53 +114,16 @@ export class HelpProvider {
 
         // remove leading '/'
         while(requestPath.startsWith('/')){
-            requestPath = requestPath.substr(1);
-        }
-
-        interface HtmlResult {
-            content?: string,
-            redirect?: string
+            requestPath = requestPath.slice(1);
         }
 
         // forward request to R instance
-        // below is just a complicated way of getting a http response from the help server
-        let url = `http://localhost:${port}/${requestPath}`;
-        let html = '';
-        const maxForwards = 3;
-        for (let index = 0; index < maxForwards; index++) {
-            const htmlPromise = new Promise<HtmlResult>((resolve, reject) => {
-                let content = '';
-                http.get(url, (res: http.IncomingMessage) => {
-                    if(res.statusCode === 302){
-                        resolve({redirect: res.headers.location});
-                    } else{
-                        res.on('data', (chunk) => {
-                            try{
-                                // eslint-disable-next-line
-                                content += chunk.toString();
-                            } catch(e){
-                                reject();
-                            }
-                        });
-                        res.on('close', () => {
-                            resolve({content: content});
-                        });
-                        res.on('error', () => {
-                            reject();
-                        });
-                    }
-                });
-            });
-            const htmlResult = await htmlPromise;
-            if(htmlResult.redirect){
-                const newUrl = new URL(htmlResult.redirect, url);
-                requestPath = newUrl.pathname;
-                url = newUrl.toString();
-            } else{
-                html = htmlResult.content || '';
-                break;
-            }
+        const url = `http://localhost:${port}/${requestPath}`;
+        const rep = await nodeFetch.default(url);
+        if(rep.status !== 200){
+            return undefined;
         }
+        const html = await rep.text();
 
         // return help file
         const ret: rHelp.HelpFile = {
@@ -171,7 +134,6 @@ export class HelpProvider {
         };
         return ret;
     }
-
 
     dispose(): void {
         this.cp.dispose();
@@ -261,8 +223,8 @@ export class AliasProvider {
             const pkgAliases = allPackageAliases[pkg].aliases || {};
             for(const fncName in pkgAliases){
                 allAliases.push({
-                    name: fncName,
-                    alias: pkgAliases[fncName],
+                    name: pkgAliases[fncName],
+                    alias: fncName,
                     package: pkgName
                 });
             }

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -672,8 +672,9 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
     helpFile.html0 = helpFile.html;
 
     // Make sure the helpfile content is actually html
-    const re = new RegExp('<html[^\\n]*>.*</html>', 'ms');
-    helpFile.isHtml = !!re.exec(helpFile.html);
+    const re = /^<!DOCTYPE html/;
+    const re2 = new RegExp('<html[^\\n]*>.*</html>', 'ms');
+    helpFile.isHtml = (!!re.exec(helpFile.html) || !!re2.exec(helpFile.html));
     if (!helpFile.isHtml) {
         const html = escapeHtml(helpFile.html);
         helpFile.html = `<html><head></head><body><pre>${html}</pre></body></html>`;

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -728,7 +728,7 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
     if(helpFile.isPreview){
         let rdInfo: string;
         if(helpFile.isIndex){
-            rdInfo = 'local .Rd files';
+            rdInfo = 'local .Rd files. Might containt non-exported entries that will not be present in the installed Index';
         } else if(helpFile.rdPath && isFileSafe(helpFile.rdPath)){
             const localRdPath = vscode.workspace.asRelativePath(helpFile.rdPath);
             const rdUri = vscode.Uri.file(helpFile.rdPath);

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -121,6 +121,17 @@ export async function initializeHelp(
                     }
                 },
             ),
+            vscode.commands.registerCommand(
+                'r.helpPanel.openFileByPath',
+                async (filepath: string, warn?: boolean) => {
+                    if(isFileSafe(filepath)){
+                        const uri = vscode.Uri.file(filepath);
+                        await vscode.window.showTextDocument(uri);
+                    } else if(warn){
+                        await vscode.window.showWarningMessage(`The file does not exist: ${filepath}`);
+                    }
+                }
+            )
         );
 
         vscode.window.registerWebviewPanelSerializer('rhelp', rHelp);
@@ -710,7 +721,7 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
         if(helpFile.rdPath && isFileSafe(helpFile.rdPath)){
             const localRdPath = vscode.workspace.asRelativePath(helpFile.rdPath);
             const rdUri = vscode.Uri.file(helpFile.rdPath);
-            const cmdUri = makeWebviewCommandUriString('vscode.open', rdUri);
+            const cmdUri = makeWebviewCommandUriString('r.helpPanel.openFileByPath', rdUri.fsPath, true);
             rdInfo = `<a href="${cmdUri}" title="Open File">${localRdPath}</a>`;
         } else{
             rdInfo = `an .Rd file`;
@@ -720,7 +731,7 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
             let rHref: string;
             if(isFileSafe(helpFile.rPath)){
                 const rUri = vscode.Uri.file(helpFile.rPath);
-                const cmdUri = makeWebviewCommandUriString('vscode.open', rUri);
+                const cmdUri = makeWebviewCommandUriString('r.helpPanel.openFileByPath', rUri.fsPath, true);
                 rHref = `<a href="${cmdUri}" title="Open File">${localRPath}</a>`;
             } else{
                 rHref = localRPath;

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -16,6 +16,7 @@ import {
     escapeHtml,
     makeWebviewCommandUriString,
     uniqueEntries,
+    isFileSafe,
 } from '../util';
 import {HelpPanel} from './panel';
 import {HelpProvider, AliasProvider} from './helpProvider';
@@ -706,7 +707,7 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
     // Highlight help preview:
     if(helpFile.isPreview){
         let rdInfo: string;
-        if(helpFile.rdPath){
+        if(helpFile.rdPath && isFileSafe(helpFile.rdPath)){
             const localRdPath = vscode.workspace.asRelativePath(helpFile.rdPath);
             const rdUri = vscode.Uri.file(helpFile.rdPath);
             const cmdUri = makeWebviewCommandUriString('vscode.open', rdUri);
@@ -716,9 +717,14 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
         }
         if(helpFile.rPath){
             const localRPath = vscode.workspace.asRelativePath(helpFile.rPath);
-            const rUri = vscode.Uri.file(helpFile.rPath);
-            const cmdUri = makeWebviewCommandUriString('vscode.open', rUri);
-            const rHref = `<a href="${cmdUri}" title="Open File">${localRPath}</a>`;
+            let rHref: string;
+            if(isFileSafe(helpFile.rPath)){
+                const rUri = vscode.Uri.file(helpFile.rPath);
+                const cmdUri = makeWebviewCommandUriString('vscode.open', rUri);
+                rHref = `<a href="${cmdUri}" title="Open File">${localRPath}</a>`;
+            } else{
+                rHref = localRPath;
+            }
             rdInfo += `, based on Roxygen comments in ${rHref}`;
         }
         const infoBlock = `<div class="previewInfo"> Preview generated from ${rdInfo}. </div>`;

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -169,7 +169,7 @@ export interface HelpFile {
     // the .Rd file that this is based on (if it is a preview)
     rdPath?: string;
     // if available, the .R file from which the documentation is generated
-    rPath?: string;
+    rPaths?: string[];
     // if available, the directory of the previewed R package
     packageDir?: string;
 }
@@ -737,17 +737,18 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
         } else{
             rdInfo = `a local file`;
         }
-        if(helpFile.rPath){
-            const localRPath = vscode.workspace.asRelativePath(helpFile.rPath);
-            let rHref: string;
-            if(isFileSafe(helpFile.rPath)){
-                const rUri = vscode.Uri.file(helpFile.rPath);
-                const cmdUri = makeWebviewCommandUriString('r.helpPanel.openFileByPath', rUri.fsPath, true);
-                rHref = `<a href="${cmdUri}" title="Open File">${localRPath}</a>`;
-            } else{
-                rHref = localRPath;
-            }
-            rdInfo += `, based on Roxygen comments in ${rHref}`;
+        if(helpFile.rPaths?.length){
+            const rHrefs = helpFile.rPaths.map(rPath => {
+                const localRPath = vscode.workspace.asRelativePath(rPath);
+                if(isFileSafe(rPath)){
+                    const rUri = vscode.Uri.file(rPath);
+                    const cmdUri = makeWebviewCommandUriString('r.helpPanel.openFileByPath', rUri.fsPath, true);
+                    return `<a href="${cmdUri}" title="Open File">${localRPath}</a>`;
+                } else{
+                    return localRPath;
+                }
+            });
+            rdInfo += `, based on Roxygen comments in ${rHrefs.join(', ')}`;
         }
         const infoBlock = `<div class="previewInfo"> Preview generated from ${rdInfo}. </div>`;
         $('body').prepend(infoBlock);

--- a/src/helpViewer/packages.ts
+++ b/src/helpViewer/packages.ts
@@ -33,12 +33,12 @@ export enum TopicType {
 export interface Topic {
     name: string;
     description: string;
-    pkgName: string;
-    href?: string;
-    helpPath: string;
     type: TopicType;
     aliases?: string[];
-    isGrouped?: boolean;
+    helpPath: string;
+}
+interface TopicExtra extends Topic {
+    href: string;
 }
 
 
@@ -275,7 +275,7 @@ export class PackageManager {
 
     // parses a package's index file to produce a list of help topics
     // highlights ths 'home' topic and adds entries for the package index and DESCRIPTION file
-    public async getTopics(pkgName: string, summarize: boolean = false, skipMeta: boolean = false): Promise<Topic[] | undefined> {
+    public async getTopics(pkgName: string, summarize: boolean = false): Promise<Topic[] | undefined> {
 
         const indexEntries = await this.getParsedIndexFile(`/library/${pkgName}/html/00Index.html`);
 
@@ -283,9 +283,8 @@ export class PackageManager {
             return undefined;
         }
 
-        const topics: Topic[] = indexEntries.map(v => {
-            const topic: Topic & {href: string} = {
-                pkgName: pkgName,
+        const topics: TopicExtra[] = indexEntries.map(v => {
+            const topic: TopicExtra = {
                 name: v.name,
                 description: v.description,
                 href: v.href || v.name,
@@ -293,45 +292,41 @@ export class PackageManager {
                 helpPath: '' // replaced below
             };
 
-            topic.type = (topic.name === `${topic.pkgName}-package` ? TopicType.HOME : TopicType.NORMAL);
+            topic.type = (topic.name === `${pkgName}-package` ? TopicType.HOME : TopicType.NORMAL);
 
             topic.helpPath = (
-                topic.pkgName === 'doc' ?
+                pkgName === 'doc' ?
                     `/doc/html/${topic.href}` :
-                    `/library/${topic.pkgName}/html/${topic.href}`
+                    `/library/${pkgName}/html/${topic.href}`
             );
             return topic;
         });
 
-        if(!skipMeta){
-            const ind = topics.findIndex(v => v.type === TopicType.HOME);
-            let homeTopic: Topic | undefined = undefined;
-            if(ind >= 0){
-                homeTopic = topics.splice(ind, 1)[0];
-            }
+        const ind = topics.findIndex(v => v.type === TopicType.HOME);
+        let homeTopic: TopicExtra | undefined = undefined;
+        if(ind >= 0){
+            homeTopic = topics.splice(ind, 1)[0];
+        }
 
-            const indexTopic: Topic = {
-                pkgName: pkgName,
-                name: 'Index',
-                description: '',
-                href: '00Index.html',
-                helpPath: `/library/${pkgName}/html/00Index.html`,
-                type: TopicType.INDEX
-            };
+        const indexTopic: TopicExtra = {
+            name: 'Index',
+            description: '',
+            href: '00Index.html',
+            helpPath: `/library/${pkgName}/html/00Index.html`,
+            type: TopicType.INDEX
+        };
 
-            const descriptionTopic: Topic = {
-                pkgName: pkgName,
-                name: 'DESCRIPTION',
-                description: '',
-                href: '../DESCRIPTION',
-                helpPath: `/library/${pkgName}/DESCRIPTION`,
-                type: TopicType.META
-            };
+        const descriptionTopic: TopicExtra = {
+            name: 'DESCRIPTION',
+            description: '',
+            href: '../DESCRIPTION',
+            helpPath: `/library/${pkgName}/DESCRIPTION`,
+            type: TopicType.META
+        };
 
-            topics.unshift(indexTopic, descriptionTopic);
-            if(homeTopic){
-                topics.unshift(homeTopic);
-            }
+        topics.unshift(indexTopic, descriptionTopic);
+        if(homeTopic){
+            topics.unshift(homeTopic);
         }
 
         const ret = (summarize ? summarizeTopics(topics) : topics);
@@ -469,7 +464,6 @@ function summarizeTopics(topics: Topic[]): Topic[] {
     const topicMap = new Map<string, Topic>();
     for(const topic of topics){
         if(topicMap.has(topic.helpPath)){
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             const newTopic = <Topic>topicMap.get(topic.helpPath); // checked above that key is present
             if(newTopic.aliases){
                 newTopic.aliases.push(topic.name);
@@ -479,7 +473,6 @@ function summarizeTopics(topics: Topic[]): Topic[] {
         } else{
             const newTopic: Topic = {
                 ...topic,
-                isGrouped: true
             };
             if(newTopic.type === TopicType.NORMAL && newTopic.description){
                 newTopic.aliases = [newTopic.name];

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -308,6 +308,8 @@ export class HelpPanel {
                 } else {
                     void this.showHelpFile(helpFile, true, currentScrollY);
                 }
+            } else{
+                void vscode.window.showWarningMessage(`Did not find help page for path ${requestPath}`);
             }
         } else if (msg.message === 'mouseClick') {
             // use the additional mouse buttons to go forward/backwards

--- a/src/helpViewer/panel.ts
+++ b/src/helpViewer/panel.ts
@@ -146,6 +146,7 @@ export class HelpPanel {
 
 
     public async setContextValues(): Promise<void> {
+        await setContext('r.helpPanel.canOpenExternal', !!this.currentEntry?.helpFile.url);
         await setContext('r.helpPanel.active', !!this.panel?.active);
         await setContext('r.helpPanel.canGoBack', this.history.length > 0);
         await setContext('r.helpPanel.canGoForward', this.forwardHistory.length > 0);

--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as ejs from 'ejs';
 
-import { asViewColumn, config, setContext, UriIcon } from '../util';
+import { asViewColumn, config, setContext, UriIcon, makeWebviewCommandUriString } from '../util';
 
 import { extensionContext } from '../extension';
 
@@ -704,10 +704,6 @@ export class HttpgdViewer implements IHttpgdViewer {
             const webViewUri = this.webviewPanel.webview.asWebviewUri(localUri);
             return webViewUri.toString();
         };
-        const makeCommandUri = (command: string, ...args: any[]) => {
-            const argString = encodeURIComponent(JSON.stringify(args));
-            return `command:${command}?${argString}`;
-        };
         let overwriteCssPath = '';
         if (this.customOverwriteCssPath) {
             const uri = vscode.Uri.file(this.customOverwriteCssPath);
@@ -724,7 +720,7 @@ export class HttpgdViewer implements IHttpgdViewer {
             host: this.host,
             asLocalPath: asLocalPath,
             asWebViewPath: asWebViewPath,
-            makeCommandUri: makeCommandUri,
+            makeCommandUri: makeWebviewCommandUriString,
             overwriteCssPath: overwriteCssPath
         };
         return ejsData;

--- a/src/util.ts
+++ b/src/util.ts
@@ -588,3 +588,57 @@ export function asViewColumn(s: string | undefined | vscode.ViewColumn, fallback
     return fallback;
 }
 
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function makeWebviewCommandUriString(command: string, ...args: any[]): string {
+    const argString = encodeURIComponent(JSON.stringify(args));
+    return `command:${command}?${argString}`;
+}
+
+// Tries to read a file, returns undefined if an error occurs (e.g. the file does not exist)
+export function readFileSyncSafe(
+    path: fs.PathOrFileDescriptor,
+    encoding: BufferEncoding = 'utf-8'
+): string | undefined {
+    try {
+        return fs.readFileSync(path, {encoding:encoding});
+    } catch (e) {
+        return undefined;
+    }
+}
+
+// Tries to read a dir, returns undefined if an error occurs (e.g. the dir does not exist)
+export function readdirSyncSafe(
+    path: fs.PathLike,
+    encoding: BufferEncoding = 'utf-8'
+){
+    try {
+        return fs.readdirSync(path, {encoding: encoding});
+    } catch (e) {
+        return undefined;
+    }
+}
+
+export function statSyncSafe(path: fs.PathLike): fs.Stats | undefined {
+    try {
+        return fs.statSync(path);
+    } catch (e) {
+        
+    }
+}
+
+export function isDirSafe(path: fs.PathLike): boolean {
+    return !!fs.statSync(path, {throwIfNoEntry: false})?.isDirectory();
+}
+
+export function isFileSafe(path: fs.PathLike): boolean {
+    return !!fs.statSync(path, {throwIfNoEntry: false})?.isFile();
+}
+
+// Keeps only the unique entries in an array, optionally with a custom comparison function
+export function uniqueEntries<T>(array: T[], isIdentical: (x: T, y: T) => boolean = (x, y) => (x === y)){
+    function uniqueFunction(v: T, index: number, array: T[]): boolean {
+        return array.findIndex(v2 => isIdentical(v2, v)) === index;
+    }
+    return array.filter(uniqueFunction);
+}


### PR DESCRIPTION
Addresses #637, replaces #644.

This PR implements a preview feature for the help pages based on .Rd files in the current directory:
- If a requested help-topic-path matches one of the present .Rd files, this file is converted to html and shown instead of the original help page
- The R side bar contains a new item which lists all of the help topics from local .Rd files
- If local files change, help previews are updated accordingly
- The setting "r.helpPanel.previewLocalPackages" controls which (sub)directories are checked for local packages. By default this is just the main workspace folder (`["."]`), but subdirectories can be specified. The feature can be disabled by setting this to `[]`.

![image](https://user-images.githubusercontent.com/53863351/201948554-22d4870d-e45a-4f24-be82-162167d8cec2.png)

![image](https://user-images.githubusercontent.com/53863351/201948200-f7322a1b-b653-450f-8661-5b6f3d76dffa.png)

Some possible future improvements are:
- ~Preview meta files (DESCRIPTION, Index)~
- Toggle between installed help/preview per page etc. (see https://github.com/REditorSupport/vscode-R/pull/1259#issuecomment-1324890174)
- Fix encoding issue on non-utf8 locales
- Performance improvements (?)

