### PR TITLE
Improve complete

### DIFF
--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -79,9 +79,19 @@ if (use_webserver) {
             },
 
             complete = function(expr, trigger, ...) {
+               
+                # remove trigger + any rhs from expr_string to evaluate
+                expr_string <- expr
+                pattern <- paste0("^(.*\\", trigger, ")")
+                finding <- regexpr(pattern, expr_string)
+                if (finding > 0) {
+                    expr_string <- substr(expr, 1L, attr(finding, "match.length") - 1L)
+                }
+
                 obj <- tryCatch({
-                    expr <- parse(text = expr, keep.source = FALSE)[[1]]
-                    eval(expr, .GlobalEnv)
+                    expr <- parse(text = expr_string, keep.source = FALSE)
+                    last_expr <- tail(expr, 1L) # only autocomplete the last expression
+                    eval(last_expr, .GlobalEnv)
                 }, error = function(e) NULL)
 
                 if (is.null(obj)) {
@@ -105,6 +115,8 @@ if (use_webserver) {
                             str = try_capture_str(item)
                         )
                     })
+
+                    print(result)
                     return(result)
                 }
 

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -166,10 +166,21 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
             });
         } else if(trigger === '$' || trigger === '@') {
             const symbolPosition = new vscode.Position(position.line, position.character - 1);
+            console.log("New completion \n sP",symbolPosition, position.line, position.character);
             if (session.server) {
+                
                 const re = /([a-zA-Z0-9._$@ ])+(?<![@$])/;
-                const exprRange = document.getWordRangeAtPosition(symbolPosition, re)?.with({ end: symbolPosition });
+                let exprRange = document.getWordRangeAtPosition(symbolPosition, re)?.with({ end: symbolPosition });
+                
+                if (!exprRange) {
+                    console.log("regex failed take all of document until trigger");
+                    const startPosition = new vscode.Position(0, 0);
+                    exprRange = new vscode.Range(startPosition, symbolPosition);
+                }
+
+                console.log("eR",exprRange);  
                 const expr = document.getText(exprRange);
+                console.log("hello world",expr);
                 const response: RObjectElement[] = await session.sessionRequest(session.server, {
                     type: 'complete',
                     expr: expr,


### PR DESCRIPTION
 # What problem did you solve?

with `setting.json`

```json
    "r.lsp.debug": true,
    "r.session.useWebServer": true,
```

vscode-R webserver [has a simple regex based isolation of code to eval](https://github.com/REditorSupport/vscode-R/blob/54f924cd2efa053cb6615903aaa8952f28405f11/src/completions.ts#L170) when using the "$"/"@" to trigger in-session completion. This regex will fail, for any but the simplest cases

Instead I suggest to rely on the R parser and the AST to decide what the left-hand-side of e.g. `$` operator is.

This will allow multi-line completion, chained method completion, and potentially anything the R parser accepts.

I'm interested in improving vscode-R similar as this [patch for Rstudio completions](https://github.com/pola-rs/r-polars/pull/597) to support completion for method chaining r-polars (... and also R6 and arrow),

## How can I check this pull request? 

> check out branch with vscode and emulate the extension

### example 1
```R
#$-complete after arbitrary parenthesis
(
    iris |> # |> is supported if the R interpreter supports it
    (\(iris) {
        iris$is_alien = FALSE
        head(iris, 3)
    })()
)$
```
<img width="1169" alt="image" src="https://github.com/sorhawell/vscode-R/assets/8015271/47c9690b-909e-471c-afea-01cae83d6933">

### example 2

```R
#$ complete chained R6 methods 
FruitBasket <- R6::R6Class(
  "FruitBasket",
  private = list(content = character()),
  public = list(
    initialize = \() {},
    mutate_content = \(fruit) {
        private$content = c(private$content, fruit)
        self
    },
    add_banana = \() self$clone()$mutate_content("banana"),
    add_apple = \() self$clone()$mutate_content("apple"),
    to_count_list = \() as.list(table(private$content))
  )
)

#$-complete any multiline chain. If it is valid R syntax is works
{
  print("this print statement is not evaluated, because not a child of `$` call in AST");
  FruitBasket$new()$
    add_apple()$
    add_banana(
    
    )$
    add_apple()$
    to_count_list()$
}
```
<img width="892" alt="image" src="https://github.com/sorhawell/vscode-R/assets/8015271/c99425c1-b019-4777-8540-33f38f4a6b7b">


### example 3

support r-polars completion ;) (disclaimer I have co-authored the polars bindings for R)

```R
# load polars and disable completion () and <- in suggestions
library(polars) #polars as of https://github.com/pola-rs/r-polars/pull/597
cs = polars:::completion_symbols
cs$method = ""
cs$setter = ""


pl$
  DataFrame(
    a = 1:5,
    b = letters[1:5]
  )$
  lazy()$
  select(
    pl$all()$head(5)
  )
```
<img width="1194" alt="image" src="https://github.com/sorhawell/vscode-R/assets/8015271/8fda6c9c-5ccd-4fb7-bc16-17600e6263d5">

<img width="978" alt="image" src="https://github.com/sorhawell/vscode-R/assets/8015271/5e6c2a29-c009-40c3-9b4f-6d267a7c7b20">

### example 4 completion for the arrow package (R6)
```R
library(arrow)


arrow_table(iris[,1:2])$
  Slice(2,10)$
  print()$
  Take(5)$
  
```
<img width="1204" alt="image" src="https://github.com/sorhawell/vscode-R/assets/8015271/5fdbe459-4f26-4fbd-9caa-eb43698f7949">