### PR TITLE
allow to invoke R terminal also in relative paths

### DIFF
--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -10,7 +10,7 @@ import * as util from './util';
 import * as selection from './selection';
 import { getSelection } from './selection';
 import { cleanupSession } from './session';
-import { config, delay, getRterm, getWorkspaceFolder } from './util';
+import { config, delay, getRterm, getCurrentWorkspaceFolder } from './util';
 import { rGuestService, isGuestSession } from './liveShare';
 import * as fs from 'fs';
 export let rTerm: vscode.Terminal | undefined = undefined;
@@ -115,7 +115,7 @@ export async function runFromLineToEnd(): Promise<void>  {
 }
 
 export async function makeTerminalOptions(): Promise<vscode.TerminalOptions> {
-    const workspaceFolderPath = getWorkspaceFolder()?.uri.fsPath;
+    const workspaceFolderPath = getCurrentWorkspaceFolder()?.uri.fsPath;
     const termPathMaybeRelative = await getRterm();
     const termPath: string | undefined = (workspaceFolderPath && termPathMaybeRelative) ?
         path.resolve(workspaceFolderPath, termPathMaybeRelative) :

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -10,7 +10,7 @@ import * as util from './util';
 import * as selection from './selection';
 import { getSelection } from './selection';
 import { cleanupSession } from './session';
-import { config, delay, getRterm } from './util';
+import { config, delay, getRterm, getWorkspaceFolder } from './util';
 import { rGuestService, isGuestSession } from './liveShare';
 import * as fs from 'fs';
 export let rTerm: vscode.Terminal | undefined = undefined;
@@ -115,12 +115,17 @@ export async function runFromLineToEnd(): Promise<void>  {
 }
 
 export async function makeTerminalOptions(): Promise<vscode.TerminalOptions> {
-    const termPath = await getRterm();
+    const workspaceFolderPath = getWorkspaceFolder()?.uri.fsPath;
+    const termPathMaybeRelative = await getRterm();
+    const termPath: string | undefined = (workspaceFolderPath && termPathMaybeRelative) ?
+        path.resolve(workspaceFolderPath, termPathMaybeRelative) :
+        termPathMaybeRelative;
     const shellArgs: string[] = config().get('rterm.option') || [];
     const termOptions: vscode.TerminalOptions = {
         name: 'R Interactive',
         shellPath: termPath,
         shellArgs: shellArgs,
+        cwd: workspaceFolderPath,
     };
     const newRprofile = extensionContext.asAbsolutePath(path.join('R', 'session', 'profile.R'));
     const initR = extensionContext.asAbsolutePath(path.join('R', 'session','init.R'));

--- a/src/util.ts
+++ b/src/util.ts
@@ -117,6 +117,11 @@ export async function getRterm(): Promise<string | undefined> {
     return undefined;
 }
 
+export const getWorkspaceFolder = () =>
+    vscode.window.activeTextEditor ?
+        vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) :
+        (vscode.workspace.workspaceFolders ?? [undefined])[0];
+
 export function ToRStringLiteral(s: string, quote: string): string {
     if (s === undefined) {
         return 'NULL';

--- a/src/util.ts
+++ b/src/util.ts
@@ -117,11 +117,6 @@ export async function getRterm(): Promise<string | undefined> {
     return undefined;
 }
 
-export const getWorkspaceFolder = () =>
-    vscode.window.activeTextEditor ?
-        vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) :
-        (vscode.workspace.workspaceFolders ?? [undefined])[0];
-
 export function ToRStringLiteral(s: string, quote: string): string {
     if (s === undefined) {
         return 'NULL';


### PR DESCRIPTION
Allow to invoke R terminal also in relative paths, and specify the right working directory for the workspace.

Now the user is allowed to enter a relative path in the option 'rterm', and this VSCode extension will invoke this relative path relative to the workspace directory. This is useful for example for people(like me) who have a bash script creating a remove R session.