### PR TITLE
Remove script tags in R v4.2.x help pages

### DIFF
--- a/html/help/script.ts
+++ b/html/help/script.ts
@@ -77,7 +77,6 @@ window.document.body.onload = () => {
     // notify vscode when code is clicked:
     if(document.body.classList.contains('preClickable')){
         const codeElements = document.getElementsByTagName('pre');
-        console.log(codeElements);
         for(let i=0; i<codeElements.length; i++){
             const el = codeElements[i];
             el.onclick = (me: MouseEvent) => {

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -698,7 +698,7 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
         $('head style').remove();
 
         // strip tags: <code class="language-R">...
-        const preCodes = $('pre>code.language-R');
+        const preCodes = $('pre>code');
         preCodes.each((_, pc) => {
             $(pc).replaceWith($(pc).html() || '');
         });

--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -696,7 +696,13 @@ function pimpMyHelp(helpFile: HelpFile): HelpFile {
     if(helpFile.isHtml){
         // Remove style elements specified in the html itself (replaced with custom CSS)
         $('head style').remove();
-        
+
+        // strip tags: <code class="language-R">...
+        const preCodes = $('pre>code.language-R');
+        preCodes.each((_, pc) => {
+            $(pc).replaceWith($(pc).html() || '');
+        });
+
         // Split code examples at empty lines:
         const codeClickConfig = config().get<CodeClickConfig>('helpPanel.clickCodeExamples');
         const isEnabled = CODE_CLICKS.some(k => codeClickConfig?.[k] !== 'Ignore');


### PR DESCRIPTION
Remove script tags introduced in R 4.2.x. These are used for syntax highlighting in the normal html help, but mess a bit with the formatting of the vscode help view.