### PR TITLE
Respect RdMacros

### DIFF
--- a/R/help/rdToHtml.R
+++ b/R/help/rdToHtml.R
@@ -7,12 +7,14 @@
 #'   3. version string of the package
 #'   4. root dir of the package
 
-e <- tools::loadPkgRdMacros(base::commandArgs(TRUE)[4])
+args <- base::commandArgs(TRUE)
+
+e <- tools::loadPkgRdMacros(args[4])
 e <- tools::loadRdMacros(file.path(R.home('share'), 'Rd', 'macros', 'system.Rd'), macros = e)
 
 tools::Rd2HTML(
-    base::commandArgs(TRUE)[1],
-    package=base::commandArgs(TRUE)[2:3],
+    args[1],
+    package=args[2:3],
     dynamic=TRUE,
     encoding='utf-8',
     macros=e,

--- a/R/help/rdToHtml.R
+++ b/R/help/rdToHtml.R
@@ -18,6 +18,6 @@ tools::Rd2HTML(
     dynamic=TRUE,
     encoding="utf-8",
     macros=e,
-    stages=c("build","install","render")
+    stages=c("build", "install", "render")
 )
 

--- a/R/help/rdToHtml.R
+++ b/R/help/rdToHtml.R
@@ -1,0 +1,21 @@
+
+#' Converts an .Rd file to HTML (output is printed to stdout)
+#'
+#' Execute this with the following trailing commandline args:
+#'   1. path of an .Rd file
+#'   2. name of the package
+#'   3. version string of the package
+#'   4. root dir of the package
+
+e <- tools::loadPkgRdMacros(base::commandArgs(TRUE)[4])
+e <- tools::loadRdMacros(file.path(R.home('share'), 'Rd', 'macros', 'system.Rd'), macros = e)
+
+tools::Rd2HTML(
+    base::commandArgs(TRUE)[1],
+    package=base::commandArgs(TRUE)[2:3],
+    dynamic=TRUE,
+    encoding='utf-8',
+    macros=e,
+    stages=c('build','install','render')
+)
+

--- a/R/help/rdToHtml.R
+++ b/R/help/rdToHtml.R
@@ -14,10 +14,9 @@ e <- tools::loadRdMacros(file.path(R.home("share"), "Rd", "macros", "system.Rd")
 
 tools::Rd2HTML(
     args[1],
-    package=args[2:3],
-    dynamic=TRUE,
-    encoding="utf-8",
-    macros=e,
-    stages=c("build", "install", "render")
+    package = args[2:3],
+    dynamic = TRUE,
+    encoding = "utf-8",
+    macros = e,
+    stages = c("build", "install", "render")
 )
-

--- a/R/help/rdToHtml.R
+++ b/R/help/rdToHtml.R
@@ -10,14 +10,14 @@
 args <- base::commandArgs(TRUE)
 
 e <- tools::loadPkgRdMacros(args[4])
-e <- tools::loadRdMacros(file.path(R.home('share'), 'Rd', 'macros', 'system.Rd'), macros = e)
+e <- tools::loadRdMacros(file.path(R.home("share"), "Rd", "macros", "system.Rd"), macros = e)
 
 tools::Rd2HTML(
     args[1],
     package=args[2:3],
     dynamic=TRUE,
-    encoding='utf-8',
+    encoding="utf-8",
     macros=e,
-    stages=c('build','install','render')
+    stages=c("build","install","render")
 )
 

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -74,6 +74,7 @@ export async function initializeHelp(
         webviewStylePath: context.asAbsolutePath('./html/help/theme.css'),
         rScriptFile: context.asAbsolutePath('./R/help/getAliases.R'),
         indexTemplatePath: context.asAbsolutePath('./html/help/00Index.ejs'),
+        rdToHtmlScriptFile: context.asAbsolutePath('./R/help/rdToHtml.R'),
         rPath: rPath,
         cwd: cwd,
         persistentState: persistentState,
@@ -196,6 +197,8 @@ export interface HelpOptions {
     cwd?: string
     // path of getAliases.R
     rScriptFile: string
+    // path of the script used to convert .Rd to html
+    rdToHtmlScriptFile: string
     // persistent state, either global or workspace specific
     persistentState: vscode.Memento
     // used by some helper classes:
@@ -266,6 +269,7 @@ export class RHelp implements api.HelpPanel, vscode.WebviewPanelSerializer<strin
         };
         this.helpPreviewerOptions = {
             indexTemplatePath: options.indexTemplatePath,
+            rdToHtmlScriptFile: options.rdToHtmlScriptFile,
             rPath: this.rPath,
             previewListener: previewListener
         };


### PR DESCRIPTION
The help preview now respects Rd-macros, defined either in a local file or using the RdMacros entry in DESCRIPTION. To test, install e.g. the package RdPack, and create a package directory with:
- `./man/macros/someMacroFile.Rd` containing 
  ```
  \newcommand{\testmacro}{This is a test!}
  ```
- `./DESCRIPTION` containing
  ```
  [...]
  RdMacros: RdPack
  ```
- `./man/someHelpFile.Rd` containing
  ```
  [...]
  \testmacro{}
  \insertAllCited{}
  ```

Previewing this help file should include the expanded macros, i.e. `"This is a test!"` and `"There are no references for Rd macro \insertAllCites on this help page."`


Furthermore, failing to convert an Rd file to HTML now shows a warning message.
