### PR TITLE
Improve code chunk handling in base `.R` files

### DIFF
--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -25,7 +25,8 @@ function isChunkStartLine(text: string, isRDoc: boolean) {
 
 function isChunkEndLine(text: string, isRDoc: boolean) {
     if (isRDoc) {
-        return (isRChunkLine(text));
+        const isSectionHeader = text.match(/^#+\s*.*[-#+=*]{4,}/g);
+        return (isRChunkLine(text) || isSectionHeader);
     } else {
         return (!!text.match(/^\s*```+\s*$/g));
     }

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -31,12 +31,19 @@ function isChunkEndLine(text: string, isRDoc: boolean) {
     }
 }
 
-function getChunkLanguage(text: string) {
+function getChunkLanguage(text: string, isRDoc: boolean = false) {
+    if (isRDoc) {
+        return 'r';
+    }  
     return text.replace(/^\s*```+\s*\{(\w+)\s*.*\}\s*$/g, '$1').toLowerCase();
 }
 
-function getChunkOptions(text: string) {
-    return text.replace(/^\s*```+\s*\{\w+\s*,?\s*(.*)\s*\}\s*$/g, '$1');
+function getChunkOptions(text: string, isRDoc: boolean = false) {
+    if (isRDoc) {
+        return text.replace(/^#+\s*%%/g, '');
+    } else {
+        return text.replace(/^\s*```+\s*\{\w+\s*,?\s*(.*)\s*\}\s*$/g, '$1');
+    }
 }
 
 function getChunkEval(chunkOptions: string) {
@@ -195,7 +202,7 @@ export function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
                 chunkId++;
                 chunkStartLine = line;
                 chunkLanguage = getChunkLanguage(lines[line]);
-                chunkOptions = getChunkOptions(lines[line]);
+                chunkOptions = getChunkOptions(lines[line], isRDoc);
                 chunkEval = getChunkEval(chunkOptions);
             }
         } else {

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -199,8 +199,15 @@ export function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
                 chunkEval = getChunkEval(chunkOptions);
             }
         } else {
-            if (isChunkEndLine(lines[line], isRDoc)) {
+            // Second condition is for the last chunk in an .R file
+            const isRDocAndFinalLine = (isRDoc && line === lines.length - 1);
+            if (isChunkEndLine(lines[line], isRDoc) || isRDocAndFinalLine) {
                 chunkEndLine = line;
+                
+                // isChunkEndLine looks for `# %%` in `.R` files, so if found, then need to go back one line to mark end of code chunk. 
+                if (isRDoc && !isRDocAndFinalLine) {
+                    line = line - 1;
+                }
 
                 const chunkRange = new vscode.Range(
                     new vscode.Position(chunkStartLine, 0),

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -191,6 +191,7 @@ export function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
     let chunkId = 0;  // One-based index
     let chunkStartLine: number | undefined = undefined;
     let chunkEndLine: number | undefined = undefined;
+    let codeEndLine: number | undefined = undefined;
     let chunkLanguage: string | undefined = undefined;
     let chunkOptions: string | undefined = undefined;
     let chunkEval: boolean | undefined = undefined;
@@ -210,20 +211,22 @@ export function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
             const isRDocAndFinalLine = (isRDoc && line === lines.length - 1);
             if (isChunkEndLine(lines[line], isRDoc) || isRDocAndFinalLine) {
                 chunkEndLine = line;
+                codeEndLine = line - 1;
                 
                 // isChunkEndLine looks for `# %%` in `.R` files, so if found, then need to go back one line to mark end of code chunk. 
                 if (isRDoc && !isRDocAndFinalLine) {
                     chunkEndLine = chunkEndLine - 1;
+                    codeEndLine = chunkEndLine;
                     line = line - 1;
                 }
-
+                
                 const chunkRange = new vscode.Range(
                     new vscode.Position(chunkStartLine, 0),
                     new vscode.Position(line, lines[line].length)
                 );
                 const codeRange = new vscode.Range(
                     new vscode.Position(chunkStartLine + 1, 0),
-                    new vscode.Position(line - 1, lines[line - 1].length)
+                    new vscode.Position(codeEndLine, lines[codeEndLine].length)
                 );
 
                 chunks.push({

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -206,6 +206,7 @@ export function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
                 
                 // isChunkEndLine looks for `# %%` in `.R` files, so if found, then need to go back one line to mark end of code chunk. 
                 if (isRDoc && !isRDocAndFinalLine) {
+                    chunkEndLine = chunkEndLine - 1;
                     line = line - 1;
                 }
 


### PR DESCRIPTION
This PR fixes #1453 and fixes some bugs in handling of code chunks in `.R` and `.Rmd` files. 

The first change is with `getChunks()`. Previously, for `.R` files, the scan would find the first `# %%` and mark it as the start line. Then, it would go until it found the next `# %%` and *incorrectly* mark this as the end line. The line just before the next `# %%` needs to be the end line (see #1453). This PR fixes this:
![CleanShot 2023-11-24 at 15 40 35@2x](https://github.com/REditorSupport/vscode-R/assets/19961439/55c0259b-9074-41c0-83cf-1e3b7c4a4b6e)

The second change is with `getCurrentChunk()`. I have simplified this code greatly and do much less work. Basically, I check for three edge cases (no chunks, line < first chunk, line < last chunk) and return early. Otherwise, I select the first chunk with `.endLine > line`. This works both for cursor within chunk and cursor between chunks. 

There is one change worth noting. Before, `getCurrentChunk()` would return undefined when `line` was after the last chunk. I instead return the last chunk and fix bugs with any commands this impacted.

## Testing

To test this, I created these two files (`temp.R` and `temp.Rmd`) and tried out the commands for running chunks, selecting current chunk, and going to next and previous chunk.

```r


# %% Chunk 1
print("Chunk 1")

# %% Chunk 2

print("Chunk 2")

# %% Chunk 3
print("Chunk 3")



```

`````r
---
---

```{r}

print("Chunk 1")

```


```{r}
print("Chunk 2")
```

```{r}
print("Chunk 3")
```

`````