### PR TITLE
feat: Add configurable working directory support for R processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Go to the installation wiki pages ([Windows](https://github.com/REditorSupport/v
 
 * [Interacting with R terminals](https://github.com/REditorSupport/vscode-R/wiki/Interacting-with-R-terminals): Sending code to terminals, running multiple terminals, working with remote servers.
 
+* **Configurable R working directory**: Run R processes from subdirectories (e.g., for renv environments) by setting `r.workingDirectory`.
+
 * [Package development](https://github.com/REditorSupport/vscode-R/wiki/Package-development): Build, test, install, load all and other commands from devtools.
 
 * [Keyboard shortcuts](https://github.com/REditorSupport/vscode-R/wiki/Keyboard-shortcuts): Built-in and customizable keyboard shortcuts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "mocha": "^11.1.0",
         "sinon": "^15.0.1",
         "ts-loader": "^9.3.1",
-        "typescript": "^4.7.2",
+        "typescript": "^4.9.5",
         "webpack": "^5.99.6",
         "webpack-cli": "^4.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -1349,6 +1349,12 @@
           "default": false,
           "markdownDescription": "Use renv library paths to launch R background processes (R languageserver, help server, etc.)."
         },
+        "r.workingDirectory": {
+          "type": "string",
+          "default": "",
+          "scope": "resource",
+          "markdownDescription": "Specifies the working directory for R processes (Language Server and terminals). If not set, defaults to the workspace root. Supports variables like `${workspaceFolder}`. Examples:\n- `${workspaceFolder}/src/r-project` for subdirectory R projects\n- `${workspaceFolder}/analysis/env` for renv environments in subdirectories\n- `${fileDirname}` to use the directory of the current file"
+        },
         "r.lsp.enabled": {
           "type": "boolean",
           "default": true,
@@ -2017,7 +2023,7 @@
     "mocha": "^11.1.0",
     "sinon": "^15.0.1",
     "ts-loader": "^9.3.1",
-    "typescript": "^4.7.2",
+    "typescript": "^4.9.5",
     "webpack": "^5.99.6",
     "webpack-cli": "^4.10.0"
   },

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -10,7 +10,7 @@ import * as util from './util';
 import * as selection from './selection';
 import { getSelection } from './selection';
 import { cleanupSession } from './session';
-import { config, delay, getRterm, getCurrentWorkspaceFolder } from './util';
+import { config, delay, getRterm, getCurrentWorkspaceFolder, resolveRWorkingDirectory } from './util';
 import { rGuestService, isGuestSession } from './liveShare';
 import * as fs from 'fs';
 export let rTerm: vscode.Terminal | undefined = undefined;
@@ -115,14 +115,15 @@ export async function runFromLineToEnd(): Promise<void>  {
 }
 
 export async function makeTerminalOptions(): Promise<vscode.TerminalOptions> {
-    const workspaceFolderPath = getCurrentWorkspaceFolder()?.uri.fsPath;
+    const workspaceFolder = getCurrentWorkspaceFolder();
+    const workingDirectory = resolveRWorkingDirectory(workspaceFolder?.uri);
     const termPath = await getRterm();
     const shellArgs: string[] = config().get<string[]>('rterm.option')?.map(util.substituteVariables) || [];
     const termOptions: vscode.TerminalOptions = {
         name: 'R Interactive',
         shellPath: termPath,
         shellArgs: shellArgs,
-        cwd: workspaceFolderPath,
+        cwd: workingDirectory,
     };
     const newRprofile = extensionContext.asAbsolutePath(path.join('R', 'session', 'profile.R'));
     const initR = extensionContext.asAbsolutePath(path.join('R', 'session','init.R'));


### PR DESCRIPTION
- Add r.workingDirectory configuration setting with variable substitution
- Support ${workspaceFolder}, ${userHome}, ${fileWorkspaceFolder}, ${fileDirname}
- Update Language Server integration to use configured working directory
- Update R terminal creation to use configured working directory
- Add resolveRWorkingDirectory() utility function with security validation
- It's backward compatible in the sense that it defaults to workspace root