### PR TITLE
Add `r.lsp.multiServer` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1509,7 +1509,7 @@
         "r.lsp.multiServer": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Use multiple language server processes for [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces)."
+          "markdownDescription": "Use multiple language servers for [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces)."
         },
         "r.rmarkdown.codeLensCommands": {
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -1509,7 +1509,7 @@
         "r.lsp.multiServer": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Use multiple language servers for [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces)."
+          "markdownDescription": "Use multiple language servers for [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces). If disabled, only one language server will be used to handle all requests from all workspaces and files."
         },
         "r.rmarkdown.codeLensCommands": {
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -1506,6 +1506,11 @@
           "default": false,
           "description": "Use STDIO connection instead of TCP. (Unix/macOS users only)"
         },
+        "r.lsp.multiServer": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Use multiple language server processes for [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces)."
+        },
         "r.rmarkdown.codeLensCommands": {
           "type": "array",
           "items": {

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -322,13 +322,11 @@ export class LanguageService implements Disposable {
 
     private stopLanguageService(): Thenable<void> {
         const promises: Thenable<void>[] = [];
-        if (this.client && this.client.needsStop()) {
+        if (this.client) {
             promises.push(this.client.stop());
         }
         for (const client of this.clients.values()) {
-            if (client.needsStop()) {
-                promises.push(client.stop());
-            }
+            promises.push(client.stop());
         }
         return Promise.all(promises).then(() => undefined);
     }

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -314,8 +314,9 @@ export class LanguageService implements Disposable {
                 { language: 'rmd' },
             ];
 
-            self.client = await self.createClient(self.config, documentSelector,
-                os.homedir(), undefined, self.outputChannel);
+            const workspaceFolder = workspace.workspaceFolders?.[0];
+            const cwd = workspaceFolder ? workspaceFolder.uri.fsPath : os.homedir();
+            self.client = await self.createClient(self.config, documentSelector, cwd, workspaceFolder, self.outputChannel);
         }
     }
 


### PR DESCRIPTION
This PR is an initial step to support #1370 by adding a setting `r.lsp.multiServer` (default `true`) to avoid breaking anything.

If disabled, only a single language server will be spawned from the first workspace folder. In the future, if languageserver implements native support for multi-root workspace (as suggested in https://github.com/REditorSupport/languageserver/issues/621), then it should automatically have similar behavior with multi-server approach with proper isolation of different workspace folders, rmarkdown documents, and jupyter notebooks.
