### PR TITLE
Handle errors in `getAliases.R`

### DIFF
--- a/R/help/getAliases.R
+++ b/R/help/getAliases.R
@@ -22,18 +22,15 @@ ret <- lapply(rownames(ip), function(row) {
     aliases = NULL
   )
   if (file.exists(filename)) {
-    info[["aliases"]] <- tryCatch(
-        expr = as.list(readRDS(filename)),
-        error = function(e) {
-            warning(
-                "An error occurred while reading the ",
-                "aliases file (aliases.rds) for package ",
-                pkg,
-                ". Try reinstalling/uninstalling the package.",
-            )
-            print(e)
-        }
+    res <- tryCatch(
+      expr = as.list(readRDS(filename)),
+      error = conditionMessage
     )
+    if (is.list(res)) {
+      info$aliases <- res
+    } else {
+      info$error <- res
+    }
   }
   info
 })

--- a/R/help/getAliases.R
+++ b/R/help/getAliases.R
@@ -22,10 +22,22 @@ ret <- lapply(rownames(ip), function(row) {
     aliases = NULL
   )
   if (file.exists(filename)) {
-    info[["aliases"]] <- as.list(readRDS(filename))
+    info[["aliases"]] <- tryCatch(
+        expr = as.list(readRDS(filename)),
+        error = function(e) {
+            warning(
+                "An error occurred while reading the ",
+                "aliases file (aliases.rds) for package ",
+                pkg,
+                ". Try reinstalling/uninstalling the package.",
+            )
+            print(e)
+        }
+    )
   }
   info
 })
+
 names(ret) <- rownames(ip)
 
 lim <- Sys.getenv("VSCR_LIM")

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -161,7 +161,8 @@ interface PackageAliases {
     aliasFile?: string;
     aliases?: {
         [key: string]: string;
-    }
+    },
+    error?: string
 }
 interface AllPackageAliases {
     [key: string]: PackageAliases
@@ -221,9 +222,16 @@ export class AliasProvider {
 
         // flatten aliases into one list:
         const allAliases: rHelp.Alias[] = [];
-        for(const pkg in allPackageAliases){
-            const pkgName = allPackageAliases[pkg].package || pkg;
-            const pkgAliases = allPackageAliases[pkg].aliases || {};
+        for (const pkg in allPackageAliases) {
+            const item = allPackageAliases[pkg];
+            const pkgName = item.package || pkg;
+
+            if (item.error) {
+                void window.showErrorMessage(`An error occurred while reading the aliases file for package ${pkgName}: ${item.error}. The package files may be corrupted. Try reinstalling the package.`);
+                continue;
+            }
+
+            const pkgAliases = item.aliases || {};
             for(const fncName in pkgAliases){
                 allAliases.push({
                     name: pkgAliases[fncName],


### PR DESCRIPTION
# What problem did you solve?

When an `aliases.rds` file in one of your installed packages is corrupt or improperly formatted, it can cause the documentation to fail every time it is requested, resulting in an error message that can be quite frustrating.

(x) Failed to get list of R functions. Make sure that `jsonlite` is installed and r.rpath.linux points to a valid R executable.
(x) Error in readRDS(filename) : error reading from connection Calls: lapply -> FUN -> as.list -> readRDS Execution halted

This PR adds a more informative message to the users.

