### PR TITLE
Remove the current chunk warning

### DIFF
--- a/src/rmarkdown/chunks.ts
+++ b/src/rmarkdown/chunks.ts
@@ -146,7 +146,6 @@ export function getChunks(document: vscode.TextDocument): RMarkdownChunk[] {
 export function getCurrentChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk | undefined {
     const textEditor = vscode.window.activeTextEditor;
     if (!textEditor) {
-        void vscode.window.showWarningMessage('No text editor active.');
         return;
     }
 


### PR DESCRIPTION
This will remove the annoying message `No text editor active` popping out even there is no Rmd at all.