### PR TITLE
Allow bracketedPaste on win32 platform

### DIFF
--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -271,10 +271,8 @@ export async function runTextInTerm(text: string, execute: boolean = true): Prom
             return;
         }
         if (config().get<boolean>('bracketedPaste')) {
-            if (process.platform !== 'win32') {
-                // Surround with ANSI control characters for bracketed paste mode
-                text = `\x1b[200~${text}\x1b[201~`;
-            }
+            // Surround with ANSI control characters for bracketed paste mode
+            text = `\x1b[200~${text}\x1b[201~`;
             term.sendText(text, execute);
         } else {
             const rtermSendDelay: number = config().get('rtermSendDelay') || 8;


### PR DESCRIPTION
latest radian seems to correctly support bracketed paste, and `bracketedPaste` defaults to disabled, so leaving this switch to windows users to control might be reasonable.