### PR TITLE
WIP: Interactive R tasks

### DIFF
--- a/R/interactiveTask.Rprofile
+++ b/R/interactiveTask.Rprofile
@@ -1,0 +1,11 @@
+
+text <- Sys.getenv('VSCODE_EVAL_CODE')
+
+ret <- try(eval(parse(text=text)))
+
+status <- 0
+if(inherits(ret, 'try-error')){
+    status <- 1
+}
+
+quit(save='no', status=status)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ import * as completions from './completions';
 import * as rShare from './liveShare';
 import * as httpgdViewer from './plotViewer';
 import * as languageService from './languageService';
-import { RTaskProvider } from './tasks';
+import * as tasks from './tasks';
 
 
 // global objects used in other files
@@ -214,8 +214,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     await rShare.initLiveShare(context);
 
     // register task provider
-    const taskProvider = new RTaskProvider();
-    vscode.tasks.registerTaskProvider(taskProvider.type, taskProvider);
+    const taskProvider = new tasks.RTaskProvider();
+    vscode.tasks.registerTaskProvider(tasks.R_TASK_TYPE, taskProvider);
 
     // deploy session watcher (if configured by user)
     if (enableSessionWatcher) {


### PR DESCRIPTION
WIP/Proof of concept. Addresses #1239, #1242.

Makes R tasks interactive by running the specified code from a custom .Rprofile. This feels a bit hacky, but was the only way I managed to make R run code specified in the task description, and still read interactive responses from stdin.

Sourcing the original .Rprofile from within the modified one should be possible (is done for the extension's R terminals anyways I think). Not sure what the other drawbacks of this approach are. Since most tasks are not supposed to be interactive, I would probably add this as an optional mechanism, to be enabled in the task definition. To test, define e.g. the following task:

```jsonc
{
  "tasks": [
    {
      "type": "R",
      "code": [
        "print('hello world')",
        "s <- readline()",
        "print(s)"
      ],
      "group": "build",
      "problemMatcher": [],
      "label": "R: Build"
    }
  ]
}
```
