### PR TITLE
Add Option to Sync renv Cache

### DIFF
--- a/R/help/getAliases.R
+++ b/R/help/getAliases.R
@@ -1,8 +1,23 @@
+.paths <- .libPaths()
+
 add_lib_paths <- Sys.getenv("VSCR_LIB_PATHS")
 if (nzchar(add_lib_paths)) {
   add_lib_paths <- strsplit(add_lib_paths, "\n", fixed = TRUE)[[1L]]
-  .libPaths(c(.libPaths(), add_lib_paths))
+  .paths <- c(.paths, add_lib_paths)
 }
+
+use_renv_lib_path <- Sys.getenv("VSCR_USE_RENV_LIB_PATH")
+use_renv_lib_path <- if (nzchar(use_renv_lib_path)) as.logical(use_renv_lib_path) else FALSE
+if (use_renv_lib_path) {
+  if (requireNamespace("renv", quietly = TRUE)) {
+    .paths <- c(.paths, renv::paths$cache())
+  } else {
+    warning("renv package is not installed. Please install renv to use renv library path.")
+  }
+}
+
+.libPaths(.paths)
+message("R library paths: ", paste(.libPaths(), collapse = "\n"))
 
 loadNamespace("jsonlite")
 

--- a/R/help/helpServer.R
+++ b/R/help/helpServer.R
@@ -1,8 +1,23 @@
+.paths <- .libPaths()
+
 add_lib_paths <- Sys.getenv("VSCR_LIB_PATHS")
 if (nzchar(add_lib_paths)) {
   add_lib_paths <- strsplit(add_lib_paths, "\n", fixed = TRUE)[[1L]]
-  .libPaths(c(.libPaths(), add_lib_paths))
+  .paths <- c(.paths, add_lib_paths)
 }
+
+use_renv_lib_path <- Sys.getenv("VSCR_USE_RENV_LIB_PATH")
+use_renv_lib_path <- if (nzchar(use_renv_lib_path)) as.logical(use_renv_lib_path) else FALSE
+if (use_renv_lib_path) {
+  if (requireNamespace("renv", quietly = TRUE)) {
+    .paths <- c(.paths, renv::paths$cache())
+  } else {
+    warning("renv package is not installed. Please install renv to use renv library path.")
+  }
+}
+
+.libPaths(.paths)
+message("R library paths: ", paste(.libPaths(), collapse = "\n"))
 
 lim <- Sys.getenv("VSCR_LIM")
 

--- a/R/languageServer.R
+++ b/R/languageServer.R
@@ -1,8 +1,23 @@
+.paths <- .libPaths()
+
 add_lib_paths <- Sys.getenv("VSCR_LIB_PATHS")
 if (nzchar(add_lib_paths)) {
   add_lib_paths <- strsplit(add_lib_paths, "\n", fixed = TRUE)[[1L]]
-  .libPaths(c(.libPaths(), add_lib_paths))
+  .paths <- c(.paths, add_lib_paths)
 }
+
+use_renv_lib_path <- Sys.getenv("VSCR_USE_RENV_LIB_PATH")
+use_renv_lib_path <- if (nzchar(use_renv_lib_path)) as.logical(use_renv_lib_path) else FALSE
+if (use_renv_lib_path) {
+  if (requireNamespace("renv", quietly = TRUE)) {
+    .paths <- c(.paths, renv::paths$cache())
+  } else {
+    warning("renv package is not installed. Please install renv to use renv library path.")
+  }
+}
+
+.libPaths(.paths)
+message("R library paths: ", paste(.libPaths(), collapse = "\n"))
 
 if (!requireNamespace("languageserver", quietly = TRUE)) {
   q(save = "no", status = 10)

--- a/package.json
+++ b/package.json
@@ -1468,6 +1468,11 @@
           "default": [],
           "markdownDescription": "Additional library paths to launch R background processes (R languageserver, help server, etc.). These paths will be appended to `.libPaths()` on process startup. It could be useful for projects with [renv](https://rstudio.github.io/renv/index.html) enabled."
         },
+        "r.useRenvLibPath" : {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Use renv library paths to launch R background processes (R languageserver, help server, etc.)."
+        },
         "r.lsp.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/helpViewer/helpProvider.ts
+++ b/src/helpViewer/helpProvider.ts
@@ -4,7 +4,7 @@ import * as cp from 'child_process';
 
 import * as rHelp from '.';
 import { extensionContext } from '../extension';
-import { catchAsError, DisposableProcess, getRLibPaths, spawn, spawnAsync } from '../util';
+import { catchAsError, config, DisposableProcess, getRLibPaths, spawn, spawnAsync } from '../util';
 
 export interface RHelpProviderOptions {
     // path of the R executable
@@ -62,7 +62,8 @@ export class HelpProvider {
             env: {
                 ...process.env,
                 VSCR_LIB_PATHS: getRLibPaths(),
-                VSCR_LIM: lim
+                VSCR_LIM: lim,
+                VSCR_USE_RENV_LIB_PATH: config().get<boolean>('useRenvLibPath') ? 'TRUE' : 'FALSE'
             },
         };
 
@@ -251,7 +252,8 @@ export class AliasProvider {
             env: {
                 ...process.env,
                 VSCR_LIB_PATHS: getRLibPaths(),
-                VSCR_LIM: lim
+                VSCR_LIM: lim,
+                VSCR_USE_RENV_LIB_PATH: config().get<boolean>('useRenvLibPath') ? 'TRUE' : 'FALSE'
             }
         };
 

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -59,6 +59,7 @@ export class LanguageService implements Disposable {
         let client: LanguageClient;
 
         const debug = config.get<boolean>('lsp.debug');
+        const useRenvLibPath = config.get<boolean>('useRenvLibPath') ?? false;
         const rPath = await getRpath() || ''; // TODO: Abort gracefully
         if (debug) {
             console.log(`R path: ${rPath}`);
@@ -67,6 +68,7 @@ export class LanguageService implements Disposable {
         const env = Object.create(process.env) as NodeJS.ProcessEnv;
         env.VSCR_LSP_DEBUG = debug ? 'TRUE' : 'FALSE';
         env.VSCR_LIB_PATHS = getRLibPaths();
+        env.VSCR_USE_RENV_LIB_PATH = useRenvLibPath ? 'TRUE' : 'FALSE';
 
         const lang = config.get<string>('lsp.lang');
         if (lang !== '') {


### PR DESCRIPTION
# What problem did you solve?

I frequently run into issues where the language or help server will start up and then crash because it cannot find packages (usually `jsonlite`). There is the option to add `.libPaths` in the extension currently, but the `renv` package cache is unstable and liable to change with different architectures and versions of `renv`.

Users can get "lucky" when the extension starts an R process in a directory where an .Rprofile bootstraps the `renv` environment correctly, but for situations where this does not happen (which I find happens often for me), the user is out of luck.

This pull request adds a boolean option to the extension where users can opt into automatically adding the `renv` package cache to `.libPaths` when these R processes start up. The mechanism is to write an environment variable on the typescript side that is then parsed as a boolean on the R side, following patterns elsewhere in the code. We then ensure that `renv` is in fact installed—issuing a warning but not crashing if it isn't—and then read the package cache path from `renv::paths$cache()` and add this to our `.libPaths`.

## Screenshot

When the language server starts up and `renv` is bootstrapped, the `.libPaths` look like this:

![Screenshot 2023-09-18 at 10 25 59 AM](https://github.com/REditorSupport/vscode-R/assets/9449706/b08fdfe5-0360-41ce-b6a2-c325a1c87c97)

When the language server starts up somewhere that does not bootstrap `renv`, `.libPaths` looks like this:

![Screenshot 2023-09-18 at 10 28 16 AM](https://github.com/REditorSupport/vscode-R/assets/9449706/a410aa74-994b-4b87-bf5a-77e25069e0f1)

## Is it a problem that we see packages that the user doesn't?

This change does *not* automatically bootstrap `renv` when an R terminal is created. Hence, the language and help servers may have more packages visible to them than the user's terminal does. Users familiar with `renv` should know how to rectify this, and the user who "accidentally" activates this option without knowing anything about `renv` can just install the missing packages. The major problem that this change overcomes is that `jsonlite` and `httpgd` often get installed into the `renv` package cache by the extension, and this is a problem that can't be overcome as easily as the accidental user error mentioned above.
