### PR TITLE
Use owner-only permissions for IPC files

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -285,6 +285,7 @@ export async function writeSessionFile(pid: string, pipePath: string) {
     await fs.ensureDir(sessionsDir);
     const filePath = path.join(sessionsDir, `${pid}.json`);
     await fs.writeJson(filePath, { pipe: pipePath });
+    await setOwnerOnlyPermissions(filePath);
 }
 
 async function updateActiveTerminalFiles(pipePath: string) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -299,6 +299,14 @@ async function updateActiveTerminalFiles(pipePath: string) {
     }
 }
 
+async function setOwnerOnlyPermissions(filePath: string): Promise<void> {
+    if (process.platform === 'win32') {
+        return;
+    }
+
+    await fs.chmod(filePath, 0o600);
+}
+
 function makePipePath(): string {
     const suffix = crypto.randomBytes(8).toString('hex');
     if (process.platform === 'win32') {
@@ -381,10 +389,12 @@ export async function getGlobalPipePath(): Promise<string> {
         });
 
         server.listen(pipePath, () => {
-            globalPipePath = pipePath;
-            globalSessionServer = server;
-            console.info(`[SessionServer] Listening on ${pipePath}`);
-            resolve(pipePath);
+            void setOwnerOnlyPermissions(pipePath).then(() => {
+                globalPipePath = pipePath;
+                globalSessionServer = server;
+                console.info(`[SessionServer] Listening on ${pipePath}`);
+                resolve(pipePath);
+            }).catch(reject);
         });
     });
 }
@@ -429,7 +439,8 @@ export async function getAttachSessionCommand(): Promise<string> {
     const sessPath = extensionContext.asAbsolutePath('sess').replace(/\\/g, '/');
     const installSessScriptPath = extensionContext.asAbsolutePath(path.join('R', 'install_sess.R')).replace(/\\/g, '/');
     const scriptPath = getAttachSessionScriptPath(pipePath);
-    await fs.writeFile(scriptPath, buildAttachSessionScript(pipePath, sessPath, installSessScriptPath), { encoding: 'utf-8' });
+    await fs.writeFile(scriptPath, buildAttachSessionScript(pipePath, sessPath, installSessScriptPath), { encoding: 'utf-8', mode: 0o600 });
+    await setOwnerOnlyPermissions(scriptPath);
     attachSessionScriptPath = scriptPath;
 
     return `source(${asRStringLiteral(scriptPath)})`;

--- a/src/test/suite/session.test.ts
+++ b/src/test/suite/session.test.ts
@@ -238,6 +238,13 @@ suite('Session Communication', () => {
             assert.strictEqual(pipeStat.mode & 0o777, 0o600, 'socket file should be owner-only');
         }
 
+        const sessionFilePid = `perm-test-${process.pid}`;
+        await session.writeSessionFile(sessionFilePid, pipePath ?? '');
+        const sessionFilePath = path.join(process.env.HOME ?? '', '.vscode-R', 'sessions', `${sessionFilePid}.json`);
+        const sessionFileStat = await fs.stat(sessionFilePath);
+        assert.strictEqual(sessionFileStat.mode & 0o777, 0o600, 'session handoff file should be owner-only');
+        await fs.remove(sessionFilePath);
+
         await session.shutdownSessionWatcher();
     }).timeout(15000);
 });

--- a/src/test/suite/session.test.ts
+++ b/src/test/suite/session.test.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 import * as assert from 'assert';
 import * as path from 'path';
+import * as os from 'os';
 import * as fs from 'fs-extra';
 
 import { mockExtensionContext } from '../common/mockvscode';
@@ -228,9 +229,11 @@ suite('Session Communication', () => {
             throw new Error('attach command should be a source(...) call');
         }
 
-        const scriptPath = commandMatch[1].slice(1, -1);
+        const scriptPath = JSON.parse(commandMatch[1]) as string;
         const scriptStat = await fs.stat(scriptPath);
-        assert.strictEqual(scriptStat.mode & 0o777, 0o600, 'attach script should be owner-only');
+        if (process.platform !== 'win32') {
+            assert.strictEqual(scriptStat.mode & 0o777, 0o600, 'attach script should be owner-only');
+        }
 
         const pipePath = session.globalPipePath;
         assert.ok(pipePath, 'global pipe path should be set');
@@ -242,9 +245,11 @@ suite('Session Communication', () => {
 
         const sessionFilePid = `perm-test-${process.pid}`;
         await session.writeSessionFile(sessionFilePid, pipePath ?? '');
-        const sessionFilePath = path.join(process.env.HOME ?? '', '.vscode-R', 'sessions', `${sessionFilePid}.json`);
+        const sessionFilePath = path.join(os.homedir(), '.vscode-R', 'sessions', `${sessionFilePid}.json`);
         const sessionFileStat = await fs.stat(sessionFilePath);
-        assert.strictEqual(sessionFileStat.mode & 0o777, 0o600, 'session handoff file should be owner-only');
+        if (process.platform !== 'win32') {
+            assert.strictEqual(sessionFileStat.mode & 0o777, 0o600, 'session handoff file should be owner-only');
+        }
         await fs.remove(sessionFilePath);
 
         await session.shutdownSessionWatcher();

--- a/src/test/suite/session.test.ts
+++ b/src/test/suite/session.test.ts
@@ -224,9 +224,11 @@ suite('Session Communication', () => {
     test('attach session artifacts are owner-only', async () => {
         const command = await session.getAttachSessionCommand();
         const commandMatch = command.match(/^source\((.*)\)$/);
-        assert.ok(commandMatch, 'attach command should be a source(...) call');
+        if (!commandMatch) {
+            throw new Error('attach command should be a source(...) call');
+        }
 
-        const scriptPath = JSON.parse(commandMatch![1]);
+        const scriptPath = commandMatch[1].slice(1, -1);
         const scriptStat = await fs.stat(scriptPath);
         assert.strictEqual(scriptStat.mode & 0o777, 0o600, 'attach script should be owner-only');
 

--- a/src/test/suite/session.test.ts
+++ b/src/test/suite/session.test.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 import * as assert from 'assert';
 import * as path from 'path';
+import * as fs from 'fs-extra';
 
 import { mockExtensionContext } from '../common/mockvscode';
 import * as rTerminal from '../../rTerminal';
@@ -219,4 +220,24 @@ suite('Session Communication', () => {
         assert.ok(createWebviewPanelSpy.calledWith('webview'), 'webview should be triggered for html file');
 
     }).timeout(45000);
+
+    test('attach session artifacts are owner-only', async () => {
+        const command = await session.getAttachSessionCommand();
+        const commandMatch = command.match(/^source\((.*)\)$/);
+        assert.ok(commandMatch, 'attach command should be a source(...) call');
+
+        const scriptPath = JSON.parse(commandMatch![1]);
+        const scriptStat = await fs.stat(scriptPath);
+        assert.strictEqual(scriptStat.mode & 0o777, 0o600, 'attach script should be owner-only');
+
+        const pipePath = session.globalPipePath;
+        assert.ok(pipePath, 'global pipe path should be set');
+
+        if (pipePath && process.platform !== 'win32') {
+            const pipeStat = await fs.stat(pipePath);
+            assert.strictEqual(pipeStat.mode & 0o777, 0o600, 'socket file should be owner-only');
+        }
+
+        await session.shutdownSessionWatcher();
+    }).timeout(15000);
 });


### PR DESCRIPTION
The file artifacts created for IPC are located in the temporary folder. The files should be owner-only.