### PR TITLE
Workspace viewer command visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -998,6 +998,10 @@
         {
           "command": "r.workspaceViewer.remove",
           "when": "false"
+        },
+        {
+          "command": "r.workspaceViewer.package.showQuickPick",
+          "when": "false"
         }
       ],
       "editor/title/run": [

--- a/package.json
+++ b/package.json
@@ -326,7 +326,8 @@
         "command": "r.workspaceViewer.refreshEntry",
         "title": "Manual Refresh",
         "icon": "$(refresh)",
-        "category": "R Workspace Viewer"
+        "category": "R Workspace Viewer",
+        "enablement": "rSessionActive"
       },
       {
         "command": "r.workspaceViewer.view",
@@ -338,7 +339,8 @@
         "command": "r.workspaceViewer.clear",
         "title": "Clear environment",
         "icon": "$(clear-all)",
-        "category": "R Workspace Viewer"
+        "category": "R Workspace Viewer",
+        "enablement": "rSessionActive"
       },
       {
         "command": "r.workspaceViewer.remove",
@@ -350,7 +352,8 @@
         "command": "r.workspaceViewer.save",
         "title": "Save workspace",
         "icon": "$(save)",
-        "category": "R Workspace Viewer"
+        "category": "R Workspace Viewer",
+        "enablement": "rSessionActive"
       },
       {
         "command": "r.workspaceViewer.load",
@@ -987,6 +990,16 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "r.workspaceViewer.view",
+          "when": "false"
+        },
+        {
+          "command": "r.workspaceViewer.remove",
+          "when": "false"
+        }
+      ],
       "editor/title/run": [
         {
           "when": "editorLangId == r",

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -164,7 +164,7 @@ export function deleteTerminal(term: vscode.Terminal): void {
         if (config().get<boolean>('sessionWatcher')) {
             void term.processId.then((v) => {
                 if (v) {
-                    cleanupSession(v.toString());
+                    void cleanupSession(v.toString());
                 }
             });
         }

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -352,22 +352,21 @@ export function saveWorkspace(): void {
 }
 
 export function loadWorkspace(): void {
-    if (workspaceData) {
-        void window.showOpenDialog({
-            defaultUri: Uri.file(workingDir),
-            filters: {
-                'Data': ['RData'],
-            },
-            title: 'Load workspace'
-        }).then(async (uri: Uri[] | undefined) => {
-            if (uri) {
-                const savePath = uri[0].fsPath.split(path.sep).join(path.posix.sep);
-                return runTextInTerm(
-                    `load("${(savePath)}")`
-                );
-            }
-        });
-    }
+    const defaultUri = workingDir ? Uri.file(workingDir) : vscode.window.activeTextEditor?.document.uri;
+    void window.showOpenDialog({
+        defaultUri: defaultUri,
+        filters: {
+            'Data': ['RData'],
+        },
+        title: 'Load workspace'
+    }).then(async (uri: Uri[] | undefined) => {
+        if (uri) {
+            const savePath = uri[0].fsPath.split(path.sep).join(path.posix.sep);
+            return runTextInTerm(
+                `load("${(savePath)}")`
+            );
+        }
+    });
 }
 
 export function viewItem(node: string): void {


### PR DESCRIPTION
- save, clear, and refresh are disabled when there is no attached terminal
- Load can be used at any time to attach a terminal + load data easily

![image](https://user-images.githubusercontent.com/60372411/223014177-6a45b113-9550-49a1-9dab-eced10c12b1d.png)

- View, remove, and quickpick are no longer shown in the command palette
   - these were not meant to be user-facing, and didn't do anything when called

![image](https://user-images.githubusercontent.com/60372411/223014320-4805e62b-3556-44cb-a08f-de24f5a76807.png)
