### PR TITLE
Don't close stale issues

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/stale@v5
         with:
           days-before-issue-stale: 365
-          days-before-issue-close: 14
+          days-before-issue-close: -1
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 365 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."


### PR DESCRIPTION
- Change the github workflow to not autoclose issues, instead just marking issues as stale for manual review
- Closes #1498 