### PR TITLE
Fix R terminal attachment when the `r.rterm` setting contains only the executable file name

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,9 @@
 {
-        "recommendations": [
-                "dbaeumer.vscode-eslint",
-                "GrapeCity.gc-excelviewer",
-                "ikuyadeu.devreplay",
-		"DavidAnson.vscode-markdownlint"
-	]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "GrapeCity.gc-excelviewer",
+    "ikuyadeu.devreplay",
+    "DavidAnson.vscode-markdownlint",
+    "amodio.tsl-problem-matcher"
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": [
-        "${workspaceFolder}/out/src/**/*.js"
+        "${workspaceFolder}/dist/**/*.js"
       ],
       "preLaunchTask": "watchAll"
     },
@@ -27,7 +27,7 @@
         "--disable-extensions"
       ],
       "outFiles": [
-        "${workspaceFolder}/out/src/**/*.js"
+        "${workspaceFolder}/dist/**/*.js"
       ],
       "preLaunchTask": "watchAll"
     },
@@ -38,10 +38,10 @@
       "runtimeExecutable": "${execPath}",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}",
-        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+        "--extensionTestsPath=${workspaceFolder}/dist/test/suite/index"
       ],
       "outFiles": [
-        "${workspaceFolder}/out/test/**/*.js"
+        "${workspaceFolder}/dist/test/**/*.js"
       ],
       "preLaunchTask": "npm: pretest"
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,16 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
-    },
-    "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
-    },
-    "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-    "r.lsp.diagnostics": true,
-    "editor.codeActionsOnSave": {
-        "source.fixAll.markdownlint": true
-    }
+  "files.exclude": {
+    "out": false, // set this to true to hide the "out" folder with the compiled JS files
+    "dist": false
+  },
+  "search.exclude": {
+    "out": true, // set this to false to include "out" folder in search results
+    "dist": true
+  },
+  "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
+  "r.lsp.diagnostics": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.markdownlint": "explicit"
+  }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -39,7 +39,7 @@
     {
       "type": "npm",
       "script": "watch",
-      "problemMatcher": "$tsc-watch",
+      "problemMatcher": "$ts-checker-eslint-webpack-watch",
       "isBackground": true,
       "presentation": {
         "reveal": "never"

--- a/package.json
+++ b/package.json
@@ -2091,6 +2091,7 @@
     "@types/express": "^4.17.12",
     "@types/fs-extra": "^9.0.11",
     "@types/glob": "^8.0.0",
+    "@types/highlight.js": "^10.1.0",
     "@types/js-yaml": "^4.0.2",
     "@types/mocha": "^8.2.2",
     "@types/node": "^18.17.1",
@@ -2101,7 +2102,6 @@
     "@typescript-eslint/eslint-plugin": "^5.30.0",
     "@typescript-eslint/parser": "^5.30.0",
     "@vscode/test-electron": "^2.2.3",
-    "@types/highlight.js": "^10.1.0",
     "copy-webpack-plugin": "^9.0.0",
     "devreplay": "^1.9.31",
     "eslint": "^7.28.0",
@@ -2116,7 +2116,6 @@
   "dependencies": {
     "ag-grid-community": "^31.3.2",
     "cheerio": "1.0.0-rc.12",
-    "crypto": "^1.0.1",
     "ejs": "^3.1.10",
     "fs-extra": "^10.0.0",
     "highlight.js": "^11.9.0",

--- a/package.json
+++ b/package.json
@@ -2082,7 +2082,7 @@
     "watchHelp": "tsc -p ./html/help --watch",
     "watchHttpgd": "tsc -p ./html/httpgd --watch",
     "pretest": "tsc -p ./",
-    "test": "node ./out/test/runTest.js",
+    "test": "node ./dist/test/runTest.js",
     "lint": "eslint src --ext ts"
   },
   "devDependencies": {

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -179,7 +179,7 @@ let panel: vscode.WebviewPanel | undefined = undefined;
 export async function updateGuestPlot(file: string): Promise<void> {
     const plotContent = await readContent(file, 'base64');
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    
+
     const guestPlotView: vscode.ViewColumn = asViewColumn(config().get<string>('session.viewers.viewColumn.plot'), vscode.ViewColumn.Two);
     if (plotContent) {
         if (panel) {

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -141,7 +141,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
     const termOptions = await makeTerminalOptions();
     const termPath = termOptions.shellPath;
     if(!termPath){
-        void vscode.window.showErrorMessage('Could not find R path. Please check r.term and r.path setting.');
+        void vscode.window.showErrorMessage('Could not find R path. Please check r.rterm and r.rpath setting.');
         return false;
     } else if(!fs.existsSync(termPath)){
         void vscode.window.showErrorMessage(`Cannot find R client at ${termPath}. Please check r.rterm setting.`);

--- a/src/rmarkdown/preview.ts
+++ b/src/rmarkdown/preview.ts
@@ -5,7 +5,6 @@ import * as cheerio from 'cheerio';
 import path = require('path');
 import crypto = require('crypto');
 
-
 import { config, readContent, setContext, escapeHtml, UriIcon, saveDocument, getRpath, DisposableProcess } from '../util';
 import { extensionContext, tmpDir } from '../extension';
 import { knitDir } from './knit';
@@ -425,4 +424,3 @@ export class RMarkdownPreviewManager extends RMarkdownManager {
         void preview.refreshContent(this.useCodeTheme);
     }
 }
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
-
 {
     "compilerOptions": {
         "module": "commonjs",
         "target": "ES2021",
-        "outDir": "out",
+        "outDir": "dist",
         "lib": [
             "ES2021"
         ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,48 +6,48 @@ const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
-  target: 'node', // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
+    target: 'node', // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
 
-  entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
-  output: {
+    entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
+    output: {
     // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'extension.js',
-    libraryTarget: 'commonjs2',
-    devtoolModuleFilenameTemplate: '../[resource-path]'
-  },
-  devtool: 'source-map',
-  externals: {
-    'utf-8-validate': 'commonjs utf-8-validate',
-    bufferutil: 'commonjs bufferutil',
-    vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
-  },
-  resolve: {
+        path: path.resolve(__dirname, 'dist'),
+        filename: 'extension.js',
+        libraryTarget: 'commonjs2',
+        devtoolModuleFilenameTemplate: '../[resource-path]'
+    },
+    devtool: 'source-map',
+    externals: {
+        'utf-8-validate': 'commonjs utf-8-validate',
+        bufferutil: 'commonjs bufferutil',
+        vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    },
+    resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
-    extensions: ['.ts', '.js']
-  },
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        exclude: /node_modules/,
-        use: [
-          {
-            loader: 'ts-loader'
-          }
+        extensions: ['.ts', '.js']
+    },
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'ts-loader'
+                    }
+                ]
+            }
         ]
-      }
-    ]
-  },
-  plugins: [
-    new CopyPlugin({
-      patterns: [
-        { from: './node_modules/jquery/dist/jquery.min.js', to: 'resources' },
-        { from: './node_modules/jquery.json-viewer/json-viewer', to: 'resources' },
-        { from: './node_modules/ag-grid-community/dist/ag-grid-community.min.noStyle.js', to: 'resources' },
-        { from: './node_modules/ag-grid-community/styles/ag-grid.min.css', to: 'resources' },
-        { from: './node_modules/ag-grid-community/styles/ag-theme-balham.min.css', to: 'resources' },
-      ]
-    }),
-  ],
+    },
+    plugins: [
+        new CopyPlugin({
+            patterns: [
+                { from: './node_modules/jquery/dist/jquery.min.js', to: 'resources' },
+                { from: './node_modules/jquery.json-viewer/json-viewer', to: 'resources' },
+                { from: './node_modules/ag-grid-community/dist/ag-grid-community.min.noStyle.js', to: 'resources' },
+                { from: './node_modules/ag-grid-community/styles/ag-grid.min.css', to: 'resources' },
+                { from: './node_modules/ag-grid-community/styles/ag-theme-balham.min.css', to: 'resources' },
+            ]
+        }),
+    ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,11 +1040,6 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
-
 css-select@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"


### PR DESCRIPTION
# What problem did you solve?

This PR fixes R terminal attachment when the `r.rterm` setting contains only the executable file name.
It takes into account if the executable file name already contains the `.exe` extension in case of the `win32` platform.

In addition, this PR:
- fixes `launch.json` and changes `outDir` to `dist` in all places to fix the extension debugging in VSCode;
- switches to the Node.js built-in `crypto` module from the deprecated external one;
- adds a proper `problemMatcher` to the `npm watch` task (the required extension `amodio.tsl-problem-matcher` is added to the `extensions.json`);
- updates `settings.json` file and fixes formatting in some files;
- fixes an error message when the extension cannot find the R path.

I would love to hear your thoughts and suggestions on this!

Looking forward to your review and feedback. Thanks!