### PR TITLE
Ability to set echo=TRUE in Run source by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1576,6 +1576,11 @@
           "default": "UTF-8",
           "markdownDescription": "An optional encoding to pass to R when executing the file, i.e. `source(FILE, encoding=ENCODING)`."
         },
+        "r.source.echo": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Should the file be executed with echo option set to TRUE by default, i.e. `source(FILE, echo=TRUE)`?"
+        },
         "r.source.focus": {
           "type": "string",
           "default": "editor",

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -30,7 +30,11 @@ export async function runSource(echo: boolean): Promise<void>  {
         return;
     }
     encodingParam = `encoding = "${encodingParam}"`;
+    const echoParam = util.config().get<boolean>('source.echo');
     rPath = [rPath, encodingParam].join(', ');
+    if (echoParam) {
+        echo = true;
+    }
     if (echo) {
         rPath = [rPath, 'echo = TRUE'].join(', ');
     }


### PR DESCRIPTION
# What problem did you solve?

The only option to run source with `echo=TRUE` was to use `ctrl+shift+enter`. I've added an option to set `echo=TRUE` by default which is the default behaviour in RStudio and might be convenient for some users.

## Screenshot

![image](https://user-images.githubusercontent.com/40692851/210439066-7ef9a21f-2064-4393-8d4f-f88d97e513b6.png)
