### PR TITLE
Always check pid before clearing workspace

### DIFF
--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -792,4 +792,4 @@ print.hsearch <- function(x, ...) {
   invisible(NULL)
 }
 
-reg.finalizer(globalenv(), function(e) .vsc$request("detach"), onexit = TRUE)
+reg.finalizer(globalenv(), function(e) .vsc$request("detach", pid = pid), onexit = TRUE)

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -792,4 +792,4 @@ print.hsearch <- function(x, ...) {
   invisible(NULL)
 }
 
-reg.finalizer(globalenv(), function(e) .vsc$request("detach", pid = pid), onexit = TRUE)
+reg.finalizer(globalenv(), function(e) .vsc$request("detach"), onexit = TRUE)

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -162,7 +162,11 @@ export function deleteTerminal(term: vscode.Terminal): void {
     if (isDeepStrictEqual(term, rTerm)) {
         rTerm = undefined;
         if (config().get<boolean>('sessionWatcher')) {
-            cleanupSession();
+            term.processId.then((v) => {
+                if (v) {
+                    cleanupSession(v.toString());
+                }
+            });
         }
     }
 }

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -162,7 +162,7 @@ export function deleteTerminal(term: vscode.Terminal): void {
     if (isDeepStrictEqual(term, rTerm)) {
         rTerm = undefined;
         if (config().get<boolean>('sessionWatcher')) {
-            term.processId.then((v) => {
+            void term.processId.then((v) => {
                 if (v) {
                     cleanupSession(v.toString());
                 }


### PR DESCRIPTION
Ensure that we aren't clearing the workspace too eagerly.
- Only clean the workspace if the current pid === stored pid

# What problem did you solve?

If you attach two terminals, closing the first one will cause vscode-R to detach the second one
