### PR TITLE
fix: prevent linting of deleted temp files

### DIFF
--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -2,6 +2,7 @@ import * as os from 'os';
 import { dirname } from 'path';
 import * as net from 'net';
 import { URL } from 'url';
+import { existsSync } from 'fs';
 import { LanguageClient, LanguageClientOptions, StreamInfo, DocumentFilter, ErrorAction, CloseAction, RevealOutputChannelOn } from 'vscode-languageclient/node';
 import { Disposable, workspace, Uri, TextDocument, WorkspaceConfiguration, OutputChannel, window, WorkspaceFolder } from 'vscode';
 import { DisposableProcess, getRLibPaths, getRpath, promptToInstallRPackage, spawn, substituteVariables } from './util';
@@ -148,6 +149,26 @@ export class LanguageService implements Disposable {
                     };
                 },
             },
+            middleware: {
+                handleDiagnostics: (uri, diagnostics, next) => {
+                    if (!uri.fsPath) {
+                        next(uri, []);
+                        return;
+                    }
+
+                    if (uri.scheme !== 'file' && uri.scheme !== 'untitled' && uri.scheme !== 'vscode-notebook-cell') {
+                        next(uri, []);
+                        return;
+                    }
+
+                    if (uri.scheme === 'file' && !existsSync(uri.fsPath)) {
+                        next(uri, []);
+                        return;
+                    }
+
+                    next(uri, diagnostics);
+                },
+            }
         };
 
         // Create the language client and start the client.
@@ -186,6 +207,10 @@ export class LanguageService implements Disposable {
     private startMultiLanguageService(self: LanguageService): void {
         async function didOpenTextDocument(document: TextDocument) {
             if (document.uri.scheme !== 'file' && document.uri.scheme !== 'untitled' && document.uri.scheme !== 'vscode-notebook-cell') {
+                return;
+            }
+
+            if (document.uri.scheme === 'file' && (!document.uri.fsPath || !existsSync(document.uri.fsPath))) {
                 return;
             }
 
@@ -312,8 +337,11 @@ export class LanguageService implements Disposable {
             return this.startMultiLanguageService(self);
         } else {
             const documentSelector: DocumentFilter[] = [
-                { language: 'r' },
-                { language: 'rmd' },
+                { scheme: 'file', language: 'r' },
+                { scheme: 'file', language: 'rmd' },
+                { scheme: 'untitled', language: 'r' },
+                { scheme: 'untitled', language: 'rmd' },
+                { scheme: 'vscode-notebook-cell', language: 'r' },
             ];
 
             const workspaceFolder = workspace.workspaceFolders?.[0];


### PR DESCRIPTION
This PR fixes stale diagnostics being kept for temporary/deleted documents (for example git diff/revision views), which could accumulate in the 'Problems' panel as `path[1]="": No such file or directory` errors. See issue #1630 for details (including a video and screenshot).

Changes:
- Drop diagnostics when the URI has an empty file path.
- Drop diagnostics for unsupported URI schemes.
- Drop diagnostics for file URIs that no longer exist.
- Restrict single-server document selector to supported schemes only, e.g.:
  - `file:///Users/me/project/script.R` => selected and linted
  - `untitled:Untitled-1` => selected and linted
  - `vscode-notebook-cell:/...` => selected and linted
  - `git:/...` (diff/revision temp document) => not selected
  - other temporary/non-standard schemes => not selected

Validation:
- Reproduced with repeated open/click/close of git diff temporary revisions on my local machine (VSCode=1.109.5, R=4.5.2, MacOS=26.2, Model=MacBook Pro M2 Max)
- Confirmed stale missing-path diagnostics no longer accumulate.
- Confirmed real diagnostics for existing files are still shown correctly.
- Packaged and installed VSIX for manual verification (available for download at [toscm/vscode-R/releases/tag/v2.8.6-tempfix.1](https://github.com/toscm/vscode-R/releases/tag/v2.8.6-tempfix.1))
