### PR TITLE
implement rstudioapi::showPrompt() and rstudioapi::askForPassword()

### DIFF
--- a/R/session/rstudioapi.R
+++ b/R/session/rstudioapi.R
@@ -265,12 +265,12 @@ getConsoleEditorContext <- .vsc_not_yet_implemented
 sourceMarkers <- .vsc_not_yet_implemented
 documentClose <- .vsc_not_yet_implemented
 showPrompt <- function(title, message, default = NULL) {
-    response <- rstudioapi_call("show_prompt", title = title, message = message, default = default)
+    response <- rstudioapi_call("show_prompt", title = title, message = message, default = default, timeout = 120)
     response$response
 }
 
 askForPassword <- function(prompt = "Please enter your password") {
-    response <- rstudioapi_call("ask_for_password", prompt = prompt)
+    response <- rstudioapi_call("ask_for_password", prompt = prompt, timeout = 120)
     response$response
 }
 

--- a/R/session/rstudioapi.R
+++ b/R/session/rstudioapi.R
@@ -264,7 +264,16 @@ sendToConsole <- function(code, execute = TRUE, echo = TRUE, focus = FALSE) {
 getConsoleEditorContext <- .vsc_not_yet_implemented
 sourceMarkers <- .vsc_not_yet_implemented
 documentClose <- .vsc_not_yet_implemented
-showPrompt <- .vsc_not_yet_implemented
+showPrompt <- function(title, message, default = NULL) {
+    response <- rstudioapi_call("show_prompt", title = title, message = message, default = default)
+    response$response
+}
+
+askForPassword <- function(prompt = "Please enter your password") {
+    response <- rstudioapi_call("ask_for_password", prompt = prompt)
+    response$response
+}
+
 showQuestion <- .vsc_not_yet_implemented
 updateDialog <- .vsc_not_yet_implemented
 openProject <- .vsc_not_yet_implemented

--- a/R/session/rstudioapi_util.R
+++ b/R/session/rstudioapi_util.R
@@ -1,5 +1,9 @@
-rstudioapi_call <- function(action, ...) {
-    request_response("rstudioapi", action = action, args = list(...))
+rstudioapi_call <- function(action, ..., timeout = NULL) {
+    args <- list("rstudioapi", action = action, args = list(...))
+    if (!is.null(timeout)) {
+        args$timeout <- timeout
+    }
+    do.call(request_response, args)
 }
 
 rstudioapi_patch_hook <- function(api_env) {

--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -833,14 +833,14 @@ if (rstudioapi_enabled()) {
         }
     }
 
-    request_response <- function(command, ...) {
+    request_response <- function(command, ..., timeout = response_timeout) {
         request(command, ..., sd = dir_session)
         wait_start <- Sys.time()
         while (!get_response_lock()) {
-            if ((Sys.time() - wait_start) > response_timeout) {
+            if ((Sys.time() - wait_start) > timeout) {
                 stop(
                     "Did not receive a response from VSCode-R API within ",
-                    response_timeout, " seconds."
+                    timeout, " seconds."
                 )
             }
             Sys.sleep(0.1)

--- a/src/rstudioapi.ts
+++ b/src/rstudioapi.ts
@@ -41,6 +41,16 @@ export async function dispatchRStudioAPICall(action: string, args: any, sd: stri
             await writeSuccessResponse(sd);
             break;
         }
+        case 'show_prompt': {
+            const result = await showPrompt(args.title, args.message, args.default);
+            await writeResponse(result, sd);
+            break;
+        }
+        case 'ask_for_password': {
+            const result = await askForPassword(args.prompt);
+            await writeResponse(result, sd);
+            break;
+        }
         case 'navigate_to_file': {
             await navigateToFile(args.file, args.line, args.column);
             await writeSuccessResponse(sd);
@@ -162,6 +172,27 @@ export function showDialog(message: string): void {
 
     void window.showInformationMessage(message);
 
+}
+
+export async function showPrompt(
+    title: string, message: string, defaultValue?: string
+): Promise<{ response: string | null }> {
+    const result = await window.showInputBox({
+        title: title,
+        prompt: message,
+        value: defaultValue ?? '',
+    });
+    return { response: result ?? null };
+}
+
+export async function askForPassword(
+    prompt: string
+): Promise<{ response: string | null }> {
+    const result = await window.showInputBox({
+        prompt: prompt,
+        password: true,
+    });
+    return { response: result ?? null };
 }
 
 export async function navigateToFile(file: string, line: number, column: number): Promise<void>{


### PR DESCRIPTION
This would allow keybindings requiring prompts, like:

```javascript
        {
          "command":"r.runCommandWithSelectionOrWord",
          "args": "dplyr::count($$, .data[rstudioapi::showPrompt("dplyr::count()", "column?")])"
        }
```

or if we want to support multiple columns:

```javascript
        {
          "command":"r.runCommandWithSelectionOrWord",
          "args": "dplyr::count(df, !!!rlang::syms(strsplit(rstudioapi::showPrompt("dplyr::count()", "columns?"), "\\s*,\\s*")[[1]]))"
        }
```