### PR TITLE
Fix RMD Progress Bar

### DIFF
--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -123,7 +123,7 @@ export abstract class RMarkdownManager {
 
                         }
                         const percentRegex = /[0-9]+(?=%)/g;
-                        const divisionRegex = /([0-9]+)\/([0-9]+) (\[.*\])/g;
+                        const divisionRegex = /([0-9]+)\/([0-9]+)/g;
                         const percentRegOutput = dat.match(percentRegex);
                         if (percentRegOutput) {
                             for (const item of percentRegOutput) {
@@ -139,12 +139,11 @@ export abstract class RMarkdownManager {
                         } else {
                             const divisionRegOutput = divisionRegex.exec(dat);
                             if (divisionRegOutput) {
-                                const perc = parseInt(divisionRegOutput[1]) / parseInt(divisionRegOutput[2]) * 100;
-                                const currentChunk = divisionRegOutput[3] ?? '';
+                                const perc = Math.ceil(parseInt(divisionRegOutput[1]) / parseInt(divisionRegOutput[2]) * 100);
                                 progress?.report(
                                     {
                                         increment: perc - currentProgress,
-                                        message: `${Math.ceil(perc)}% ${currentChunk}`
+                                        message: `${perc}%`
                                     }
                                 );
                                 currentProgress = perc;

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -123,7 +123,7 @@ export abstract class RMarkdownManager {
 
                         }
                         const percentRegex = /[0-9]+(?=%)/g;
-                        const divisionRegex = /([0-9]+)\/([0-9]+)/g;
+                        const divisionRegex = /([0-9]+)\/([0-9]+) (\[.*\])/g;
                         const percentRegOutput = dat.match(percentRegex);
                         if (percentRegOutput) {
                             for (const item of percentRegOutput) {
@@ -140,17 +140,16 @@ export abstract class RMarkdownManager {
                             const divisionRegOutput = divisionRegex.exec(dat);
                             if (divisionRegOutput) {
                                 const perc = parseInt(divisionRegOutput[1]) / parseInt(divisionRegOutput[2]) * 100;
+                                const currentChunk = divisionRegOutput[3] ?? '';
                                 progress?.report(
                                     {
                                         increment: perc - currentProgress,
-                                        message: `${Math.ceil(perc)}%`
+                                        message: `${Math.ceil(perc)}% ${currentChunk}`
                                     }
                                 );
                                 currentProgress = perc;
                             }
                         }
-
-
 
                         if (token?.isCancellationRequested) {
                             if (childProcess) {

--- a/src/rmarkdown/manager.ts
+++ b/src/rmarkdown/manager.ts
@@ -123,8 +123,8 @@ export abstract class RMarkdownManager {
 
                         }
                         const percentRegex = /[0-9]+(?=%)/g;
+                        const divisionRegex = /([0-9]+)\/([0-9]+)/g;
                         const percentRegOutput = dat.match(percentRegex);
-
                         if (percentRegOutput) {
                             for (const item of percentRegOutput) {
                                 const perc = Number(item);
@@ -136,7 +136,22 @@ export abstract class RMarkdownManager {
                                 );
                                 currentProgress = perc;
                             }
+                        } else {
+                            const divisionRegOutput = divisionRegex.exec(dat);
+                            if (divisionRegOutput) {
+                                const perc = parseInt(divisionRegOutput[1]) / parseInt(divisionRegOutput[2]) * 100;
+                                progress?.report(
+                                    {
+                                        increment: perc - currentProgress,
+                                        message: `${Math.ceil(perc)}%`
+                                    }
+                                );
+                                currentProgress = perc;
+                            }
                         }
+
+
+
                         if (token?.isCancellationRequested) {
                             if (childProcess) {
                                 resolve(childProcess);


### PR DESCRIPTION
# What problem did you solve?

Closes #1404. 

This PR adds another regex to check for chunk progress in the form of `x/y`. This appears to have been a change made to the rmarkdown package, so the previous implementation is needed for backwards compatibility.

## How can I check this pull request?
With the latest version of rmarkdown, use vscode-R's knit preview or smart knit commands.