### PR TITLE
Show sidebar icon only when extension is active

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
         {
           "id": "workspaceViewer",
           "title": "R",
-          "icon": "./images/Rlogo.svg"
+          "icon": "./images/Rlogo.svg",
+          "when": "r.isActive"
         }
       ]
     },


### PR DESCRIPTION
Fixes #1572. Note that I am completely new to VSC extensions, so I've probably missed something, but I think this change is what other extensions like Julia or Python are doing.

I also tried to add `"onLanguage:r"` to the `"activationEvents"` array, but this does not seem to be necessary (it shows me a quick fix message "This activation event can be removed as VS Code generates these automatically from your package.json contribution declarations.").
