### PR TITLE
`numeric_version()` wants character as of R 4.4

### DIFF
--- a/R/session/rstudioapi.R
+++ b/R/session/rstudioapi.R
@@ -237,7 +237,7 @@ versionInfo <- function() {
     list(
         citation = "",
         mode = "vscode",
-        version = numeric_version(0),
+        version = numeric_version("0"),
         release_name = "vscode"
     )
 }


### PR DESCRIPTION
I believe this should fix #1518.