### PR TITLE
Make help preview async

### DIFF
--- a/src/helpViewer/index.ts
+++ b/src/helpViewer/index.ts
@@ -608,7 +608,7 @@ export class RHelp implements api.HelpPanel, vscode.WebviewPanelSerializer<strin
         skipCache: boolean = false
     ): Promise<HelpFile | undefined> {
         // try to get a preview first
-        const preview = this.getHelpPreviewForPath(requestPath);
+        const preview = await this.getHelpPreviewForPath(requestPath);
         if(preview){
             pimpMyHelp(preview);
             return preview;
@@ -639,9 +639,9 @@ export class RHelp implements api.HelpPanel, vscode.WebviewPanelSerializer<strin
         return helpFile;
     }
     
-    private getHelpPreviewForPath(requestPath: string): HelpFile | undefined {
+    private async getHelpPreviewForPath(requestPath: string): Promise<HelpFile | undefined> {
         for (const previewer of this.previewProviders) {
-            const ret = previewer.getHelpFileFromRequestPath(requestPath);
+            const ret = await previewer.getHelpFileFromRequestPath(requestPath);
             if(ret){
                 return ret;
             }


### PR DESCRIPTION
Makes the generation of help page previews from .Rd files asynchronous to avoid blocking vscode, if the generation takes longer.

I don't know a reproducible example to illustrate this, but on slower machines this PR should eliminate one (possible) source of vscode delays.
