### PR TITLE
Add new command for load all with reset = FALSE

### DIFF
--- a/package.json
+++ b/package.json
@@ -479,6 +479,11 @@
         "command": "r.loadAll"
       },
       {
+        "title": "Load All (reset = FALSE)",
+        "category": "R Package",
+        "command": "r.loadAllCached"
+      },
+      {
         "title": "Build",
         "category": "R Package",
         "command": "r.build"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,6 +116,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         'r.createLintrConfig': lintrConfig.createLintrConfig,
         'r.generateCCppProperties': cppProperties.generateCppProperties,
         'r.loadAll': () => rTerminal.runTextInTerm('devtools::load_all()'),
+        'r.loadAllCached': () => rTerminal.runTextInTerm('devtools::load_all(reset = FALSE)'),
 
         // environment independent commands. this is a workaround for using the Tasks API: https://github.com/microsoft/vscode/issues/40758
         'r.build': () => vscode.commands.executeCommand('workbench.action.tasks.runTask', 'R: Build'),


### PR DESCRIPTION
# What problem did you solve?

When working with a large codebase in R, it is handy to use `devtools::load_all(reset = FALSE)`. It will be much faster and usually do just as good a job as the full `devtools::load_all()`.

I would like to have a similar way to run this as when I press `Ctrl + Shift + L`. However, when I want to add a key binding for this, I need a command.

So I tried to replicate the code that was used for adding the `devtools::load_all()` command (`r.loadAll`) and added a `r.loadAllCached` command.

I am happy to make any additional changes but I have to say that I know absolutely nothing about VS code extensions.

## (If you do not have screenshot) How can I check this pull request?

I am unsure if I added this command in the right way. I tried replicating what was done to add `r.loadAll` and hope I found the right places to add this.