### PR TITLE
Substitute variables in `r.rpath` and `r.rterm` settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": [
-        "${workspaceRoot}/out/src/**/*.js"
+        "${workspaceFolder}/out/src/**/*.js"
       ],
       "preLaunchTask": "watchAll"
     },
@@ -27,7 +27,7 @@
         "--disable-extensions"
       ],
       "outFiles": [
-        "${workspaceRoot}/out/src/**/*.js"
+        "${workspaceFolder}/out/src/**/*.js"
       ],
       "preLaunchTask": "watchAll"
     },

--- a/package.json
+++ b/package.json
@@ -1422,32 +1422,32 @@
         "r.rpath.windows": {
           "type": "string",
           "default": "",
-          "description": "Path to an R executable to launch R background processes (Windows). Must be \"vanilla\" R, not radian etc.!"
+          "markdownDescription": "Path to an R executable to launch R background processes (Windows). Must be \"vanilla\" R, not radian etc.! Some variables defined in <https://code.visualstudio.com/docs/editor/variables-reference> such as `${userHome}`, `${workspaceFolder}`, `${fileWorkspaceFolder}`, and `${fileDirname}` are supported."
         },
         "r.rpath.mac": {
           "type": "string",
           "default": "",
-          "description": "Path to an R executable to launch R background processes (macOS). Must be \"vanilla\" R, not radian etc.!"
+          "markdownDescription": "Path to an R executable to launch R background processes (macOS). Must be \"vanilla\" R, not radian etc.! Some variables defined in <https://code.visualstudio.com/docs/editor/variables-reference> such as `${userHome}`, `${workspaceFolder}`, `${fileWorkspaceFolder}`, and `${fileDirname}` are supported."
         },
         "r.rpath.linux": {
           "type": "string",
           "default": "",
-          "description": "Path to an R executable to launch R background processes (Linux). Must be \"vanilla\" R, not radian etc.!"
+          "markdownDescription": "Path to an R executable to launch R background processes (Linux). Must be \"vanilla\" R, not radian etc.! Some variables defined in <https://code.visualstudio.com/docs/editor/variables-reference> such as `${userHome}`, `${workspaceFolder}`, `${fileWorkspaceFolder}`, and `${fileDirname}` are supported."
         },
         "r.rterm.windows": {
           "type": "string",
           "default": "",
-          "description": "R path for interactive terminals (Windows). Can also be radian etc."
+          "markdownDescription": "R path for interactive terminals (Windows). Can also be radian etc. Some variables defined in <https://code.visualstudio.com/docs/editor/variables-reference> such as `${userHome}`, `${workspaceFolder}`, `${fileWorkspaceFolder}`, and `${fileDirname}` are supported."
         },
         "r.rterm.mac": {
           "type": "string",
           "default": "",
-          "description": "R path for interactive terminals (macOS). Can also be radian etc."
+          "markdownDescription": "R path for interactive terminals (macOS). Can also be radian etc. Some variables defined in <https://code.visualstudio.com/docs/editor/variables-reference> such as `${userHome}`, `${workspaceFolder}`, `${fileWorkspaceFolder}`, and `${fileDirname}` are supported."
         },
         "r.rterm.linux": {
           "type": "string",
           "default": "",
-          "description": "R path for interactive terminals (Linux). Can also be radian etc."
+          "markdownDescription": "R path for interactive terminals (Linux). Can also be radian etc. Some variables defined in <https://code.visualstudio.com/docs/editor/variables-reference> such as `${userHome}`, `${workspaceFolder}`, `${fileWorkspaceFolder}`, and `${fileDirname}` are supported."
         },
         "r.rterm.option": {
           "type": "array",

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -116,10 +116,7 @@ export async function runFromLineToEnd(): Promise<void>  {
 
 export async function makeTerminalOptions(): Promise<vscode.TerminalOptions> {
     const workspaceFolderPath = getCurrentWorkspaceFolder()?.uri.fsPath;
-    const termPathMaybeRelative = await getRterm();
-    const termPath: string | undefined = (workspaceFolderPath && termPathMaybeRelative) ?
-        path.resolve(workspaceFolderPath, termPathMaybeRelative) :
-        termPathMaybeRelative;
+    const termPath = await getRterm();
     const shellArgs: string[] = config().get('rterm.option') || [];
     const termOptions: vscode.TerminalOptions = {
         name: 'R Interactive',

--- a/src/util.ts
+++ b/src/util.ts
@@ -143,7 +143,6 @@ export async function getRterm(): Promise<string | undefined> {
     const configEntry = getRPathConfigEntry(true);
     let rpath = config().get<string>(configEntry);
     rpath &&= substituteVariables(rpath);
-    console.log(rpath);
     rpath ||= await getRpathFromSystem();
 
     if (rpath !== '') {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { homedir } from 'os';
 import { existsSync, PathLike, readFile } from 'fs-extra';
 import * as fs from 'fs';
 import winreg = require('winreg');
@@ -12,6 +13,40 @@ import { randomBytes } from 'crypto';
 
 export function config(): vscode.WorkspaceConfiguration {
     return vscode.workspace.getConfiguration('r');
+}
+
+function substituteVariables(str: string) {
+    let result = str;
+
+    if (str.includes('${userHome}')) {
+        const userHome = homedir();
+        if (userHome) {
+            result = str.replaceAll('${userHome}', userHome);
+        }
+    }
+
+    if (str.includes('${workspaceFolder}')) {
+        const workspaceFolderPath = getCurrentWorkspaceFolder()?.uri.fsPath;
+        if (workspaceFolderPath) {
+            result = str.replaceAll('${workspaceFolder}', workspaceFolderPath);
+        }
+    }
+
+    if (str.includes('${fileWorkspaceFolder}')) {
+        const workspaceFolderPath = getActiveFileWorkspaceFolder()?.uri.fsPath;
+        if (workspaceFolderPath) {
+            result = str.replaceAll('${fileWorkspaceFolder}', workspaceFolderPath);
+        }
+    }
+
+    if (str.includes('${fileDirname}')) {
+        const activeFilePath = vscode.window.activeTextEditor?.document.uri.fsPath;
+        if (activeFilePath) {
+            result = str.replaceAll('${fileDirname}', path.dirname(activeFilePath));
+        }
+    }
+
+    return result;
 }
 
 function getRfromEnvPath(platform: string) {
@@ -79,6 +114,7 @@ export async function getRpath(quote = false, overwriteConfig?: string): Promise
     // try the os-specific config entry for the rpath:
     const configEntry = getRPathConfigEntry();
     rpath ||= config().get<string>(configEntry);
+    rpath &&= substituteVariables(rpath);
 
     // read from path/registry:
     rpath ||= await getRpathFromSystem();
@@ -106,7 +142,8 @@ export async function getRpath(quote = false, overwriteConfig?: string): Promise
 export async function getRterm(): Promise<string | undefined> {
     const configEntry = getRPathConfigEntry(true);
     let rpath = config().get<string>(configEntry);
-
+    rpath &&= substituteVariables(rpath);
+    console.log(rpath);
     rpath ||= await getRpathFromSystem();
 
     if (rpath !== '') {
@@ -147,15 +184,19 @@ export function checkIfFileExists(filePath: string): boolean {
     return existsSync(filePath);
 }
 
+function getActiveFileWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
+    const currentDocument = vscode.window.activeTextEditor;
+    if (currentDocument !== undefined) {
+        return vscode.workspace.getWorkspaceFolder(currentDocument.document.uri);
+    }
+}
+
 export function getCurrentWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
     if (vscode.workspace.workspaceFolders !== undefined) {
         if (vscode.workspace.workspaceFolders.length === 1) {
             return vscode.workspace.workspaceFolders[0];
         } else if (vscode.workspace.workspaceFolders.length > 1) {
-            const currentDocument = vscode.window.activeTextEditor;
-            if (currentDocument !== undefined) {
-                return vscode.workspace.getWorkspaceFolder(currentDocument.document.uri);
-            }
+            return getActiveFileWorkspaceFolder() || vscode.workspace.workspaceFolders[0];
         }
     }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,36 +15,27 @@ export function config(): vscode.WorkspaceConfiguration {
     return vscode.workspace.getConfiguration('r');
 }
 
+function substituteVariable(str: string, key: string, getValue: () => string | undefined) {
+    if (str.includes(key)) {
+        const value = getValue();
+        if (value) {
+            return str.replaceAll(key, value);
+        }
+    }
+    return str;
+}
+
 function substituteVariables(str: string) {
     let result = str;
-
-    if (str.includes('${userHome}')) {
-        const userHome = homedir();
-        if (userHome) {
-            result = str.replaceAll('${userHome}', userHome);
-        }
-    }
-
-    if (str.includes('${workspaceFolder}')) {
-        const workspaceFolderPath = getCurrentWorkspaceFolder()?.uri.fsPath;
-        if (workspaceFolderPath) {
-            result = str.replaceAll('${workspaceFolder}', workspaceFolderPath);
-        }
-    }
-
-    if (str.includes('${fileWorkspaceFolder}')) {
-        const workspaceFolderPath = getActiveFileWorkspaceFolder()?.uri.fsPath;
-        if (workspaceFolderPath) {
-            result = str.replaceAll('${fileWorkspaceFolder}', workspaceFolderPath);
-        }
-    }
-
-    if (str.includes('${fileDirname}')) {
+    result = substituteVariable(result, '${userHome}', () => homedir());
+    result = substituteVariable(result, '${workspaceFolder}', () => getCurrentWorkspaceFolder()?.uri.fsPath);
+    result = substituteVariable(result, '${fileWorkspaceFolder}', () => getActiveFileWorkspaceFolder()?.uri.fsPath);
+    result = substituteVariable(result, '${fileDirname}', () => {
         const activeFilePath = vscode.window.activeTextEditor?.document.uri.fsPath;
         if (activeFilePath) {
-            result = str.replaceAll('${fileDirname}', path.dirname(activeFilePath));
+            return path.dirname(activeFilePath);
         }
-    }
+    });
 
     return result;
 }


### PR DESCRIPTION
# What problem did you solve?

#1398 allows specifying an R term path relative to the current workspace folder, which causes an undesirable behavior as described in #1437.

This PR no longer allows relative path but switches to an approach (more standard for vscode extensions) using variable substitutions in `r.rpath` and `r.rterm` settings.

VS Code has built-in support for variable substitution in `launch.json` and `tasks.json` files as described at <https://code.visualstudio.com/docs/editor/variables-reference>. We support a small subset of those variables which are most useful here:

* `${userHome}` - the path of the user's home folder
* `${workspaceFolder}` - the path of the folder opened in VS Code
* `${fileWorkspaceFolder}` - the current opened file's workspace folder
* `${fileDirname}` - the current opened file's folder path

We could always add more if demanded.
