### PR TITLE
Security: TLS Certificate Validation Disabled

### DIFF
--- a/src/helpViewer/cran.ts
+++ b/src/helpViewer/cran.ts
@@ -25,7 +25,6 @@ export async function getPackagesFromCran(cranUrl: string): Promise<Package[]> {
     for(const site of cranSites){
         try{
             // fetch html
-            process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // seems to fail otherwise?
             const res = await fetch(site.url);
             const html = await (res).text();
 
@@ -33,9 +32,6 @@ export async function getPackagesFromCran(cranUrl: string): Promise<Package[]> {
             packages = site.parseFunction(html, site.url);
         } catch(e) {
             // These errors are expected, if the repo does not serve a specific URL
-        } finally {
-            // make sure to use safe https again
-            process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
         }
 
         // break if successfully fetched & parsed


### PR DESCRIPTION
## Summary

Security: TLS Certificate Validation Disabled

## Problem

**Severity**: `Critical` | **File**: `src/helpViewer/cran.ts:L17`

In src/helpViewer/cran.ts line 17, the code sets `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'` to bypass TLS certificate verification. This creates a serious security vulnerability allowing man-in-the-middle attacks when fetching packages from CRAN mirrors.

## Solution

Remove the TLS bypass. If there are specific CRAN mirrors with certificate issues, use a custom CA certificate instead of disabling validation globally. The finally block attempts to reset it but this pattern is unsafe.

## Changes

- `src/helpViewer/cran.ts` (modified)