### PR TITLE
refactor!: replace WebSocket/TCP transport with Unix socket / Windows named pipe

### DIFF
--- a/R/install_sess.R
+++ b/R/install_sess.R
@@ -1,10 +1,24 @@
 local({
     args <- commandArgs(trailingOnly = TRUE)
-    if (length(args) < 2) {
-        stop("Missing arguments: pkg_path and repo")
+    pkg_path <- Sys.getenv("VSCODE_R_SESS_PKG_PATH", unset = "")
+    if (!nzchar(pkg_path) && length(args) >= 1) {
+        pkg_path <- args[1]
     }
-    pkg_path <- args[1]
-    repo <- args[2]
+
+    if (!nzchar(pkg_path)) {
+        stop("Missing pkg_path (set VSCODE_R_SESS_PKG_PATH or pass as first command arg)")
+    }
+
+    repo <- Sys.getenv("VSCODE_R_SESS_REPO", unset = "")
+    if (!nzchar(repo) && length(args) >= 2) {
+        repo <- args[2]
+    }
+    if (!nzchar(repo)) {
+        repo <- getOption("repos")[["CRAN"]]
+    }
+    if (is.na(repo) || identical(repo, "@CRAN@")) {
+        repo <- ""
+    }
 
     if (!file.exists(file.path(pkg_path, "DESCRIPTION"))) {
         stop(paste("DESCRIPTION file not found in", pkg_path))
@@ -23,7 +37,11 @@ local({
 
     if (length(deps) > 0) {
         message("Installing dependencies: ", paste(deps, collapse = ", "))
-        install.packages(deps, repos = repo)
+        if (nzchar(repo)) {
+            install.packages(deps, repos = repo)
+        } else {
+            install.packages(deps)
+        }
     }
 
     message("Installing sess package from: ", pkg_path)

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,7 @@
         "js-yaml": "^4.1.1",
         "node-fetch": "^2.7.0",
         "vscode-languageclient": "^9.0.1",
-        "vsls": "^1.0.4753",
-        "winreg": "^1.2.5",
-        "ws": "^8.19.0"
+        "winreg": "^1.2.5"
       },
       "devDependencies": {
         "@types/cheerio": "^0.22.35",
@@ -38,7 +36,6 @@
         "@types/sinon": "^10.0.20",
         "@types/vscode": "^1.75.0",
         "@types/winreg": "^1.2.36",
-        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "@vscode/test-cli": "^0.0.12",
@@ -877,28 +874,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@microsoft/servicehub-framework": {
-      "version": "2.6.74",
-      "resolved": "https://registry.npmjs.org/@microsoft/servicehub-framework/-/servicehub-framework-2.6.74.tgz",
-      "integrity": "sha512-QJ//zzvxffupIkzupnVbMYY5YDOP+g5FlG6x0Pl7svRyq8pAouiibckJJcZlMtsMypKWwAnVBKb9/sonEOsUxw==",
-      "license": "LICENSE.txt",
-      "dependencies": {
-        "await-semaphore": "^0.1.3",
-        "msgpack-lite": "^0.1.26",
-        "nerdbank-streams": "2.5.60",
-        "strict-event-emitter-types": "^2.0.0",
-        "vscode-jsonrpc": "^4.0.0"
-      }
-    },
-    "node_modules/@microsoft/servicehub-framework/node_modules/vscode-jsonrpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1647,12 +1622,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/await-semaphore": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/await-semaphore/-/await-semaphore-0.1.3.tgz",
-      "integrity": "sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q==",
-      "license": "MIT"
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1777,18 +1746,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/cancellationtoken": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cancellationtoken/-/cancellationtoken-2.2.0.tgz",
-      "integrity": "sha512-uF4sHE5uh2VdEZtIRJKGoXAD9jm7bFY0tDRCzH4iLp262TOJ2lrtNHjMG2zc8H+GICOpELIpM7CGW5JeWnb3Hg==",
-      "license": "MIT"
-    },
-    "node_modules/caught": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/caught/-/caught-0.1.3.tgz",
-      "integrity": "sha512-DTWI84qfoqHEV5jHRpsKNnEisVCeuBDscXXaXyRLXC+4RD6rFftUNuTElcQ7LeO7w622pfzWkA1f6xu5qEAidw==",
-      "license": "MIT"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2746,12 +2703,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-lite": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.3.tgz",
-      "integrity": "sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw==",
-      "license": "MIT"
-    },
     "node_modules/execa": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -3475,26 +3426,6 @@
         "node": ">=18.18.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3557,12 +3488,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/int64-buffer": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
-      "integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA==",
-      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3686,6 +3611,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4213,21 +4139,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/msgpack-lite": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-      "integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
-      "license": "MIT",
-      "dependencies": {
-        "event-lite": "^0.1.1",
-        "ieee754": "^1.1.8",
-        "int64-buffer": "^0.1.9",
-        "isarray": "^1.0.0"
-      },
-      "bin": {
-        "msgpack": "bin/msgpack"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4241,18 +4152,6 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nerdbank-streams": {
-      "version": "2.5.60",
-      "resolved": "https://registry.npmjs.org/nerdbank-streams/-/nerdbank-streams-2.5.60.tgz",
-      "integrity": "sha512-saQaMyTtVDAEc+S+BPXKM6K1AF3FyrorFSDzaCkdmtDe2kZzu1aYPQZNLmnxJhxbTcghYrEmYFFoaDxBDVadCw==",
-      "license": "MIT",
-      "dependencies": {
-        "await-semaphore": "^0.1.3",
-        "cancellationtoken": "^2.0.1",
-        "caught": "^0.1.3",
-        "msgpack-lite": "^0.1.26"
-      }
     },
     "node_modules/nise": {
       "version": "5.1.9",
@@ -5186,12 +5085,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strict-event-emitter-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
-      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
-      "license": "ISC"
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -5685,15 +5578,6 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "license": "MIT"
-    },
-    "node_modules/vsls": {
-      "version": "1.0.4753",
-      "resolved": "https://registry.npmjs.org/vsls/-/vsls-1.0.4753.tgz",
-      "integrity": "sha512-hmrsMbhjuLoU8GgtVfqhbV4ZkGvDpLV2AFmzx+cCOGNra2qk0Q36dYkfwENqy/vJVQ/2/lhxcn+69FYnKQRhgg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "dependencies": {
-        "@microsoft/servicehub-framework": "^2.6.74"
-      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -2000,7 +2000,6 @@
     "@types/sinon": "^10.0.20",
     "@types/vscode": "^1.75.0",
     "@types/winreg": "^1.2.36",
-    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@vscode/test-cli": "^0.0.12",
@@ -2026,8 +2025,7 @@
     "js-yaml": "^4.1.1",
     "node-fetch": "^2.7.0",
     "vscode-languageclient": "^9.0.1",
-    "winreg": "^1.2.5",
-    "ws": "^8.19.0"
+    "winreg": "^1.2.5"
   },
   "extensionDependencies": [
     "REditorSupport.r-syntax"

--- a/sess/DESCRIPTION
+++ b/sess/DESCRIPTION
@@ -8,12 +8,14 @@ Description: Implements a high-performance HTTP and WebSocket server for R Inter
 License: MIT
 Encoding: UTF-8
 LazyData: true
-Imports: 
-    websocket,
+Imports:
+    processx (>= 3.5.0),
     later,
     jsonlite,
     utils,
     methods,
     rstudioapi,
     svglite
+Suggests:
+    testthat (>= 3.0.0)
 Config/roxygen2/version: 8.0.0

--- a/sess/DESCRIPTION
+++ b/sess/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Modern R IPC Server
 Version: 3.0.0
 Author: Gemini
 Maintainer: Gemini <gemini@example.com>
-Description: Implements a high-performance HTTP and WebSocket server for R Inter-Process Communication, replacing legacy file-system watchers. This package provides a generic protocol for IDEs and other clients to communicate with an R session.
+Description: Implements a high-performance IPC client for R sessions using Unix domain sockets and Windows named pipes. Replaces legacy file-system watcher based workflows while keeping JSON-RPC communication semantics for IDE/editor integration.
 License: MIT
 Encoding: UTF-8
 LazyData: true

--- a/sess/R/dispatch.R
+++ b/sess/R/dispatch.R
@@ -7,7 +7,14 @@ ipc_write <- function(data) {
   line <- paste0(jsonlite::toJSON(data, auto_unbox = TRUE, null = "null", force = TRUE), "\n")
   tryCatch(
     {
-      processx::conn_write(con, line)
+      remainder <- processx::conn_write(con, line)
+
+      # processx::conn_write() may perform a partial write and return
+      # remaining bytes; keep writing until all data is flushed.
+      while (is.raw(remainder) && length(remainder) > 0) {
+        remainder <- processx::conn_write(con, remainder)
+      }
+
       invisible(TRUE)
     },
     error = function(e) {

--- a/sess/R/dispatch.R
+++ b/sess/R/dispatch.R
@@ -1,6 +1,23 @@
-#' Send a message to the client via WebSocket (JSON-RPC 2.0)
-#'
-#' This is the internal workhorse for both Notifications and Requests.
+#' Write a JSON object to the IPC pipe as a NDJSON line (internal)
+#' @keywords internal
+ipc_write <- function(data) {
+  con <- .sess_env$con
+  if (is.null(con)) return(invisible(FALSE))
+
+  line <- paste0(jsonlite::toJSON(data, auto_unbox = TRUE, null = "null", force = TRUE), "\n")
+  tryCatch(
+    {
+      processx::conn_write(con, line)
+      invisible(TRUE)
+    },
+    error = function(e) {
+      warning("[sess] Failed to send IPC message: ", e$message)
+      invisible(FALSE)
+    }
+  )
+}
+
+#' Send a message to the client via IPC pipe (JSON-RPC 2.0)
 #'
 #' @param method String. The JSON-RPC method.
 #' @param params List. The parameters for the method.
@@ -8,7 +25,7 @@
 #' @return The result of the request if request=TRUE, otherwise TRUE if sent.
 #' @keywords internal
 rpc_send <- function(method, params = list(), request = FALSE) {
-  if (is.null(.sess_env$ws)) {
+  if (is.null(.sess_env$con)) {
     return(invisible(FALSE))
   }
 
@@ -24,45 +41,30 @@ rpc_send <- function(method, params = list(), request = FALSE) {
     msg$id <- req_id
   }
 
-  # Push over the websocket
-  payload <- jsonlite::toJSON(msg, auto_unbox = TRUE, null = "null", force = TRUE)
-  tryCatch(
-    {
-      .sess_env$ws$send(payload)
-    },
-    error = function(e) {
-      warning("Failed to send IPC message: ", e$message)
-      invisible(FALSE)
-    }
-  )
+  ipc_write(msg)
 
   if (!request) {
-    return(invisible(TRUE))
+    invisible(TRUE)
+  } else {
+    # NON-BLOCKING WAIT:
+    # Run later callbacks (which include poll_connection) while waiting for a response.
+    while (is.null(.sess_env$pending_responses[[req_id]])) {
+      later::run_now()
+      Sys.sleep(0.01)
+    }
+
+    response <- .sess_env$pending_responses[[req_id]]
+    .sess_env$pending_responses[[req_id]] <- NULL
+
+    if (inherits(response, "json_rpc_error")) {
+      stop(sprintf("JSON-RPC Error [%d]: %s", response$code, response$message))
+    }
+
+    response
   }
-
-  # NON-BLOCKING WAIT:
-  # Process HTTP/WS events in the background while blocking the R console execution
-  # This prevents the R event loop from locking up.
-  while (is.null(.sess_env$pending_responses[[req_id]])) {
-    later::run_now()
-    Sys.sleep(0.01)
-  }
-
-  # Retrieve and clean up response
-  response <- .sess_env$pending_responses[[req_id]]
-  .sess_env$pending_responses[[req_id]] <- NULL
-
-  # Handle JSON-RPC Errors if any
-  if (inherits(response, "json_rpc_error")) {
-    stop(sprintf("JSON-RPC Error [%d]: %s", response$code, response$message))
-  }
-
-  response
 }
 
-#' Notify the client via WebSocket (JSON-RPC 2.0 Notification)
-#'
-#' Pushes an event instantly to the client extension via the active WebSocket connection.
+#' Notify the client via IPC pipe (JSON-RPC 2.0 Notification)
 #'
 #' @param method A string representing the action (e.g., "dataview", "plot_updated")
 #' @param params A list containing the arguments for the command

--- a/sess/R/server.R
+++ b/sess/R/server.R
@@ -41,6 +41,14 @@ connect <- function(pipe_path = NULL, use_rstudioapi = TRUE, use_httpgd = TRUE) 
     return(invisible(NULL))
   }
 
+  # processx uses the \\?\pipe\ namespace on Windows.
+  # Normalize \\.\pipe\* paths from Node.js to improve compatibility.
+  if (.Platform$OS.type == "windows") {
+    if (startsWith(pipe_path, "\\\\.\\pipe\\")) {
+      pipe_path <- sub("^\\\\\\\\\\.\\\\pipe\\\\", "\\\\\\\\?\\\\pipe\\\\", pipe_path)
+    }
+  }
+
   print_async_msg <- function(msg) {
     prompt <- if (interactive()) getOption("prompt") else ""
     cat(sprintf("\r%s\n\n%s", msg, prompt))

--- a/sess/R/server.R
+++ b/sess/R/server.R
@@ -1,51 +1,42 @@
-#' Start the client R IPC connection
+#' Connect to the VS Code IPC server
 #'
-#' @param port Integer. The port of the VS Code WebSocket server.
-#'   If NULL, it will use SESS_PORT env var.
-#' @param token String. The authentication token. If NULL, it will use SESS_TOKEN env var.
-#' @param use_rstudioapi Logical. Should the rstudioapi emulation layer
-#'   be enabled? Defaults to TRUE.
-#' @param use_httpgd Logical. Should httpgd be used for plotting if available? Defaults to TRUE
+#' @param pipe_path Character. Path to the named pipe / Unix domain socket.
+#'   If NULL, uses the SESS_PIPE environment variable, then falls back to the
+#'   session JSON file written by the extension.
+#' @param use_rstudioapi Logical. Enable rstudioapi emulation. Defaults to TRUE.
+#' @param use_httpgd Logical. Use httpgd for plotting if available. Defaults to TRUE.
 #' @export
-connect <- function(port = NULL, token = NULL, use_rstudioapi = TRUE, use_httpgd = TRUE) {
-  # Initialize state
-  .sess_env$server <- NULL
-  .sess_env$ws <- NULL
+connect <- function(pipe_path = NULL, use_rstudioapi = TRUE, use_httpgd = TRUE) {
+  .sess_env$con <- NULL
   .sess_env$pending_responses <- list()
+  .sess_env$read_buffer <- ""
 
-  # Specific tempdir for vscode-R
   .sess_env$tempdir <- file.path(tempdir(), "sess")
   dir.create(.sess_env$tempdir, showWarnings = FALSE, recursive = TRUE)
 
-  # Temporary file for static plot serving
   .sess_env$latest_plot_path <- file.path(.sess_env$tempdir, "sess_plot.png")
 
-  is_manual <- (!is.null(port) && !is.na(port) && nzchar(port)) ||
-    (!is.null(token) && !is.na(token) && nzchar(token))
+  is_manual <- !is.null(pipe_path) && !is.na(pipe_path) && nzchar(pipe_path)
 
-  if (is.null(port) || is.na(port)) {
-    port <- Sys.getenv("SESS_PORT")
-  }
-  if (is.null(token) || is.na(token) || !nzchar(token)) {
-    token <- Sys.getenv("SESS_TOKEN")
+  if (is.null(pipe_path) || is.na(pipe_path)) {
+    pipe_path <- Sys.getenv("SESS_PIPE")
   }
 
-  # Derive file path for fallback/reconnection
+  # Fallback: read from session JSON file written by the extension
   pid <- Sys.getpid()
   home <- path.expand("~")
   file_path <- file.path(home, ".vscode-R", "sessions", sprintf("%d.json", pid))
 
-  if (!nzchar(port) || !nzchar(token)) {
+  if (!nzchar(pipe_path)) {
     if (file.exists(file_path)) {
       tryCatch({
-        config <- jsonlite::fromJSON(readLines(file_path, warn = FALSE))
-        port <- config$port
-        token <- config$token
+        cfg <- jsonlite::fromJSON(readLines(file_path, warn = FALSE))
+        pipe_path <- cfg$pipe
       }, error = function(e) NULL)
     }
   }
 
-  if (!nzchar(port) || !nzchar(token)) {
+  if (!nzchar(pipe_path)) {
     warning("[sess] Connection info not available. Cannot connect to VS Code.")
     return(invisible(NULL))
   }
@@ -56,120 +47,145 @@ connect <- function(port = NULL, token = NULL, use_rstudioapi = TRUE, use_httpgd
   }
 
   do_connect <- function() {
-    url <- sprintf("ws://127.0.0.1:%s/?token=%s", port, token)
-    ws <- websocket::WebSocket$new(
-      url,
-      autoConnect = FALSE,
-      accessLogChannels = "none",
-      errorLogChannels = "none"
+    con <- tryCatch(
+      processx::conn_connect_unix_socket(pipe_path, encoding = ""),
+      error = function(e) {
+        print_async_msg(sprintf("[sess] Failed to connect to IPC pipe: %s", e$message))
+        NULL
+      }
     )
+    if (is.null(con)) return()
 
-    ws$onOpen(function(event) {
-      .sess_env$ws <- ws
-      print_async_msg("[sess] Connected to VS Code")
+    .sess_env$con <- con
 
-      # Send the attach handshake immediately upon connection
-      notify_client("attach", list(
-        version = sprintf("%s.%s", R.version$major, R.version$minor),
-        pid = Sys.getpid(),
-        tempdir = .sess_env$tempdir,
-        wd = getwd(),
-        info = list(
-          command = commandArgs()[[1L]],
-          version = R.version.string,
-          start_time = format(Sys.time())
-        )
-      ))
-    })
+    # Send attach handshake
+    notify_client("attach", list(
+      version = sprintf("%s.%s", R.version$major, R.version$minor),
+      pid = Sys.getpid(),
+      tempdir = .sess_env$tempdir,
+      wd = getwd(),
+      info = list(
+        command = commandArgs()[[1L]],
+        version = R.version.string,
+        start_time = format(Sys.time())
+      )
+    ))
 
-    ws$onMessage(function(event) {
-      # Handle JSON-RPC 2.0 messages COMING FROM the client
-      payload <- tryCatch(jsonlite::fromJSON(event$data), error = function(e) NULL)
+    print_async_msg("[sess] Connected to VS Code")
 
-      if (!is.null(payload) && !is.null(payload$id)) {
-        if (!is.null(payload$method)) {
-          # It's a Request from the Client (e.g., 'workspace', 'plot_latest')
-          handlers <- list(
-            "workspace" = function(p) get_workspace_data(),
-            "hover" = function(p) handle_hover(p$expr),
-            "completion" = function(p) handle_complete(p$expr, p$trigger),
-            "plot_latest" = function(p) handle_plot_latest(p)
-          )
-
-          if (payload$method %in% names(handlers)) {
-            res <- tryCatch(
-              {
-                handlers[[payload$method]](payload$params)
-              },
-              error = function(e) {
-                warning(sprintf(
-                  "[sess] Error in handler for '%s': %s",
-                  payload$method, e$message
-                ))
-                NULL
-              }
-            )
-
-            succ_resp <- list(
-              jsonrpc = "2.0",
-              id = payload$id,
-              result = res
-            )
-            ws$send(jsonlite::toJSON(succ_resp, auto_unbox = TRUE, null = "null", force = TRUE))
-          } else {
-            err_resp <- list(
-              jsonrpc = "2.0",
-              id = payload$id,
-              error = list(code = -32601, message = "Method not found")
-            )
-            ws$send(jsonlite::toJSON(err_resp, auto_unbox = TRUE, null = "null", force = TRUE))
-          }
-        } else {
-          # It's a Response (to our RStudio API request)
-          if (!is.null(payload$result)) {
-            .sess_env$pending_responses[[as.character(payload$id)]] <-
-              payload$result
-          } else if (!is.null(payload$error)) {
-            .sess_env$pending_responses[[as.character(payload$id)]] <-
-              structure(payload$error, class = "json_rpc_error")
-          }
-        }
-      }
-    })
-
-    ws$onClose(function(event) {
-      .sess_env$ws <- NULL
-      if (is_manual) {
-        print_async_msg("[sess] Disconnected from VS Code.")
-        return()
-      }
-      print_async_msg("[sess] Disconnected from VS Code. Retrying in 5 seconds...")
-      later::later(function() {
-        if (file.exists(file_path)) {
-          tryCatch({
-            config <- jsonlite::fromJSON(readLines(file_path, warn = FALSE))
-            port <<- config$port
-            token <<- config$token
-          }, error = function(e) NULL)
-        }
-        do_connect()
-      }, 5)
-    })
-
-    ws$onError(function(event) {
-      print_async_msg(sprintf("[sess] WebSocket error: %s", event$message))
-    })
-
-    ws$connect()
+    # Start the polling loop
+    poll_connection()
   }
 
-  # Connect to VS Code
   do_connect()
 
-  # Register runtime hooks
   if (is.na(use_rstudioapi)) use_rstudioapi <- TRUE
   if (is.na(use_httpgd)) use_httpgd <- TRUE
   register_hooks(use_rstudioapi = use_rstudioapi, use_httpgd = use_httpgd)
 
   invisible(NULL)
+}
+
+#' Poll the IPC connection for incoming messages (internal)
+#'
+#' Runs as a recurring later callback; dispatches NDJSON messages from vscode.
+#' @keywords internal
+poll_connection <- function() {
+  con <- .sess_env$con
+  if (is.null(con)) return()
+
+  # Non-blocking poll: 0 ms timeout
+  ready <- tryCatch(
+    processx::poll(list(con), 0L),
+    error = function(e) NULL
+  )
+
+  if (!is.null(ready) && length(ready) > 0 && identical(ready[[1]], "ready")) {
+    chunk <- tryCatch(
+      processx::conn_read_chars(con),
+      error = function(e) {
+        .sess_env$con <- NULL
+        NULL
+      }
+    )
+
+    if (!is.null(chunk) && nzchar(chunk)) {
+      .sess_env$read_buffer <- paste0(.sess_env$read_buffer, chunk)
+      parts <- strsplit(.sess_env$read_buffer, "\n", fixed = TRUE)[[1]]
+
+      n <- length(parts)
+      # Keep any trailing partial line in the buffer
+      if (endsWith(.sess_env$read_buffer, "\n")) {
+        .sess_env$read_buffer <- ""
+      } else {
+        .sess_env$read_buffer <- parts[n]
+        parts <- parts[-n]
+      }
+
+      for (line in parts) {
+        line <- trimws(line)
+        if (!nzchar(line)) next
+        tryCatch(
+          dispatch_message(line),
+          error = function(e) {
+            warning("[sess] Error dispatching message: ", e$message)
+          }
+        )
+      }
+    }
+  }
+
+  later::later(poll_connection, 0.01)
+}
+
+#' Dispatch a single NDJSON line as a JSON-RPC message (internal)
+#' @keywords internal
+dispatch_message <- function(line) {
+  payload <- tryCatch(jsonlite::fromJSON(line, simplifyVector = FALSE), error = function(e) NULL)
+  if (is.null(payload)) return(invisible(NULL))
+
+  has_id <- !is.null(payload$id)
+  has_method <- !is.null(payload$method)
+
+  if (has_id && !has_method) {
+    # Response to a request we sent
+    key <- as.character(payload$id)
+    if (!is.null(payload$result)) {
+      .sess_env$pending_responses[[key]] <- payload$result
+    } else if (!is.null(payload$error)) {
+      .sess_env$pending_responses[[key]] <-
+        structure(payload$error, class = "json_rpc_error")
+    }
+  } else if (has_method && has_id) {
+    # Request from vscode → R must reply
+    handlers <- list(
+      "workspace" = function(p) get_workspace_data(),
+      "hover" = function(p) handle_hover(p$expr),
+      "completion" = function(p) handle_complete(p$expr, p$trigger),
+      "plot_latest" = function(p) handle_plot_latest(p)
+    )
+
+    if (payload$method %in% names(handlers)) {
+      res <- tryCatch(
+        handlers[[payload$method]](payload$params),
+        error = function(e) {
+          warning(sprintf("[sess] Error in handler for '%s': %s", payload$method, e$message))
+          NULL
+        }
+      )
+      rpc_reply(payload$id, result = res)
+    } else {
+      rpc_reply(payload$id, error = list(code = -32601L, message = "Method not found"))
+    }
+  }
+  # has_method && !has_id: unsolicited notification from vscode — ignore gracefully
+  invisible(NULL)
+}
+
+#' Send a JSON-RPC reply to a request (internal)
+#' @keywords internal
+rpc_reply <- function(id, result = NULL, error = NULL) {
+  msg <- list(jsonrpc = "2.0", id = id)
+  if (!is.null(error)) msg$error <- error else msg$result <- result
+  ipc_write(msg)
 }

--- a/sess/README.md
+++ b/sess/README.md
@@ -1,9 +1,16 @@
 # `sess`: Modern R IPC Protocol
 
-The `sess` package provides a lightweight IPC layer between an R session and a client (such as the VS Code R extension). It uses JSON-RPC 2.0 messages over:
+The `sess` package provides an IPC layer between an R session and a client (such as the VS Code R extension).
+
+Transport:
 
 - Unix domain sockets (macOS/Linux)
 - Windows named pipes
+
+Protocol:
+
+- JSON-RPC 2.0 messages
+- JSON Lines (JSONL, newline-delimited JSON) framing (one JSON message per line)
 
 ## 1. Connection Handshake
 
@@ -22,20 +29,86 @@ If `pipe_path` is omitted, `connect()` resolves it in this order:
 1. `SESS_PIPE` environment variable
 2. `~/.vscode-R/sessions/{PID}.json` (`pipe` field)
 
-After connecting, `sess` sends an `attach` notification with R version, process id, and session metadata.
+After connecting, `sess` sends an `attach` notification.
 
-## 2. Message Transport
+Example:
 
-Transport is NDJSON (newline-delimited JSON). Each line is one JSON-RPC message.
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "attach",
+  "params": {
+    "version": "4.5.0",
+    "pid": 12345,
+    "tempdir": "/tmp/Rtmp.../sess",
+    "wd": "/path/to/project",
+    "info": {
+      "command": "/usr/bin/R",
+      "version": "R version 4.5.0 (...) ",
+      "start_time": "2026-05-05 06:00:00"
+    }
+  }
+}
+```
 
-- R writes JSON-RPC payloads with a trailing `\n`
-- R polls the pipe periodically and dispatches complete lines
+## 2. Message Transport and Framing
 
-The protocol semantics remain JSON-RPC 2.0.
+Transport uses JSON Lines (JSONL, newline-delimited JSON):
 
-### Notifications (`notify_client`)
+- sender writes one JSON-RPC object + `\n`
+- receiver buffers stream chunks and dispatches complete lines only
 
-R sends JSON-RPC notifications (without `id`) for one-way events such as:
+This preserves JSON-RPC semantics while handling stream fragmentation safely.
+
+## 3. JSON-RPC Message Types
+
+### Notification (one-way)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "method_name",
+  "params": {}
+}
+```
+
+### Request (expects response)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "method_name",
+  "params": {}
+}
+```
+
+### Response (success)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {}
+}
+```
+
+### Response (error)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32601,
+    "message": "Method not found"
+  }
+}
+```
+
+## 4. Notifications from R to Client
+
+`notify_client()` sends one-way events (no `id`), including:
 
 - `attach`
 - `dataview`
@@ -47,10 +120,11 @@ R sends JSON-RPC notifications (without `id`) for one-way events such as:
 - `restart_r`
 - `send_to_console`
 
-### Requests (`request_client`)
+## 5. Requests from R to Client (`request_client`)
 
-R can synchronously call client methods (JSON-RPC request with `id`) via `request_client()`.
-This is used for RStudio API emulation methods, such as:
+`request_client()` sends JSON-RPC requests and waits for matching response `id`.
+
+Used by RStudio API emulation methods, such as:
 
 - `rstudioapi/active_editor_context`
 - `rstudioapi/replace_text_in_current_selection`
@@ -65,16 +139,89 @@ This is used for RStudio API emulation methods, such as:
 - `rstudioapi/document_new`
 - `rstudioapi/document_close`
 
-### Client Pull Requests
+Coordinate convention on the wire:
 
-The client can request state from R with JSON-RPC requests:
+- rows/columns are 1-indexed (R-style)
+- client may convert to internal 0-indexed representation
 
-- `workspace`
-- `plot_latest`
-- `hover`
-- `completion`
+## 6. Requests from Client to R (Pull API)
 
-## 3. Hook Registration & Options
+Client queries R state through JSON-RPC requests.
+
+### `workspace`
+
+Request:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"workspace","params":{}}
+```
+
+Response (example):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "globalenv": {
+      "my_df": {"class": ["data.frame"], "type": "list", "length": 11}
+    },
+    "search": ["package:stats", "package:graphics"],
+    "loaded_namespaces": ["sess", "utils"]
+  }
+}
+```
+
+### `plot_latest`
+
+Request params example:
+
+```json
+{"width":800,"height":600,"format":"svglite"}
+```
+
+Response example:
+
+```json
+{"jsonrpc":"2.0","id":2,"result":{"format":"svglite","data":"<base64 or svg payload>"}}
+```
+
+### `hover`
+
+Request params example:
+
+```json
+{"expr":"head(mtcars)"}
+```
+
+Response example:
+
+```json
+{"jsonrpc":"2.0","id":3,"result":{"str":"'data.frame': 6 obs. ..."}}
+```
+
+### `completion`
+
+Request params example:
+
+```json
+{"expr":"mtcars","trigger":"$"}
+```
+
+Response example:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": [
+    {"name":"mpg","type":"double","str":"numeric"},
+    {"name":"cyl","type":"double","str":"numeric"}
+  ]
+}
+```
+
+## 7. Hook Registration and Options
 
 `connect()` initializes runtime hooks via `register_hooks()`.
 
@@ -84,7 +231,7 @@ Intercepted features include:
 - `browser()`, `viewer()`, `page_viewer()`
 - help topic rendering hooks
 
-Relevant options include:
+Relevant options:
 
 - `sess.row_limit`
 - `sess.dataview`
@@ -92,19 +239,24 @@ Relevant options include:
 - `sess.webview`
 - `sess.helpPanel`
 
-## 4. Connection Discovery
+## 8. Discovery File
 
-To support VS Code reloads and attach workflows, the extension writes:
+To support reloads and attach workflows, the extension writes:
 
 - `~/.vscode-R/sessions/{PID}.json`
 
-`sess::connect()` reads this file as a fallback when direct connection parameters are not provided.
+`sess::connect()` reads this file as fallback when direct pipe parameters are unavailable.
 
-## 5. Legacy IPC Comparison
+## 9. What Changed from the WebSocket Transport
 
-Compared with legacy file-watcher IPC, `sess` provides:
+Changed:
 
-- JSON-RPC 2.0 for structured messaging
-- socket/pipe transport instead of lock-file command channels
-- on-demand workspace queries
-- lower background churn and fewer file watch races
+- transport is now UDS / named pipe
+- framing is JSON Lines (JSONL) over stream sockets
+- authentication token exchange is removed
+
+Unchanged:
+
+- JSON-RPC method names and payload shapes
+- request/response correlation by `id`
+- high-level feature behavior (workspace, hover, completion, plot, dataview, RStudio API emulation)

--- a/sess/README.md
+++ b/sess/README.md
@@ -1,188 +1,110 @@
-# `sess`: Modern R IPC Server Protocol
+# `sess`: Modern R IPC Protocol
 
-The `sess` package provides a high-performance, token-authenticated IPC (Inter-Process Communication) mechanism between R and a client (such as an IDE or editor extension). It uses a pure **WebSocket** architecture to replace legacy file-based watchers.
+The `sess` package provides a lightweight IPC layer between an R session and a client (such as the VS Code R extension). It uses JSON-RPC 2.0 messages over:
+
+- Unix domain sockets (macOS/Linux)
+- Windows named pipes
 
 ## 1. Connection Handshake
 
-### Starting the Server
-
-The server can be started by calling `sess::sess_app()`:
+Start the client connection from R:
 
 ```r
-sess::sess_app(
-  port = NULL,           # Integer: Server port (random if NULL)
-  token = NULL,          # String: Authentication token (random if NULL)
-  use_rstudioapi = TRUE, # Logical: Enable RStudio API emulation
-  use_httpgd = TRUE      # Logical: Use httpgd for plotting if available
+sess::connect(
+  pipe_path = NULL,      # Character: pipe/socket path. NULL -> SESS_PIPE or session file fallback
+  use_rstudioapi = TRUE, # Logical: enable rstudioapi emulation
+  use_httpgd = TRUE      # Logical: use httpgd for plotting if available
 )
 ```
 
-It prints a connection string to the R console:
+If `pipe_path` is omitted, `connect()` resolves it in this order:
 
-```text
-[sess] Server address: ws://127.0.0.1:PORT?token=TOKEN
-```
+1. `SESS_PIPE` environment variable
+2. `~/.vscode-R/sessions/{PID}.json` (`pipe` field)
 
-## 2. Communication Channels
+After connecting, `sess` sends an `attach` notification with R version, process id, and session metadata.
 
-`sess` uses a pure WebSocket architecture following the **JSON-RPC 2.0** specification for all structured data exchange. The WebSocket connection serves three main purposes: pushing instantaneous events from R to the client via notifications, allowing R to synchronously call client-side methods, and allowing the client to query R state via asynchronous requests.
+## 2. Message Transport
 
-### 1. Client Notifications (`notify_client`)
+Transport is NDJSON (newline-delimited JSON). Each line is one JSON-RPC message.
 
-The WebSocket is used for instantaneous events pushed from R to the client as **JSON-RPC Notifications** (no `id`).
+- R writes JSON-RPC payloads with a trailing `\n`
+- R polls the pipe periodically and dispatches complete lines
 
-**Notification Format:**
+The protocol semantics remain JSON-RPC 2.0.
 
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "method_name",
-  "params": { ... }
-}
-```
+### Notifications (`notify_client`)
 
-The following methods are sent as notifications from R to the client:
+R sends JSON-RPC notifications (without `id`) for one-way events such as:
 
-- **`attach`**: Sent immediately upon connection. Includes PID, R version, and session metadata.
-- **`detach`**: Sent when the R session is shutting down (params: `pid`).
-- **`dataview`**: Triggered by `View()`. Params include a temporary JSON file path containing the data.
-- **`plot_updated`**: Notifies that a new static plot is available. The client should request the `plot_latest` method.
-- **`httpgd`**: Provides a URL for an `httpgd` live plot server (params: `url`).
-- **`help`**: Requests the client to display an R help page (params: `requestPath`).
-- **`browser`**: Requests the client to open a URL (params: `url`, `title`, `viewer`).
-- **`webview`**: Requests the client to open a local HTML file or URL in a webview (params: `file`, `title`, `viewer`).
-- **`restart_r`**: Requests the client to restart the R session (params: `command`, `clean`).
-- **`send_to_console`**: Sends code to the console for execution without blocking the R session (params: `code`, `execute`, `focus`, `animate`).
+- `attach`
+- `dataview`
+- `plot_updated`
+- `httpgd`
+- `help`
+- `browser`
+- `webview`
+- `restart_r`
+- `send_to_console`
 
-### 2. Synchronous Client Requests (`request_client`)
+### Requests (`request_client`)
 
-The `request_client()` function allows R to call client-side functions synchronously by sending a **JSON-RPC Request** (with an `id`) over the WebSocket. This is primarily used to emulate the RStudio API.
+R can synchronously call client methods (JSON-RPC request with `id`) via `request_client()`.
+This is used for RStudio API emulation methods, such as:
 
-**Coordinate Handling**: The `sess` protocol uses **1-indexed** coordinates for all rows (lines) and columns (characters) on the wire. This aligns with R's internal representation. The client (e.g., VS Code extension) is responsible for converting these to its internal 0-indexed representation if necessary.
+- `rstudioapi/active_editor_context`
+- `rstudioapi/replace_text_in_current_selection`
+- `rstudioapi/insert_or_modify_text`
+- `rstudioapi/show_dialog`
+- `rstudioapi/navigate_to_file`
+- `rstudioapi/set_selection_ranges`
+- `rstudioapi/document_save`
+- `rstudioapi/get_project_path`
+- `rstudioapi/document_context`
+- `rstudioapi/document_save_all`
+- `rstudioapi/document_new`
+- `rstudioapi/document_close`
 
-**Serialization Format**:
+### Client Pull Requests
 
-- **Position**: A numeric array `[row, column]`.
-- **Range**: An object `{ "start": [row, column], "end": [row, column] }`.
+The client can request state from R with JSON-RPC requests:
 
-Below are the JSON-RPC methods sent from R to the client to emulate RStudio API functionality:
-
-- **`rstudioapi/active_editor_context`**: Requests the current context of the active editor.
-- **`rstudioapi/replace_text_in_current_selection`**: Replaces text in the current selection (params: `text`, `id`).
-- **`rstudioapi/insert_or_modify_text`**: Inserts or modifies text at specific locations (params: `query`, `id`).
-- **`rstudioapi/show_dialog`**: Displays a message dialog to the user (params: `message`).
-- **`rstudioapi/navigate_to_file`**: Opens and navigates to a specific file, line, and column (params: `file`, `line`, `column`).
-- **`rstudioapi/set_selection_ranges`**: Sets the cursor or selection ranges in the editor (params: `ranges`, `id`).
-- **`rstudioapi/document_save`**: Saves the specified document (params: `id`).
-- **`rstudioapi/get_project_path`**: Retrieves the current project path.
-- **`rstudioapi/document_context`**: Retrieves the context of a specific document (params: `id`).
-- **`rstudioapi/document_save_all`**: Saves all open documents.
-- **`rstudioapi/document_new`**: Creates a new document with specified text and type (params: `text`, `type`, `position`).
-- **`rstudioapi/document_close`**: Closes the specified document (params: `id`, `save`).
-
-### 3. Server Requests (Pull API)
-
-The Pull API allows the client to query state using **JSON-RPC Requests** sent over the active WebSocket.
-
-#### JSON-RPC Request Format
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "method_name",
-  "params": { ... }
-}
-```
-
-#### Available Methods
-
-**`workspace`**
-Returns object metadata from the Global Environment.
-
-- **Request Params**: None.
-- **Response Result**:
-
-  ```json
-  {
-    "globalenv": {
-      "my_df": { "class": "data.frame", "type": "list", "length": 5, "str": "data.frame: 32 obs. of 11 variables:" }
-    },
-    "search": ["package:stats", "package:graphics"],
-    "loaded_namespaces": ["sess", "httpuv"]
-  }
-  ```
-
-**`plot_latest`**
-Returns the most recent static plot captured by the R session.
-
-- **Request Params**: None.
-- **Response Result**: `{"data": "iVBORw0KGgoAAAANSUhEUgA..."}` (base64 encoded PNG string). Returns `{"data": null}` if no plot exists.
-
-**`hover`**
-
-- **Request Params**: `{"expr": "head(mtcars)"}`
-- **Response Result**: `{"str": " 'data.frame': 6 obs. of 11 variables: ..."}`
-
-**`completion`**
-
-- **Request Params**: `{"expr": "mtcars", "trigger": "$"}`
-- **Response Result**:
-
-  ```json
-  [
-    { "name": "mpg", "type": "double", "str": "numeric" },
-    { "name": "cyl", "type": "double", "str": "numeric" }
-  ]
-  ```
-
----
+- `workspace`
+- `plot_latest`
+- `hover`
+- `completion`
 
 ## 3. Hook Registration & Options
 
-By default, the package does not inject hooks into the R session on load. Calling `sess::sess_app()` will start the server and automatically call `sess::register_hooks()` to enable features like automatic `View()` interception or plot redirection.
+`connect()` initializes runtime hooks via `register_hooks()`.
 
-### Intercepted Functions
+Intercepted features include:
 
-- **`utils::View()`**: Redirects data to the client's data viewer. Supports `data.frame`, `matrix`, `list`, and `ArrowTabular` objects.
-- **`browser()`**, **`viewer()`**, **`page_viewer()`**: Redirects URLs and HTML files to the client's browser or webview.
-- **Help System**: Intercepts help topic printing to route HTML help to the client.
+- `utils::View()`
+- `browser()`, `viewer()`, `page_viewer()`
+- help topic rendering hooks
 
-### Global Options
+Relevant options include:
 
-- **`sess.row_limit`**: Limits the number of rows sent to the data viewer (default: 100). Set to 0 for no limit.
-- **`sess.dataview`**: Target viewer column for data (default: `"Two"`).
-- **`sess.browser`**: Target viewer for browser (default: `"Active"`).
-- **`sess.webview`**: Target viewer for webview (default: `"Two"`).
-- **`sess.helpPanel`**: Target viewer for help (default: `"Two"`).
+- `sess.row_limit`
+- `sess.dataview`
+- `sess.browser`
+- `sess.webview`
+- `sess.helpPanel`
 
-## 4. Comparison with Legacy IPC
+## 4. Connection Discovery
 
-The `sess` package replaces the legacy file-based IPC mechanism with a modern, in-memory WebSocket architecture using **JSON-RPC 2.0**.
+To support VS Code reloads and attach workflows, the extension writes:
 
-| Feature | Legacy IPC (File-based) | Modern IPC (`sess`) |
-| :--- | :--- | :--- |
-| **Command Dispatch** | `request.log` + `request.lock` | **WS Notification** (JSON-RPC) |
-| **Workspace State** | `workspace.json` + `workspace.lock` | **WS Request `workspace`** (On-demand) |
-| **Static Plots** | `plot.png` + `plot.lock` | **WS Notification** + **WS Request `plot_latest`** |
-| **RStudio API (Sync)**| `request.log` + `response.lock` | **WS Request** (JSON-RPC) |
-| **Client Queries** | Internal HTTP Server (`httpuv`) | **WS Request** (JSON-RPC 2.0) |
-| **Transport Reliability**| OS-level File System Watchers | **WebSocket** |
-| **Protocol Standard** | Ad-hoc JSON formats | **JSON-RPC 2.0** |
+- `~/.vscode-R/sessions/{PID}.json`
 
-### Architectural Shifts
+`sess::connect()` reads this file as a fallback when direct connection parameters are not provided.
 
-1. **Elimination of File Watchers**: Replaces unreliable OS-level file system watchers with persistent WebSocket connections for instantaneous event pushing.
-2. **On-Demand Evaluation**: Evaluations of the Global Environment are now performed only when requested by the client, reducing R's background workload.
-3. **Unified Standard**: Unifies all structured communication under the **JSON-RPC 2.0** standard across a single WebSocket connection.
+## 5. Legacy IPC Comparison
 
-### Connection Discovery & Reconnection
+Compared with legacy file-watcher IPC, `sess` provides:
 
-While `sess` primarily uses WebSockets for low-latency communication, it uses a file-based
-discovery mechanism to handle VS Code window reloads and support manual connections:
-
-1. **Initial Connection**: VS Code passes `SESS_PORT` and `SESS_TOKEN` environment variables when launching R. R connects directly.
-2. **Discovery File**: VS Code writes the current connection info to `~/.vscode-R/sessions/{PID}.json`.
-3. **Reconnection**: If disconnected (e.g., after a window reload), R retries connecting by
-   reading the file to find the new port and token. Automatic reconnection is skipped
-   for manual connections (where port/token were passed as arguments).
+- JSON-RPC 2.0 for structured messaging
+- socket/pipe transport instead of lock-file command channels
+- on-demand workspace queries
+- lower background churn and fewer file watch races

--- a/sess/man/connect.Rd
+++ b/sess/man/connect.Rd
@@ -2,21 +2,19 @@
 % Please edit documentation in R/server.R
 \name{connect}
 \alias{connect}
-\title{Start the client R IPC connection}
+\title{Connect to the VS Code IPC server}
 \usage{
-connect(port = NULL, token = NULL, use_rstudioapi = TRUE, use_httpgd = TRUE)
+connect(pipe_path = NULL, use_rstudioapi = TRUE, use_httpgd = TRUE)
 }
 \arguments{
-\item{port}{Integer. The port of the VS Code WebSocket server.
-If NULL, it will use SESS_PORT env var.}
+\item{pipe_path}{Character. Path to the named pipe / Unix domain socket.
+If NULL, uses the SESS_PIPE environment variable, then falls back to the
+session JSON file written by the extension.}
 
-\item{token}{String. The authentication token. If NULL, it will use SESS_TOKEN env var.}
+\item{use_rstudioapi}{Logical. Enable rstudioapi emulation. Defaults to TRUE.}
 
-\item{use_rstudioapi}{Logical. Should the rstudioapi emulation layer
-be enabled? Defaults to TRUE.}
-
-\item{use_httpgd}{Logical. Should httpgd be used for plotting if available? Defaults to TRUE}
+\item{use_httpgd}{Logical. Use httpgd for plotting if available. Defaults to TRUE.}
 }
 \description{
-Start the client R IPC connection
+Connect to the VS Code IPC server
 }

--- a/sess/man/notify_client.Rd
+++ b/sess/man/notify_client.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/dispatch.R
 \name{notify_client}
 \alias{notify_client}
-\title{Notify the client via WebSocket (JSON-RPC 2.0 Notification)}
+\title{Notify the client via IPC pipe (JSON-RPC 2.0 Notification)}
 \usage{
 notify_client(method, params = list())
 }
@@ -12,5 +12,5 @@ notify_client(method, params = list())
 \item{params}{A list containing the arguments for the command}
 }
 \description{
-Pushes an event instantly to the client extension via the active WebSocket connection.
+Pushes an event instantly to the client extension via the active IPC pipe connection.
 }

--- a/sess/man/rpc_send.Rd
+++ b/sess/man/rpc_send.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/dispatch.R
 \name{rpc_send}
 \alias{rpc_send}
-\title{Send a message to the client via WebSocket (JSON-RPC 2.0)}
+\title{Send a message to the client via IPC pipe (JSON-RPC 2.0)}
 \usage{
 rpc_send(method, params = list(), request = FALSE)
 }

--- a/sess/tests/testthat.R
+++ b/sess/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(sess)
+
+test_check("sess")

--- a/sess/tests/testthat/test-ipc.R
+++ b/sess/tests/testthat/test-ipc.R
@@ -1,0 +1,84 @@
+test_that("NDJSON framing round-trips correctly through a socket pair", {
+  skip_if_not_installed("processx")
+  skip_on_os("windows") # Windows named pipe paths are tested separately
+
+  pipe_path <- tempfile(fileext = ".sock")
+  on.exit(unlink(pipe_path), add = TRUE)
+
+  server_con <- processx::conn_create_unix_socket(pipe_path, encoding = "")
+  on.exit(close(server_con), add = TRUE)
+
+  client_con <- processx::conn_connect_unix_socket(pipe_path, encoding = "")
+  on.exit(close(client_con), add = TRUE)
+
+  # Accept the incoming client on the server side
+  processx::poll(list(server_con), 1000L)
+  conn_con <- processx::conn_accept_unix_socket(server_con)
+  on.exit(close(conn_con), add = TRUE)
+
+  # Write a NDJSON line from client to server
+  msg <- list(jsonrpc = "2.0", method = "ping", params = list(value = 42L))
+  line <- paste0(jsonlite::toJSON(msg, auto_unbox = TRUE), "\n")
+  processx::conn_write(client_con, line, sep = "")
+
+  # Poll and read on server side
+  ready <- processx::poll(list(conn_con), 1000L)
+  expect_equal(ready[[1]], "ready")
+
+  received <- processx::conn_read_chars(conn_con)
+  expect_true(nzchar(received))
+
+  # Parse and verify
+  parsed <- jsonlite::fromJSON(trimws(received), simplifyVector = FALSE)
+  expect_equal(parsed$method, "ping")
+  expect_equal(parsed$params$value, 42L)
+})
+
+test_that("dispatch_message routes responses to pending_responses", {
+  .sess_env <- sess:::.sess_env
+  orig_pending <- .sess_env$pending_responses
+  on.exit(.sess_env$pending_responses <- orig_pending, add = TRUE)
+
+  .sess_env$pending_responses <- list()
+
+  response_line <- as.character(jsonlite::toJSON(
+    list(jsonrpc = "2.0", id = "req_001", result = list(x = 1L)),
+    auto_unbox = TRUE
+  ))
+
+  sess:::dispatch_message(response_line)
+
+  expect_false(is.null(.sess_env$pending_responses[["req_001"]]))
+  expect_equal(.sess_env$pending_responses[["req_001"]]$x, 1L)
+})
+
+test_that("dispatch_message stores JSON-RPC errors with error class", {
+  .sess_env <- sess:::.sess_env
+  orig_pending <- .sess_env$pending_responses
+  on.exit(.sess_env$pending_responses <- orig_pending, add = TRUE)
+
+  .sess_env$pending_responses <- list()
+
+  error_line <- as.character(jsonlite::toJSON(
+    list(jsonrpc = "2.0", id = "req_002",
+         error = list(code = -32601L, message = "Method not found")),
+    auto_unbox = TRUE
+  ))
+
+  sess:::dispatch_message(error_line)
+
+  resp <- .sess_env$pending_responses[["req_002"]]
+  expect_false(is.null(resp))
+  expect_true(inherits(resp, "json_rpc_error"))
+  expect_equal(resp$code, -32601L)
+})
+
+test_that("ipc_write returns FALSE when no connection is open", {
+  .sess_env <- sess:::.sess_env
+  orig_con <- .sess_env$con
+  on.exit(.sess_env$con <- orig_con, add = TRUE)
+
+  .sess_env$con <- NULL
+  result <- sess:::ipc_write(list(jsonrpc = "2.0", method = "test"))
+  expect_false(isTRUE(result))
+})

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -41,11 +41,11 @@ export class HoverProvider implements vscode.HoverProvider {
         let hoverRange = document.getWordRangeAtPosition(position);
         let hoverText = null;
 
-        if (session.server) {
+        if (session.globalPipePath) {
             const exprRegex = /([a-zA-Z0-9._$@ ])+(?<![@$])/;
             hoverRange = document.getWordRangeAtPosition(position, exprRegex)?.with({ end: hoverRange?.end });
             const expr = document.getText(hoverRange);
-            const response = await session.sessionRequest(session.server, {
+            const response = await session.sessionRequest({
                 method: 'hover',
                 params: { expr: expr }
             }) as { str: string };
@@ -162,11 +162,11 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
             });
         } else if(trigger === '$' || trigger === '@') {
             const symbolPosition = new vscode.Position(position.line, position.character - 1);
-            if (session.server) {
+            if (session.globalPipePath) {
                 const re = /([a-zA-Z0-9._$@ ])+(?<![@$])/;
                 const exprRange = document.getWordRangeAtPosition(symbolPosition, re)?.with({ end: symbolPosition });
                 const expr = document.getText(exprRange);
-                const response = await session.sessionRequest(session.server, {
+                const response = await session.sessionRequest({
                     method: 'completion',
                     params: { expr: expr, trigger: trigger }
                 }) as RObjectElement[];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,3 +250,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
     return rExtension;
 }
+
+export async function deactivate(): Promise<void> {
+    await session.shutdownSessionWatcher();
+}

--- a/src/plotViewer/standardViewer.ts
+++ b/src/plotViewer/standardViewer.ts
@@ -1,7 +1,7 @@
 
 import * as vscode from 'vscode';
 import { asViewColumn, config, UriIcon } from '../util';
-import { sessionRequest, server } from '../session';
+import { sessionRequest, globalPipePath } from '../session';
 import { PlotViewer } from './types';
 
 interface PlotResponse {
@@ -75,13 +75,13 @@ export class StandardPlotViewer implements PlotViewer {
     }
 
     private async requestPlot() {
-        if (!server || !this.panel) {
+        if (!globalPipePath || !this.panel) {
             return;
         }
 
         const format = config().get<string>('plot.format', 'svglite');
         const devArgs = config().get<Record<string, unknown>>('plot.devArgs');
-        const response = await sessionRequest(server, {
+        const response = await sessionRequest({
             method: 'plot_latest',
             params: {
                 width: this.viewWidth,

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -179,7 +179,7 @@ export async function runFromLineToEnd(): Promise<void>  {
     await runTextInTerm(text);
 }
 
-import { getGlobalSessionServer, writeSessionFile } from './session';
+import { getGlobalPipePath, writeSessionFile } from './session';
 
 export async function makeTerminalOptions(): Promise<vscode.TerminalOptions> {
     const workspaceFolderPath = getCurrentWorkspaceFolder()?.uri.fsPath;
@@ -193,12 +193,11 @@ export async function makeTerminalOptions(): Promise<vscode.TerminalOptions> {
     };
     const newRprofile = extensionContext.asAbsolutePath(path.join('R', 'profile.R'));
     if (config().get<boolean>('sessionWatcher')) {
-        const { port, token } = await getGlobalSessionServer();
+        const pipePath = await getGlobalPipePath();
         termOptions.env = {
             R_PROFILE_USER_OLD: process.env.R_PROFILE_USER,
             R_PROFILE_USER: newRprofile,
-            SESS_PORT: port.toString(),
-            SESS_TOKEN: token,
+            SESS_PIPE: pipePath,
             SESS_RSTUDIOAPI: config().get<boolean>('session.emulateRStudioAPI') ? 'TRUE' : 'FALSE',
             SESS_USE_HTTPGD: config().get<boolean>('plot.useHttpgd') ? 'TRUE' : 'FALSE'
         };
@@ -220,10 +219,10 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
     rTerm = vscode.window.createTerminal(termOptions);
     rTerm.show(preserveshow);
     
-    void rTerm.processId.then(async (pid) => {
+    void rTerm.processId.then(async (pid: number | undefined) => {
         if (pid) {
-            const { port, token } = await getGlobalSessionServer();
-            await writeSessionFile(pid.toString(), port, token);
+            const pipePath = await getGlobalPipePath();
+            await writeSessionFile(pid.toString(), pipePath);
         }
     });
     

--- a/src/session.ts
+++ b/src/session.ts
@@ -201,7 +201,9 @@ export async function getGlobalPipePath(): Promise<string> {
 
                 for (let i = 0; i < lines.length - 1; i++) {
                     const line = lines[i].trim();
-                    if (!line) continue;
+                    if (!line) {
+                        continue;
+                    }
                     void (async () => {
                         try {
                             const message = JSON.parse(line) as Record<string, unknown>;
@@ -269,30 +271,22 @@ function getAttachSessionScriptPath(pipePath: string): string {
     return path.join(tmpDir(), `${scriptBase}.R`);
 }
 
-function buildAttachSessionScript(pipePath: string, sessPath: string): string {
+function buildAttachSessionScript(pipePath: string, sessPath: string, installSessScriptPath: string): string {
     return [
         'local({',
         `  pipe_path <- ${asRStringLiteral(pipePath)}`,
         `  sess_src <- ${asRStringLiteral(sessPath)}`,
+        `  install_sess_script <- ${asRStringLiteral(installSessScriptPath)}`,
         '  bundled_version <- tryCatch(read.dcf(file.path(sess_src, "DESCRIPTION"))[1, "Version"], error = function(e) NA_character_)',
         '  installed_version <- suppressWarnings(tryCatch(as.character(utils::packageVersion("sess")), error = function(e) NA_character_))',
         '  needs_install <- is.na(installed_version) || (!is.na(bundled_version) && utils::compareVersion(installed_version, bundled_version) < 0)',
         '  if (needs_install) {',
-        '    lib_candidates <- unique(c(.libPaths(), Sys.getenv("R_LIBS_USER", unset = "")))',
-        '    lib_candidates <- lib_candidates[nzchar(lib_candidates)]',
-        '    writable <- lib_candidates[vapply(lib_candidates, function(lib) {',
-        '      if (!dir.exists(lib)) {',
-        '        dir.create(lib, recursive = TRUE, showWarnings = FALSE)',
-        '      }',
-        '      file.access(lib, 2) == 0',
-        '    }, logical(1))]',
-        '    if (length(writable) < 1) {',
-        '      message("[vscode-R] Could not find a writable library path for this terminal.")',
-        '      message("[vscode-R] Install the bundled sess package manually:")',
-        '      message(sprintf("install.packages(%s, repos = NULL, type = \\"source\\")", shQuote(sess_src)))',
-        '      stop("No writable R library path available for installing sess")',
+        '    if (!file.exists(install_sess_script)) {',
+        '      stop(sprintf("install_sess.R not found: %s", install_sess_script))',
         '    }',
-        '    install.packages(sess_src, repos = NULL, type = "source", lib = writable[[1]])',
+        '    Sys.setenv(VSCODE_R_SESS_PKG_PATH = sess_src)',
+        '    on.exit(Sys.unsetenv(c("VSCODE_R_SESS_PKG_PATH", "VSCODE_R_SESS_REPO")), add = TRUE)',
+        '    source(install_sess_script, local = TRUE)',
         '  }',
         '  sess::connect(pipe_path = pipe_path)',
         '})',
@@ -303,8 +297,9 @@ function buildAttachSessionScript(pipePath: string, sessPath: string): string {
 export async function getAttachSessionCommand(): Promise<string> {
     const pipePath = await getGlobalPipePath();
     const sessPath = extensionContext.asAbsolutePath('sess').replace(/\\/g, '/');
+    const installSessScriptPath = extensionContext.asAbsolutePath(path.join('R', 'install_sess.R')).replace(/\\/g, '/');
     const scriptPath = getAttachSessionScriptPath(pipePath);
-    await fs.writeFile(scriptPath, buildAttachSessionScript(pipePath, sessPath), { encoding: 'utf-8' });
+    await fs.writeFile(scriptPath, buildAttachSessionScript(pipePath, sessPath, installSessScriptPath), { encoding: 'utf-8' });
     attachSessionScriptPath = scriptPath;
 
     return `source(${asRStringLiteral(scriptPath)})`;

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,7 +13,7 @@ import { config, readContent, setContext, UriIcon } from './util';
 import * as rTerminal from './rTerminal';
 import { purgeAddinPickerItems, RSEditOperation, RSRange } from './rstudioapi';
 
-import { homeExtDir, rWorkspace, globalRHelp, globalPlotManager, sessionStatusBarItem } from './extension';
+import { extensionContext, homeExtDir, rWorkspace, globalRHelp, globalPlotManager, sessionStatusBarItem, tmpDir } from './extension';
 
 import { showWebView } from './webViewer';
 
@@ -114,6 +114,7 @@ const pendingRequests = new Map<number, { resolve: (value: unknown) => void, rej
 const readBuffers = new Map<IpcSocket, string>();
 
 let globalSessionServer: net.Server | undefined;
+let attachSessionScriptPath: string | undefined;
 
 function isPidRunning(pid: number): boolean {
     try {
@@ -256,6 +257,103 @@ export async function getGlobalPipePath(): Promise<string> {
     });
 }
 
+function asRStringLiteral(value: string): string {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function getAttachSessionScriptPath(pipePath: string): string {
+    if (pipePath.endsWith('.sock')) {
+        return pipePath.replace(/\.sock$/, '.R');
+    }
+    const scriptBase = path.basename(pipePath).replace(/[^a-zA-Z0-9_.-]/g, '_') || 'attach_session';
+    return path.join(tmpDir(), `${scriptBase}.R`);
+}
+
+function buildAttachSessionScript(pipePath: string, sessPath: string): string {
+    return [
+        'local({',
+        `  pipe_path <- ${asRStringLiteral(pipePath)}`,
+        `  sess_src <- ${asRStringLiteral(sessPath)}`,
+        '  bundled_version <- tryCatch(read.dcf(file.path(sess_src, "DESCRIPTION"))[1, "Version"], error = function(e) NA_character_)',
+        '  installed_version <- suppressWarnings(tryCatch(as.character(utils::packageVersion("sess")), error = function(e) NA_character_))',
+        '  needs_install <- is.na(installed_version) || (!is.na(bundled_version) && utils::compareVersion(installed_version, bundled_version) < 0)',
+        '  if (needs_install) {',
+        '    lib_candidates <- unique(c(.libPaths(), Sys.getenv("R_LIBS_USER", unset = "")))',
+        '    lib_candidates <- lib_candidates[nzchar(lib_candidates)]',
+        '    writable <- lib_candidates[vapply(lib_candidates, function(lib) {',
+        '      if (!dir.exists(lib)) {',
+        '        dir.create(lib, recursive = TRUE, showWarnings = FALSE)',
+        '      }',
+        '      file.access(lib, 2) == 0',
+        '    }, logical(1))]',
+        '    if (length(writable) < 1) {',
+        '      message("[vscode-R] Could not find a writable library path for this terminal.")',
+        '      message("[vscode-R] Install the bundled sess package manually:")',
+        '      message(sprintf("install.packages(%s, repos = NULL, type = \\"source\\")", shQuote(sess_src)))',
+        '      stop("No writable R library path available for installing sess")',
+        '    }',
+        '    install.packages(sess_src, repos = NULL, type = "source", lib = writable[[1]])',
+        '  }',
+        '  sess::connect(pipe_path = pipe_path)',
+        '})',
+        '',
+    ].join('\n');
+}
+
+export async function getAttachSessionCommand(): Promise<string> {
+    const pipePath = await getGlobalPipePath();
+    const sessPath = extensionContext.asAbsolutePath('sess').replace(/\\/g, '/');
+    const scriptPath = getAttachSessionScriptPath(pipePath);
+    await fs.writeFile(scriptPath, buildAttachSessionScript(pipePath, sessPath), { encoding: 'utf-8' });
+    attachSessionScriptPath = scriptPath;
+
+    return `source(${asRStringLiteral(scriptPath)})`;
+}
+
+async function removePathIfExists(pathLike: string): Promise<void> {
+    try {
+        if (await fs.pathExists(pathLike)) {
+            await fs.remove(pathLike);
+        }
+    } catch (e) {
+        console.warn(`[session cleanup] Failed to remove ${pathLike}`, e);
+    }
+}
+
+export async function shutdownSessionWatcher(): Promise<void> {
+    const pipePath = globalPipePath;
+
+    for (const socket of activeConnections) {
+        socket.destroy();
+    }
+    activeConnections.clear();
+    pipeClient = undefined;
+    readBuffers.clear();
+
+    if (globalSessionServer) {
+        await new Promise<void>((resolve) => {
+            try {
+                globalSessionServer?.close(() => resolve());
+            } catch {
+                resolve();
+            }
+        });
+        globalSessionServer = undefined;
+    }
+
+    if (attachSessionScriptPath) {
+        await removePathIfExists(attachSessionScriptPath);
+        attachSessionScriptPath = undefined;
+    }
+
+    if (pipePath && pipePath.endsWith('.sock')) {
+        await removePathIfExists(pipePath);
+        await removePathIfExists(pipePath.replace(/\.sock$/, '.R'));
+    }
+
+    globalPipePath = undefined;
+}
+
 export async function activateRSession(): Promise<void> {
     if (config().get<boolean>('sessionWatcher')) {
         console.info('[activateRSession]');
@@ -282,6 +380,30 @@ export async function activateRSession(): Promise<void> {
                     return;
                 }
             }
+        }
+
+        if (config().get<boolean>('alwaysUseActiveTerminal')) {
+            if (terminal) {
+                const command = await getAttachSessionCommand();
+                terminal.sendText(command, true);
+                terminal.show();
+                return;
+            }
+
+            const action = await window.showInformationMessage(
+                'No active terminal is available. You can copy the attach command or create a managed R terminal.',
+                'Copy Attach Command',
+                'Create R Terminal'
+            );
+
+            if (action === 'Copy Attach Command') {
+                await connectToSession();
+                return;
+            }
+            if (action === 'Create R Terminal') {
+                await rTerminal.createRTerm();
+            }
+            return;
         }
 
         console.info('[activateRSession] Creating new R terminal');
@@ -1008,8 +1130,7 @@ export async function sessionRequest(data: Record<string, unknown>): Promise<unk
 }
 
 export async function connectToSession(): Promise<void> {
-    const pipePath = await getGlobalPipePath();
-    const command = `sess::connect(pipe_path="${pipePath.replace(/\\/g, '\\\\')}")`;
+    const command = await getAttachSessionCommand();
     void vscode.env.clipboard.writeText(command);
     void vscode.window.showInformationMessage(`R command copied to clipboard: ${command}`);
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -3,6 +3,8 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
+import * as net from 'net';
+import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 import { commands, Uri, ViewColumn, Webview, window, workspace, env } from 'vscode';
 
@@ -15,18 +17,10 @@ import { homeExtDir, rWorkspace, globalRHelp, globalPlotManager, sessionStatusBa
 
 import { showWebView } from './webViewer';
 
-import WebSocket from 'ws';
-
 export interface SessionInfo {
     version: string;
     command: string;
     start_time: string;
-}
-
-interface ExtWebSocket extends WebSocket {
-    _terminalPid?: number;
-    _port?: number;
-    _token?: string;
 }
 
 export interface GlobalEnv {
@@ -48,15 +42,15 @@ export interface WorkspaceData {
     globalenv: GlobalEnv;
 }
 
-export interface SessionServer {
-    host: string;
-    port: number;
-    token: string;
+// Thin adapter to track per-socket metadata alongside net.Socket
+interface IpcSocket extends net.Socket {
+    _terminalPid?: number;
+    _pipePath?: string;
 }
 
 export class Session {
-    public server: SessionServer;
-    public ws: WebSocket;
+    public pipePath: string;
+    public socket: IpcSocket;
     public pid: string;
     public rVer: string;
     public info: SessionInfo;
@@ -64,9 +58,9 @@ export class Session {
     public workingDir: string;
     public workspaceData: WorkspaceData;
 
-    constructor(server: SessionServer, ws: WebSocket) {
-        this.server = server;
-        this.ws = ws;
+    constructor(pipePath: string, socket: IpcSocket) {
+        this.pipePath = pipePath;
+        this.socket = socket;
         this.pid = '';
         this.rVer = '';
         this.info = { version: '', command: '', start_time: '' };
@@ -85,7 +79,7 @@ export let workingDir: string;
 let rVer: string;
 let pid: string;
 let info: SessionInfo;
-export let server: SessionServer | undefined;
+export let globalPipePath: string | undefined;
 export let workspaceFile: string;
 
 const sessions = new Map<string, Session>();
@@ -96,10 +90,9 @@ export function deploySessionWatcher(extensionPath: string): void {
     console.info(`[deploySessionWatcher] extensionPath: ${extensionPath}`);
     resDir = path.join(extensionPath, 'dist', 'resources');
 
-    // Initialize the WebSocket server when the extension activates
-    void getGlobalSessionServer().then(async (srv) => {
+    void getGlobalPipePath().then(async (pipePath) => {
         await pruneSessionFiles();
-        await updateActiveTerminalFiles(srv.port, srv.token);
+        await updateActiveTerminalFiles(pipePath);
     }).catch(err => {
         console.error('Failed to initialize global session server', err);
     });
@@ -112,14 +105,15 @@ export function deploySessionWatcher(extensionPath: string): void {
     });
 }
 
-import * as crypto from 'crypto';
-
-let wsClient: ExtWebSocket | undefined;
-export const activeConnections = new Set<ExtWebSocket>();
+let pipeClient: IpcSocket | undefined;
+export const activeConnections = new Set<IpcSocket>();
 
 const pendingRequests = new Map<number, { resolve: (value: unknown) => void, reject: (reason?: unknown) => void }>();
 
-let globalSessionServer: { port: number, token: string } | undefined;
+// Per-socket read buffers for NDJSON framing
+const readBuffers = new Map<IpcSocket, string>();
+
+let globalSessionServer: net.Server | undefined;
 
 function isPidRunning(pid: number): boolean {
     try {
@@ -154,104 +148,110 @@ async function pruneSessionFiles() {
     }
 }
 
-export async function writeSessionFile(pid: string, port: number, token: string) {
+export async function writeSessionFile(pid: string, pipePath: string) {
     const homeDir = os.homedir();
     const sessionsDir = path.join(homeDir, '.vscode-R', 'sessions');
     await fs.ensureDir(sessionsDir);
     const filePath = path.join(sessionsDir, `${pid}.json`);
-    await fs.writeJson(filePath, { port, token });
+    await fs.writeJson(filePath, { pipe: pipePath });
 }
 
-async function updateActiveTerminalFiles(port: number, token: string) {
+async function updateActiveTerminalFiles(pipePath: string) {
     const terminals = vscode.window.terminals;
     for (const term of terminals) {
         if (term.name === 'R Interactive') {
             const pid = await term.processId;
             if (pid) {
-                await writeSessionFile(pid.toString(), port, token);
+                await writeSessionFile(pid.toString(), pipePath);
             }
         }
     }
 }
 
-export async function getGlobalSessionServer(): Promise<{ port: number, token: string }> {
-    if (globalSessionServer) {
-        return globalSessionServer;
+function makePipePath(): string {
+    const suffix = crypto.randomBytes(8).toString('hex');
+    if (process.platform === 'win32') {
+        return `\\\\.\\pipe\\vscode-r-${suffix}`;
+    } else {
+        return path.join(os.tmpdir(), `vscode-r-${suffix}.sock`);
+    }
+}
+
+export async function getGlobalPipePath(): Promise<string> {
+    if (globalPipePath) {
+        return globalPipePath;
     }
 
     return new Promise((resolve, reject) => {
-        const token = crypto.randomBytes(16).toString('hex');
-        const wss = new WebSocket.Server({ port: 0, host: '127.0.0.1' });
+        const pipePath = makePipePath();
+        const server = net.createServer((rawSocket) => {
+            const socket = rawSocket as IpcSocket;
+            console.info('[SessionServer] Client connected via IPC pipe');
+            activeConnections.add(socket);
+            pipeClient = socket;
+            readBuffers.set(socket, '');
 
-        wss.on('listening', () => {
-            const address = wss.address();
-            if (typeof address === 'object' && address !== null) {
-                globalSessionServer = { port: address.port, token };
-                console.info(`[SessionServer] Listening on ws://127.0.0.1:${address.port}?token=${token}`);
-                
-                // Initialize the old global server object for compatibility
-                server = { host: '127.0.0.1', port: address.port, token };
-                resolve(globalSessionServer);
-            } else {
-                reject(new Error('Failed to get WebSocket server address'));
-            }
-        });
+            socket.on('data', (data: Buffer) => {
+                const incoming = data.toString('utf8');
+                const buf = (readBuffers.get(socket) ?? '') + incoming;
+                const lines = buf.split('\n');
+                // Last element is a potentially incomplete line — keep in buffer
+                readBuffers.set(socket, lines[lines.length - 1]);
 
-        wss.on('connection', (ws: ExtWebSocket, req) => {
-            const url = new URL(req.url || '', `http://${req.headers.host || '127.0.0.1'}`);
-            const clientToken = url.searchParams.get('token');
-
-            if (clientToken !== token) {
-                console.warn('[SessionServer] Connection rejected: invalid token');
-                ws.close();
-                return;
-            }
-
-            console.info('[SessionServer] Client connected');
-            activeConnections.add(ws);
-            wsClient = ws;
-
-            ws.on('message', (data: WebSocket.Data) => {
-                void (async () => {
-                    try {
-                        const message = JSON.parse(data.toString()) as Record<string, unknown>;
-                        if (message.id !== undefined && !message.method) {
-                            // Response to a client request
-                            const id = Number(message.id);
-                            const pending = pendingRequests.get(id);
-                            if (pending) {
-                                pendingRequests.delete(id);
-                                if (message.error) {
-                                    pending.reject(message.error);
-                                } else {
-                                    pending.resolve(message.result);
+                for (let i = 0; i < lines.length - 1; i++) {
+                    const line = lines[i].trim();
+                    if (!line) continue;
+                    void (async () => {
+                        try {
+                            const message = JSON.parse(line) as Record<string, unknown>;
+                            if (message.id !== undefined && !message.method) {
+                                // Response to a request we sent
+                                const id = Number(message.id);
+                                const pending = pendingRequests.get(id);
+                                if (pending) {
+                                    pendingRequests.delete(id);
+                                    if (message.error) {
+                                        pending.reject(message.error);
+                                    } else {
+                                        pending.resolve(message.result);
+                                    }
                                 }
+                            } else if (!message.id) {
+                                await handleNotification(message, socket);
+                            } else {
+                                await handleRequest(message, socket);
                             }
-                        } else if (!message.id) {
-                            // Notification from server
-                            await handleNotification(message, ws);
-                        } else {
-                            // Request from server
-                            await handleRequest(message, ws);
+                        } catch (e) {
+                            console.error('[SessionServer] Error handling message', e);
                         }
-                    } catch (e) {
-                        console.error('[SessionServer] Error handling message', e);
-                    }
-                })();
-            });
-
-            ws.on('close', () => {
-                console.info('[SessionServer] Client disconnected');
-                activeConnections.delete(ws);
-                if (wsClient === ws) {
-                    wsClient = undefined;
+                    })();
                 }
             });
+
+            socket.on('close', () => {
+                console.info('[SessionServer] Client disconnected');
+                readBuffers.delete(socket);
+                activeConnections.delete(socket);
+                if (pipeClient === socket) {
+                    pipeClient = undefined;
+                }
+            });
+
+            socket.on('error', (err) => {
+                console.error('[SessionServer] Socket error', err);
+            });
         });
 
-        wss.on('error', (err) => {
+        server.on('error', (err) => {
             console.error('[SessionServer] Server error', err);
             reject(err);
+        });
+
+        server.listen(pipePath, () => {
+            globalPipePath = pipePath;
+            globalSessionServer = server;
+            console.info(`[SessionServer] Listening on ${pipePath}`);
+            resolve(pipePath);
         });
     });
 }
@@ -325,14 +325,14 @@ function writeSettings() {
 }
 
 async function updatePlot() {
-    if (!server) {return;}
+    if (!globalPipePath) {return;}
     await globalPlotManager?.showStandardPlot();
 }
 
 export async function updateWorkspace() {
-    if (!server) {return;}
+    if (!globalPipePath) {return;}
     try {
-        const response = await sessionRequest(server, { method: 'workspace' });
+        const response = await sessionRequest({ method: 'workspace' });
         if (response) {
             workspaceData = response as WorkspaceData;
             if (activeSession) {
@@ -693,14 +693,14 @@ import * as rstudioapi from './rstudioapi';
 
 export async function activateSession(session: Session): Promise<void> {
     activeSession = session;
-    wsClient = session.ws as ExtWebSocket;
-    server = session.server;
+    pipeClient = session.socket;
+    globalPipePath = session.pipePath;
     pid = session.pid;
     rVer = session.rVer;
     info = session.info;
     sessionDir = session.sessionDir;
     workingDir = session.workingDir;
-    
+
     if (sessionStatusBarItem) {
         sessionStatusBarItem.text = `R ${rVer}: ${pid}`;
         sessionStatusBarItem.tooltip = `${info.version}\nProcess ID: ${pid}\nCommand: ${info.command}\nStart time: ${info.start_time}\nClick to attach to active terminal.`;
@@ -727,7 +727,13 @@ export async function switchSessionByTerminal(terminal: vscode.Terminal | undefi
     }
 }
 
-async function handleNotification(message: Record<string, unknown>, ws: ExtWebSocket) {
+function sendToSocket(socket: IpcSocket, data: Record<string, unknown>): void {
+    if (!socket.destroyed) {
+        socket.write(JSON.stringify(data) + '\n');
+    }
+}
+
+async function handleNotification(message: Record<string, unknown>, socket: IpcSocket) {
     const method = String(message.method);
     const params = (message.params as Record<string, unknown>) || {};
 
@@ -735,13 +741,12 @@ async function handleNotification(message: Record<string, unknown>, ws: ExtWebSo
         case 'attach': {
             if (!params.tempdir || !params.wd) {return;}
             const rPid = String(params.pid);
-            const terminalPid = ws._terminalPid ? String(ws._terminalPid) : rPid;
-            
+            const terminalPid = socket._terminalPid ? String(socket._terminalPid) : rPid;
+
             let session = sessions.get(terminalPid);
             if (!session) {
-                session = new Session({ host: '127.0.0.1', port: ws._port || 0, token: ws._token || '' }, ws);
+                session = new Session(socket._pipePath ?? globalPipePath ?? '', socket);
                 sessions.set(terminalPid, session);
-                // Also map R PID if it's different
                 if (rPid !== terminalPid) {
                     sessions.set(rPid, session);
                 }
@@ -752,7 +757,6 @@ async function handleNotification(message: Record<string, unknown>, ws: ExtWebSo
             session.sessionDir = String(params.tempdir);
             session.workingDir = String(params.wd);
 
-            // Switch active session
             await activateSession(session);
 
             console.info(`[startSessionWatcher] attach R PID: ${rPid}, terminal PID: ${terminalPid}`);
@@ -760,17 +764,11 @@ async function handleNotification(message: Record<string, unknown>, ws: ExtWebSo
             if (params.plot_url) {
                 await globalPlotManager?.showHttpgdPlot(String(params.plot_url));
             }
-            void updateWorkspace(); // Initial workspace fetch
+            void updateWorkspace();
             void watchProcess(rPid).then((v: string) => { void cleanupSession(v); });
             break;
         }
 
-        // case 'detach': {
-        //     if (params.pid) {
-        //         await cleanupSession(String(params.pid));
-        //     }
-        //     break;
-        // }
         case 'workspace_updated': {
             void updateWorkspace();
             break;
@@ -844,13 +842,13 @@ async function handleNotification(message: Record<string, unknown>, ws: ExtWebSo
     }
 }
 
-async function handleRequest(message: Record<string, unknown>, ws: ExtWebSocket) {
+async function handleRequest(message: Record<string, unknown>, socket: IpcSocket) {
     if (message.method) {
         const method = String(message.method);
         const params = (message.params as Record<string, unknown>) || {};
         let result: unknown = null;
         let error: unknown = null;
-        
+
         try {
             switch (method) {
                 case 'rstudioapi/active_editor_context':
@@ -910,22 +908,19 @@ async function handleRequest(message: Record<string, unknown>, ws: ExtWebSocket)
         } catch (e) {
             error = { code: -32603, message: String(e) };
         }
-        
-        if (ws.readyState === ws.OPEN) {
-            ws.send(JSON.stringify({
-                jsonrpc: '2.0',
-                id: message.id,
-                result: result,
-                error: error
-            }));
-        }
+
+        sendToSocket(socket, {
+            jsonrpc: '2.0',
+            id: message.id,
+            result: result,
+            error: error
+        });
     }
 }
 
 export async function cleanupSession(pidArg: string): Promise<void> {
     const session = sessions.get(pidArg);
     if (session) {
-        // Find all keys in sessions that point to this session and remove them
         const keysToRemove: string[] = [];
         for (const [k, v] of sessions.entries()) {
             if (v === session) {
@@ -933,12 +928,11 @@ export async function cleanupSession(pidArg: string): Promise<void> {
             }
         }
         keysToRemove.forEach(k => sessions.delete(k));
-        // Terminate the WebSocket
-        session.ws.terminate();
+        session.socket.destroy();
     }
     if (activeSession === session || pid === pidArg) {
         resetStatusBar();
-        server = undefined;
+        globalPipePath = undefined;
         activeSession = undefined;
         workspaceData.globalenv = {};
         workspaceData.loaded_namespaces = [];
@@ -972,12 +966,12 @@ async function watchProcess(pid: string): Promise<string> {
     return pid;
 }
 
-export async function sessionRequest(server: SessionServer, data: Record<string, unknown>): Promise<unknown> {
+export async function sessionRequest(data: Record<string, unknown>): Promise<unknown> {
     try {
-        if (!wsClient || wsClient.readyState !== WebSocket.OPEN) {
-            throw new Error('WebSocket is not connected');
+        if (!pipeClient || pipeClient.destroyed) {
+            throw new Error('IPC socket is not connected');
         }
-        
+
         return await new Promise((resolve, reject) => {
             const id = data.id !== undefined ? Number(data.id) : Math.floor(Math.random() * 1000000);
             const payload = data.jsonrpc ? data : {
@@ -985,17 +979,16 @@ export async function sessionRequest(server: SessionServer, data: Record<string,
                 id,
                 ...data
             };
-            
+
             pendingRequests.set(id, { resolve, reject });
-            
+
             try {
-                wsClient?.send(JSON.stringify(payload));
+                pipeClient?.write(JSON.stringify(payload) + '\n');
             } catch (e) {
                 pendingRequests.delete(id);
                 reject(e);
             }
-            
-            // Timeout after 5 seconds
+
             setTimeout(() => {
                 if (pendingRequests.has(id)) {
                     pendingRequests.delete(id);
@@ -1015,8 +1008,14 @@ export async function sessionRequest(server: SessionServer, data: Record<string,
 }
 
 export async function connectToSession(): Promise<void> {
-    const { port, token } = await getGlobalSessionServer();
-    const command = `sess::connect(port=${port}, token="${token}")`;
+    const pipePath = await getGlobalPipePath();
+    const command = `sess::connect(pipe_path="${pipePath.replace(/\\/g, '\\\\')}")`;
     void vscode.env.clipboard.writeText(command);
     void vscode.window.showInformationMessage(`R command copied to clipboard: ${command}`);
+}
+
+// Kept for backward compatibility - callers in rTerminal.ts use this
+export async function getGlobalSessionServer(): Promise<{ port: number, token: string }> {
+    await getGlobalPipePath();
+    return { port: 0, token: '' };
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -216,7 +216,7 @@ export async function getGlobalPipePath(): Promise<string> {
                                         pending.resolve(message.result);
                                     }
                                 }
-                            } else if (!message.id) {
+                            } else if (message.id === undefined || message.id === null) {
                                 await handleNotification(message, socket);
                             } else {
                                 await handleRequest(message, socket);

--- a/src/test/suite/session.test.ts
+++ b/src/test/suite/session.test.ts
@@ -100,7 +100,7 @@ suite('Session Communication', () => {
             expr: 'my_list',
             trigger: '$'
         };
-        const completionResult = await session.sessionRequest(session.activeSession.server, {
+        const completionResult = await session.sessionRequest({
             method: 'completion',
             params: completionRequestParams
         }) as Record<string, unknown>[];
@@ -162,7 +162,7 @@ suite('Session Communication', () => {
         let svgliteResp: { data?: string, format?: string, error?: unknown } | undefined;
         await waitFor(async () => {
             try {
-                svgliteResp = await session.sessionRequest(activeSession.server, {
+                svgliteResp = await session.sessionRequest({
                     method: 'plot_latest',
                     params: { width: 800, height: 600, format: 'svglite' }
                 }) as { data?: string, format?: string, error?: unknown };
@@ -193,7 +193,7 @@ suite('Session Communication', () => {
         let pngResp: { data?: string, format?: string } | undefined;
         await waitFor(async () => {
             try {
-                pngResp = await session.sessionRequest(activeSession.server, {
+                pngResp = await session.sessionRequest({
                     method: 'plot_latest',
                     params: { width: 800, height: 600, format: 'png' }
                 }) as { data?: string, format?: string };

--- a/src/test/suite/terminal.test.ts
+++ b/src/test/suite/terminal.test.ts
@@ -49,8 +49,7 @@ suite('R Terminal', () => {
 
         assert.strictEqual(options.name, 'R Interactive');
         assert.ok(options.env);
-        assert.ok(options.env['SESS_PORT']);
-        assert.ok(options.env['SESS_TOKEN']);
+        assert.ok(options.env['SESS_PIPE']);
         assert.strictEqual(options.env['SESS_RSTUDIOAPI'], 'TRUE');
         assert.strictEqual(options.env['SESS_USE_HTTPGD'], 'TRUE');
         assert.ok(options.env['R_PROFILE_USER']);
@@ -72,7 +71,7 @@ suite('R Terminal', () => {
 
         const options = await rTerminal.makeTerminalOptions();
 
-        assert.ok(options.env === undefined || options.env['SESS_PORT'] === undefined);
+        assert.ok(options.env === undefined || options.env['SESS_PIPE'] === undefined);
     });
 
     test('createRTerm and restartRTerminal integration test', async () => {

--- a/src/test/suite/terminal.test.ts
+++ b/src/test/suite/terminal.test.ts
@@ -130,8 +130,8 @@ suite('R Terminal', () => {
             sessionDir: '',
             workingDir: '',
             workspaceData: { search: [], loaded_namespaces: [], globalenv: {} },
-            server: { host: '127.0.0.1', port: 1234, token: 'abc' },
-            ws: {} as unknown as session.Session['ws']
+            pipePath: '',
+            socket: { destroyed: true, destroy: () => undefined } as unknown as session.Session['socket']
         };
 
         await session.activateSession(fakeSession as unknown as session.Session);


### PR DESCRIPTION
Replace the WebSocket-over-TCP IPC between vscode and R sessions with a Unix domain socket (Linux/Mac) or Windows named pipe transport.