### PR TITLE
Add task to run `testthat::test_file()` on current file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2081,7 +2081,7 @@
         ],
         "pattern": [
           {
-            "regexp": "^(Failure|Error)\\s\\((.*\\.[Rr]):(\\d+):?(\\d+)?\\):\\s(.*)",
+            "regexp": "^[-─ ]*(Failure|Error)\\s\\((.*\\.[Rr]):(\\d+):?(\\d+)?\\):\\s(.*)",
             "file": 2,
             "line": 3,
             "column": 4,

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -48,6 +48,16 @@ const rtasks: RTaskInfo[] = [
     {
         definition: {
             type: TYPE,
+            code: ['testthat::test_file("${file}")']
+        },
+        name: 'Test (Current File)',
+        group: vscode.TaskGroup.Test,
+        problemMatchers: '$testthat'
+    },
+
+    {
+        definition: {
+            type: TYPE,
             code: ['devtools::build()']
         },
         name: 'Build',


### PR DESCRIPTION
# What problem did you solve?

Added a VScode task to run `testthat::test_file()` on the currently open file. This is particularly useful when snapshot tests which don't really work in batch or if you have a large test script that you want to run but you don't want to run your entire test suite.

Likewise it looks like the failure string is slightly different for this function so I attempted to modify the regex to ensure the problem matching still works. 

## (If you have)Screenshot

In this GIF I show that the feature works and correctly errors for a failed test whilst it works correctly if I open a file that has a successful test. 

![2023-09-05 17 21 07](https://github.com/REditorSupport/vscode-R/assets/8447209/76980cd1-f38c-4818-86ca-9ee9d1af3ae3)

