### PR TITLE
Explicit workspace behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,7 @@
           "id": "workspaceViewer",
           "name": "Workspace",
           "icon": "./images/Rlogo.svg",
-          "contextualTitle": "R",
-          "when": "r.WorkspaceViewer:show"
+          "contextualTitle": "R"
         },
         {
           "id": "rHelpPages",
@@ -117,7 +116,8 @@
     "viewsWelcome": [
       {
         "view": "workspaceViewer",
-        "contents": "R workspace is empty."
+        "when": "!r.WorkspaceViewer:show",
+        "contents": "R workspace viewer requires that the [session watcher be enabled](https://github.com/REditorSupport/vscode-R/wiki/R-Session-watcher)."
       },
       {
         "view": "rHelpPages",

--- a/package.json
+++ b/package.json
@@ -1246,22 +1246,22 @@
         {
           "command": "r.workspaceViewer.load",
           "group": "navigation@0",
-          "when": "view == workspaceViewer && !r.liveShare:isGuest"
+          "when": "r.WorkspaceViewer:show && view == workspaceViewer && !r.liveShare:isGuest"
         },
         {
           "command": "r.workspaceViewer.save",
           "group": "navigation@1",
-          "when": "view == workspaceViewer && !r.liveShare:isGuest"
+          "when": "r.WorkspaceViewer:show && view == workspaceViewer && !r.liveShare:isGuest"
         },
         {
           "command": "r.workspaceViewer.clear",
           "group": "navigation@2",
-          "when": "view == workspaceViewer"
+          "when": "r.WorkspaceViewer:show && view == workspaceViewer"
         },
         {
           "command": "r.workspaceViewer.refreshEntry",
           "group": "navigation@3",
-          "when": "view == workspaceViewer"
+          "when": "r.WorkspaceViewer:show && view == workspaceViewer"
         },
         {
           "command": "r.helpPanel.showQuickPick",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -241,13 +241,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         // register the R Workspace tree view
         // creates a custom context value for the workspace view
         // only shows view when session watcher is enabled
+        rWorkspace = new workspaceViewer.WorkspaceDataProvider();
 
         // if session watcher is active, register dyamic completion provider
         const liveTriggerCharacters = ['', '[', '(', ',', '$', '@', '"', '\''];
         vscode.languages.registerCompletionItemProvider(['r', 'rmd'], new completions.LiveCompletionItemProvider(), ...liveTriggerCharacters);
     }
 
-    rWorkspace = new workspaceViewer.WorkspaceDataProvider(enableSessionWatcher);
+    void vscode.commands.executeCommand('setContext', 'r.WorkspaceViewer:show', enableSessionWatcher);
 
     return rExtension;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     extensionContext = context;
 
     // assign session watcher setting to global variable
-    enableSessionWatcher = util.config().get<boolean>('sessionWatcher');
+    enableSessionWatcher = util.config().get<boolean>('sessionWatcher') ?? false;
     rmdPreviewManager = new rmarkdown.RMarkdownPreviewManager();
     rmdKnitManager = new rmarkdown.RMarkdownKnitManager();
 
@@ -133,8 +133,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
         // workspace viewer
         'r.workspaceViewer.refreshEntry': () => rWorkspace?.refresh(),
-        'r.workspaceViewer.view': (node: workspaceViewer.GlobalEnvItem) => node.label && workspaceViewer.viewItem(node.label),
-        'r.workspaceViewer.remove': (node: workspaceViewer.GlobalEnvItem) => node.label && workspaceViewer.removeItem(node.label),
+        'r.workspaceViewer.view': (node: workspaceViewer.GlobalEnvItem) => node?.label && workspaceViewer.viewItem(node.label),
+        'r.workspaceViewer.remove': (node: workspaceViewer.GlobalEnvItem) => node?.label && workspaceViewer.removeItem(node.label),
         'r.workspaceViewer.clear': workspaceViewer.clearWorkspace,
         'r.workspaceViewer.load': workspaceViewer.loadWorkspace,
         'r.workspaceViewer.save': workspaceViewer.saveWorkspace,
@@ -241,18 +241,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         // register the R Workspace tree view
         // creates a custom context value for the workspace view
         // only shows view when session watcher is enabled
-        rWorkspace = new workspaceViewer.WorkspaceDataProvider();
-        vscode.window.registerTreeDataProvider(
-            'workspaceViewer',
-            rWorkspace
-        );
-        void vscode.commands.executeCommand('setContext', 'r.WorkspaceViewer:show', enableSessionWatcher);
 
         // if session watcher is active, register dyamic completion provider
         const liveTriggerCharacters = ['', '[', '(', ',', '$', '@', '"', '\''];
         vscode.languages.registerCompletionItemProvider(['r', 'rmd'], new completions.LiveCompletionItemProvider(), ...liveTriggerCharacters);
     }
 
+    rWorkspace = new workspaceViewer.WorkspaceDataProvider(enableSessionWatcher);
 
     return rExtension;
 }

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -30,9 +30,9 @@ function getPackageNode(name: string): PackageNode | undefined {
 }
 
 export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
-    private readonly attachedNamespacesRootItem: TreeItem;
-    private readonly loadedNamespacesRootItem: TreeItem;
-    private readonly globalEnvRootItem: TreeItem;
+    private readonly attachedNamespacesRootItem: TreeItem | undefined;
+    private readonly loadedNamespacesRootItem: TreeItem | undefined;
+    private readonly globalEnvRootItem: TreeItem | undefined;
     private _onDidChangeTreeData: EventEmitter<void> = new EventEmitter();
 
     public readonly onDidChangeTreeData: Event<void> = this._onDidChangeTreeData.event;
@@ -43,24 +43,29 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
         this._onDidChangeTreeData.fire();
     }
 
-    public constructor() {
-        this.attachedNamespacesRootItem = new TreeItem('Attached Namespaces', TreeItemCollapsibleState.Collapsed);
-        this.attachedNamespacesRootItem.id = 'attached-namespaces';
-        this.attachedNamespacesRootItem.iconPath = new ThemeIcon('library');
+    public constructor(sessionEnabled: boolean) {
+        if (sessionEnabled) {
+            this.attachedNamespacesRootItem = new TreeItem('Attached Namespaces', TreeItemCollapsibleState.Collapsed);
+            this.attachedNamespacesRootItem.id = 'attached-namespaces';
+            this.attachedNamespacesRootItem.iconPath = new ThemeIcon('library');
 
-        this.loadedNamespacesRootItem = new TreeItem('Loaded Namespaces', TreeItemCollapsibleState.Collapsed);
-        this.loadedNamespacesRootItem.id = 'loaded-namespaces';
-        this.loadedNamespacesRootItem.iconPath = new ThemeIcon('package');
+            this.loadedNamespacesRootItem = new TreeItem('Loaded Namespaces', TreeItemCollapsibleState.Collapsed);
+            this.loadedNamespacesRootItem.id = 'loaded-namespaces';
+            this.loadedNamespacesRootItem.iconPath = new ThemeIcon('package');
 
-        this.globalEnvRootItem = new TreeItem('Global Environment', TreeItemCollapsibleState.Expanded);
-        this.globalEnvRootItem.id = 'globalenv';
-        this.globalEnvRootItem.iconPath = new ThemeIcon('menu');
+            this.globalEnvRootItem = new TreeItem('Global Environment', TreeItemCollapsibleState.Expanded);
+            this.globalEnvRootItem.id = 'globalenv';
+            this.globalEnvRootItem.iconPath = new ThemeIcon('menu');
 
-        extensionContext.subscriptions.push(
-            vscode.commands.registerCommand(PackageItem.command, async (node: PackageNode) => {
-                await node.showQuickPick();
-            })
-        );
+            extensionContext.subscriptions.push(
+                vscode.commands.registerCommand(PackageItem.command, async (node: PackageNode) => {
+                    await node.showQuickPick();
+                })
+            );
+        }
+
+        vscode.window.registerTreeDataProvider('workspaceViewer', this);
+        void vscode.commands.executeCommand('setContext', 'r.WorkspaceViewer:show', sessionEnabled);
     }
 
     public getTreeItem(element: TreeItem): TreeItem {

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -30,9 +30,9 @@ function getPackageNode(name: string): PackageNode | undefined {
 }
 
 export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
-    private readonly attachedNamespacesRootItem: TreeItem | undefined;
-    private readonly loadedNamespacesRootItem: TreeItem | undefined;
-    private readonly globalEnvRootItem: TreeItem | undefined;
+    private readonly attachedNamespacesRootItem: TreeItem;
+    private readonly loadedNamespacesRootItem: TreeItem;
+    private readonly globalEnvRootItem: TreeItem;
     private _onDidChangeTreeData: EventEmitter<void> = new EventEmitter();
 
     public readonly onDidChangeTreeData: Event<void> = this._onDidChangeTreeData.event;
@@ -43,29 +43,26 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
         this._onDidChangeTreeData.fire();
     }
 
-    public constructor(sessionEnabled: boolean) {
-        if (sessionEnabled) {
-            this.attachedNamespacesRootItem = new TreeItem('Attached Namespaces', TreeItemCollapsibleState.Collapsed);
-            this.attachedNamespacesRootItem.id = 'attached-namespaces';
-            this.attachedNamespacesRootItem.iconPath = new ThemeIcon('library');
+    public constructor() {
+        this.attachedNamespacesRootItem = new TreeItem('Attached Namespaces', TreeItemCollapsibleState.Collapsed);
+        this.attachedNamespacesRootItem.id = 'attached-namespaces';
+        this.attachedNamespacesRootItem.iconPath = new ThemeIcon('library');
 
-            this.loadedNamespacesRootItem = new TreeItem('Loaded Namespaces', TreeItemCollapsibleState.Collapsed);
-            this.loadedNamespacesRootItem.id = 'loaded-namespaces';
-            this.loadedNamespacesRootItem.iconPath = new ThemeIcon('package');
+        this.loadedNamespacesRootItem = new TreeItem('Loaded Namespaces', TreeItemCollapsibleState.Collapsed);
+        this.loadedNamespacesRootItem.id = 'loaded-namespaces';
+        this.loadedNamespacesRootItem.iconPath = new ThemeIcon('package');
 
-            this.globalEnvRootItem = new TreeItem('Global Environment', TreeItemCollapsibleState.Expanded);
-            this.globalEnvRootItem.id = 'globalenv';
-            this.globalEnvRootItem.iconPath = new ThemeIcon('menu');
+        this.globalEnvRootItem = new TreeItem('Global Environment', TreeItemCollapsibleState.Expanded);
+        this.globalEnvRootItem.id = 'globalenv';
+        this.globalEnvRootItem.iconPath = new ThemeIcon('menu');
 
-            extensionContext.subscriptions.push(
-                vscode.commands.registerCommand(PackageItem.command, async (node: PackageNode) => {
-                    await node.showQuickPick();
-                })
-            );
-        }
+        extensionContext.subscriptions.push(
+            vscode.commands.registerCommand(PackageItem.command, async (node: PackageNode) => {
+                await node.showQuickPick();
+            })
+        );
 
         vscode.window.registerTreeDataProvider('workspaceViewer', this);
-        void vscode.commands.executeCommand('setContext', 'r.WorkspaceViewer:show', sessionEnabled);
     }
 
     public getTreeItem(element: TreeItem): TreeItem {
@@ -177,7 +174,7 @@ export class WorkspaceDataProvider implements TreeDataProvider<TreeItem> {
 }
 
 class PackageItem extends TreeItem {
-    public static command : string = 'r.workspaceViewer.package.showQuickPick';
+    public static command: string = 'r.workspaceViewer.package.showQuickPick';
     public label?: string;
     public name: string;
     public pkgNode?: PackageNode;
@@ -263,7 +260,7 @@ export class GlobalEnvItem extends TreeItem {
     }
 
     private getTooltip(
-        label:string,
+        label: string,
         rClass: string,
         size?: number,
         treeLevel?: number
@@ -296,7 +293,7 @@ export class GlobalEnvItem extends TreeItem {
     of what elements can have have 'child' nodes os not. It can be expanded
     in the futere for more tree levels.*/
     private static setCollapsibleState(treeLevel: number, type: string, str: string): vscode.TreeItemCollapsibleState {
-        if (treeLevel === TreeLevel.Parent && collapsibleTypes.includes(type) && str.includes('\n')){
+        if (treeLevel === TreeLevel.Parent && collapsibleTypes.includes(type) && str.includes('\n')) {
             return TreeItemCollapsibleState.Collapsed;
         } else {
             return TreeItemCollapsibleState.None;


### PR DESCRIPTION
- Always show workspace viewer
- Fallback message when session watcher is disabled
- Don't error when calling view without an active workspace viewer

# What problem did you solve?
It can be confusing for users when the workspace viewer doesn't show up, especially when there is no message explicitly stating why it isn't appearing. This PR ensures that users are pointed in the right direction.

## Screenshot

![image](https://user-images.githubusercontent.com/60372411/222406965-beb0d675-1c74-4193-9b42-afee4d655dcb.png)


## How can I check this pull request?
Disable session watcher & reload --> should be greeted by welcome text
