### PR TITLE
Add the column name to the tooltip on data viewer

### DIFF
--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -326,7 +326,8 @@ if (show_view) {
   get_column_def <- function(name, field, value) {
     filter <- TRUE
     tooltip <- sprintf(
-      "class: [%s], type: %s",
+      "%s, class: [%s], type: %s",
+      name,
       toString(class(value)),
       typeof(value)
     )


### PR DESCRIPTION
# What problem did you solve?

Related to #1121
When a data frame with many columns is displayed in the data viewer, the column names may not be readable due to column width limitations.
Display the column name in the tooltip so that we can see the column name.

## (If you have)Screenshot

![image](https://user-images.githubusercontent.com/50911393/208229885-f6f252bf-386e-4b90-9977-d1399725a5fe.png)

## (If you do not have screenshot) How can I check this pull request?

```r
n <- 1000
df <- data.frame(id = 1:n)
for (i in 1:100) {
  df[[paste0("loooooooooooooooooooooooong", i)]] <- rnorm(n)
}

View(df)
```
