### PR TITLE
Update data viewer so that only single window will be used for the same data

### DIFF
--- a/R/session/init.R
+++ b/R/session/init.R
@@ -17,7 +17,7 @@ init_first <- function() {
     }
 
     # check required packages
-    required_packages <- c("jsonlite", "rlang")
+    required_packages <- c("jsonlite", "rlang", "data.table")
     missing_packages <- required_packages[
         !vapply(required_packages, requireNamespace,
             logical(1L), quietly = TRUE

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "activationEvents": [
     "workspaceContains:**/*.{rproj,Rproj,r,R,rd,Rd,rmd,Rmd}",
     "onCommand:r.runSelectionInActiveTerm",
-    "onWebviewPanel:rhelp"
+    "onWebviewPanel:rhelp",
+    "onWebviewPanel:rdataviewer"
   ],
   "main": "./dist/extension",
   "contributes": {
@@ -1871,6 +1872,11 @@
             }
           },
           "additionalProperties": false
+        },
+        "r.dataViewer.reuseWindow": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Reuse the existing data viewer window when `View()` is called multiple times. When enabled, only one data viewer window will be shown and refreshed with new data."
         },
         "r.rtermSendDelay": {
           "type": "integer",

--- a/src/liveShare/shareSession.ts
+++ b/src/liveShare/shareSession.ts
@@ -36,6 +36,7 @@ export interface IRequest {
     url?: string;
     requestPath?: string;
     uuid?: number;
+    dataview_uuid?: string;  // Add this property
     tempdir?: string;
     version?: string;
     info?: {
@@ -149,7 +150,7 @@ export async function updateGuestRequest(file: string, force: boolean = false): 
                 if (request.source && request.type && request.title && request.file
                     && request.viewer !== undefined) {
                     await showDataView(request.source,
-                        request.type, request.title, request.file, request.viewer);
+                        request.type, request.title, request.file, request.viewer, request.dataview_uuid);
                 }
                 break;
             }


### PR DESCRIPTION
This PR fixes the issue that `View(data table)` will create multiple data viewer windows on the same `data table`. 
It creates a unique ID (`dataview_uuid`) for the `data table` based on the title, and checks if an existing window with this ID has already existed. 


https://github.com/user-attachments/assets/b580b641-0537-42c7-a0b2-760758c53dc7


Love to hear your feedback on whether this could be incorporated into the extension. 
