### PR TITLE
RMD Preview: font-size setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1544,10 +1544,10 @@
           "default": true,
           "markdownDescription": "Enable automatic refresh of R Markdown preview on file update."
         },
-        "r.rmarkdown.preview.fontSize": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Controls the font size in pixels used in the R Markdown preview. When unspecified, `#markdown.preview.fontSize#` is used."
+        "r.rmarkdown.preview.zoom": {
+          "type": "number",
+          "default": 1,
+          "markdownDescription": "Controls the zoom of the R Markdown preview."
         },
         "r.rmarkdown.knit.useBackgroundProcess": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1544,6 +1544,11 @@
           "default": true,
           "markdownDescription": "Enable automatic refresh of R Markdown preview on file update."
         },
+        "r.rmarkdown.preview.fontSize": {
+          "type": "number",
+          "default": 12,
+          "description": "Controls the font size in pixels used in the R Markdown preview."
+        },
         "r.rmarkdown.knit.useBackgroundProcess": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -1545,9 +1545,9 @@
           "markdownDescription": "Enable automatic refresh of R Markdown preview on file update."
         },
         "r.rmarkdown.preview.fontSize": {
-          "type": "number",
-          "default": 12,
-          "description": "Controls the font size in pixels used in the R Markdown preview."
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Controls the font size in pixels used in the R Markdown preview. When unspecified, `#markdown.preview.fontSize#` is used."
         },
         "r.rmarkdown.knit.useBackgroundProcess": {
           "type": "boolean",

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -89,7 +89,9 @@ class RMarkdownPreview extends vscode.Disposable {
 
         // make the output chunks a little lighter to stand out
         let chunkCol = String(config().get('rmarkdown.chunkBackgroundColor'));
-        const fontSize = config().get<number>('rmarkdown.preview.fontSize', 14);
+        const fallbackSize = vscode.workspace.getConfiguration('markdown').get<number>('preview.fontSize', 14);
+        let fontSize = Number(config().get<string>('rmarkdown.preview.fontSize'));
+        fontSize = fontSize > 0 ? fontSize : fallbackSize;
 
         let outCol: string;
         if (chunkCol) {
@@ -107,25 +109,27 @@ class RMarkdownPreview extends vscode.Disposable {
 
         const style =
             `<style>
+            * {
+                font-size: ${fontSize}px !important;
+            }
             body {
                 color: var(--vscode-editor-foreground);
                 background: var(--vscode-editor-background);
-                font-size: ${fontSize}px;
             }
             h1, .h1 {
-                font-size: ${fontSize + 20}px;
+                font-size: ${fontSize + 20}px !important;
             }
             h2, .h2 {
-                font-size: ${fontSize + 16}px;
+                font-size: ${fontSize + 16}px !important;
             }
             h3, .h3 {
-                font-size: ${fontSize + 10}px;
+                font-size: ${fontSize + 10}px !important;
             }
             h4, .h4 {
-                font-size: ${fontSize + 4}px;
+                font-size: ${fontSize + 4}px !important;
             }
             h5, .h5 {
-                font-size: ${fontSize + 2}px;
+                font-size: ${fontSize + 2}px !important;
             }
 
             .hljs {

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -87,11 +87,10 @@ class RMarkdownPreview extends vscode.Disposable {
         const $ = cheerio.load(content);
         this.htmlLightContent = $.html();
 
+        const zoom = config().get<number>('rmarkdown.preview.zoom', 1);
+
         // make the output chunks a little lighter to stand out
         let chunkCol = String(config().get('rmarkdown.chunkBackgroundColor'));
-        const fallbackSize = vscode.workspace.getConfiguration('markdown').get<number>('preview.fontSize', 14);
-        let fontSize = Number(config().get<string>('rmarkdown.preview.fontSize'));
-        fontSize = fontSize > 0 ? fontSize : fallbackSize;
 
         let outCol: string;
         if (chunkCol) {
@@ -109,29 +108,11 @@ class RMarkdownPreview extends vscode.Disposable {
 
         const style =
             `<style>
-            * {
-                font-size: ${fontSize}px !important;
-            }
             body {
+                zoom: ${zoom};
                 color: var(--vscode-editor-foreground);
                 background: var(--vscode-editor-background);
             }
-            h1, .h1 {
-                font-size: ${fontSize + 20}px !important;
-            }
-            h2, .h2 {
-                font-size: ${fontSize + 16}px !important;
-            }
-            h3, .h3 {
-                font-size: ${fontSize + 10}px !important;
-            }
-            h4, .h4 {
-                font-size: ${fontSize + 4}px !important;
-            }
-            h5, .h5 {
-                font-size: ${fontSize + 2}px !important;
-            }
-
             .hljs {
                 color: var(--vscode-editor-foreground);
             }

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -89,6 +89,8 @@ class RMarkdownPreview extends vscode.Disposable {
 
         // make the output chunks a little lighter to stand out
         let chunkCol = String(config().get('rmarkdown.chunkBackgroundColor'));
+        const fontSize = config().get<number>('rmarkdown.preview.fontSize', 14);
+
         let outCol: string;
         if (chunkCol) {
             const colReg = /[0-9.]+/g;
@@ -108,7 +110,24 @@ class RMarkdownPreview extends vscode.Disposable {
             body {
                 color: var(--vscode-editor-foreground);
                 background: var(--vscode-editor-background);
+                font-size: ${fontSize}px;
             }
+            h1, .h1 {
+                font-size: ${fontSize + 20}px;
+            }
+            h2, .h2 {
+                font-size: ${fontSize + 16}px;
+            }
+            h3, .h3 {
+                font-size: ${fontSize + 10}px;
+            }
+            h4, .h4 {
+                font-size: ${fontSize + 4}px;
+            }
+            h5, .h5 {
+                font-size: ${fontSize + 2}px;
+            }
+
             .hljs {
                 color: var(--vscode-editor-foreground);
             }


### PR DESCRIPTION
# What problem did you solve?
Solves #1332 by injecting font-size in the preview HTML's css.

## (If you do not have screenshot) How can I check this pull request?

Render the following, modifying the `r.rmarkdown.preview.fontSize` setting or the `markdown.preview.fontSize` setting to change the size of text in the preview.

``````
# H1

Foo.

## H2

Bar.

### H3

Baz.

#### H4

Foo.

##### H5

Bar.

```{r}
x <- 1
x
```

``````