### PR TITLE
Fix multiline smart-knit

### DIFF
--- a/src/rmarkdown/knit.ts
+++ b/src/rmarkdown/knit.ts
@@ -137,7 +137,7 @@ export class RMarkdownKnitManager extends RMarkdownManager {
         // precedence:
         // knit > site > configuration
         if (yamlParams?.['knit']) {
-            const knitParam = yamlParams['knit'];
+            const knitParam = yamlParams['knit'].trim();
             knitCommand = outputFormat ?
                 `${knitParam}(${docPath}, output_format = '${outputFormat}')` :
                 `${knitParam}(${docPath})`;


### PR DESCRIPTION
# What problem did you solve?

Closes #1403. Smart knitting was failing for multi-line custom knits because the filepath argument was being put on a newline (seemingly due to a linebreak). E.g.

```
[VSC-R] foo.Rmd process started
==> (function(input, ...) {
  rmarkdown::render(
    input,
    output_file = paste0(
      xfun::sans_ext(input), '-', Sys.Date(), '.html'
    ),
    envir = globalenv()
  )
})
('/run/media/elian/Main/Documents/Coding/R/enumr/foo.Rmd')
``` 

Trimming the whitespace from the knit param appears to fix this issue.

## How can I check this pull request?

Smart knit a document with the following frontmatter:

```
---
knit: |
  (function(input, ...) {
    rmarkdown::render(
      input,
      output_file = paste0(
        xfun::sans_ext(input), '-', Sys.Date(), '.html'
      ),
      envir = globalenv()
    )
  })
---
```

This will succeed with this PR, but will fail otherwise. The output file should be something like `foo-2024-02-23.html`