### PR TITLE
Split chunk options between R and Rmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -1471,6 +1471,35 @@
           "additionalItems": false,
           "additionalProperties": false
         },
+        "r.chunks.enable": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable code chunks in plain R files. When enabled, R files will show code chunk functionality (e.g., 'Run Chunk' buttons) for sections marked with `# %%`. When disabled, plain R files will not display code chunk features, though R Markdown (.Rmd) files are unaffected.\n\n- This setting only affects `.R` files, not `.Rmd` files\n- Disable this if you prefer to use R files without chunk-based workflow\n- CodeLens commands are customizable via `#r.rmarkdown.codeLensCommands#`"
+        },
+        "r.chunks.codeLensCommands": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "r.selectCurrentChunk",
+              "r.runCurrentChunk",
+              "r.runCurrentChunkAndMove",
+              "r.runAboveChunks",
+              "r.runCurrentAndBelowChunks",
+              "r.runBelowChunks",
+              "r.runAllChunks",
+              "r.runPreviousChunk",
+              "r.runNextChunk",
+              "r.goToPreviousChunk",
+              "r.goToNextChunk"
+            ]
+          },
+          "default": [
+            "r.runCurrentChunk",
+            "r.runAboveChunks"
+          ],
+          "description": "Customize R file CodeLens, which are inline commands/buttons e.g. 'Run Chunk' shown on the first line of each code chunk. \nCustomize both the commands AND its orders (that is, CodeLens respect user-specified orders):"
+        },
         "r.helpPanel.enableSyntaxHighlighting": {
           "type": "boolean",
           "default": true,

--- a/src/rmarkdown/chunks.ts
+++ b/src/rmarkdown/chunks.ts
@@ -396,10 +396,11 @@ export function selectCurrentChunk(chunks: RMarkdownChunk[] = _getChunks(),
     );
 }
 
-export function getCodeLenses(chunks: RMarkdownChunk[], token: vscode.CancellationToken): vscode.CodeLens[] {
+export function getCodeLenses(chunks: RMarkdownChunk[], token: vscode.CancellationToken, isRFile?: boolean): vscode.CodeLens[] {
 
     const enabledCodeLens = config().get<boolean>('rmarkdown.enableCodeLens');
-    if (enabledCodeLens === false) {
+    const enabledInRFiles = config().get<boolean>('chunks.enable');
+    if ((isRFile && enabledInRFiles === false) || (!isRFile && enabledCodeLens === false)) {
         return [];
     }
     
@@ -485,13 +486,19 @@ export function getCodeLenses(chunks: RMarkdownChunk[], token: vscode.Cancellati
 
     // For default options, both options and sort order are based on options specified in package.json.
     // For user-specified options, both options and sort order are based on options specified in settings UI or settings.json.
-    const rmdCodeLensCommands: string[] = config().get('rmarkdown.codeLensCommands', []);
+    let codeLensCommands: string[];
+    if (isRFile) {
+        codeLensCommands = config().get('chunks.codeLensCommands', []);
+    } else {
+        codeLensCommands = config().get('rmarkdown.codeLensCommands', []);
+    }
+
     codeLenses = codeLenses.
-        filter(e => e.command && rmdCodeLensCommands.includes(e.command.command)).
+        filter(e => e.command && codeLensCommands.includes(e.command.command)).
         sort(function (a, b) {
             if (!a.command || !b.command) { return 0; }
-            const sorted = rmdCodeLensCommands.indexOf(a.command.command) -
-                rmdCodeLensCommands.indexOf(b.command.command);
+            const sorted = codeLensCommands.indexOf(a.command.command) -
+                codeLensCommands.indexOf(b.command.command);
             return sorted;
         });
 

--- a/src/rmarkdown/index.ts
+++ b/src/rmarkdown/index.ts
@@ -114,10 +114,11 @@ export class RMarkdownCodeLensProvider implements vscode.CodeLensProvider {
 
         // Highlight chunks
         this.highlight(chunks, document);        
-
+        
         // Loop through chunks and setup
+        const isRDoc = isRDocument(document);
         const codeLenses = getCodeLenses(
-            chunks, token
+            chunks, token, isRDoc
         );
 
         return codeLenses;


### PR DESCRIPTION
I'm working on a small extension to work with `ark` in an interactive window in vscode. I realized that the option to enable/disable code chunks is the same for `.Rmd` and `.R` files. This might not be desired behavior, so this small PR separates the two into separate options