### PR TITLE
remove '.' as an R language editor.wordSeparators

### DIFF
--- a/package.json
+++ b/package.json
@@ -2037,6 +2037,11 @@
         }
       }
     },
+    "configurationDefaults": {
+      "[r]": {
+        "editor.wordSeparators": "`~!@#$%^&*()-=+[{]}\\|;:'\",<>/"
+      }
+    },
     "taskDefinitions": [
       {
         "type": "R",


### PR DESCRIPTION
# Removing '.' from the R word separators

Variable and function names in `R` can have the `.` character in them. 
Removing it from the `"[r]": "editor.wordSeparators"` enables selection of the whole variable or function name instead of just part of it.

## Example
Double-clicking on the base function `as.matrix` in the editor:
- before change: only selects either `as` or `matrix`.
- after change: selects `as.matrix`

I think the latter is a more desirable behaviour when editing an R file.
