### PR TITLE
`numeric_version()` with character arg

### DIFF
--- a/R/session/rstudioapi.R
+++ b/R/session/rstudioapi.R
@@ -230,7 +230,7 @@ viewer <- function(url, height = NULL) {
 }
 
 getVersion <- function() {
-    numeric_version(0)
+    numeric_version("0")
 }
 
 versionInfo <- function() {


### PR DESCRIPTION
a follow-up on https://github.com/REditorSupport/vscode-R/pull/1520

There is one more occurrence where this function is called on numeric. On R 4.4.0 it is failing
```
r$> numeric_version(0)
Error in .make_numeric_version(x, strict, .standard_regexps()$valid_numeric_version) : 
  invalid non-character version specification 'x' (type: double)
```