### PR TITLE
feat(data viewer): Allow reusing data viewer instead of opening a new…

### DIFF
--- a/sess/R/handlers.R
+++ b/sess/R/handlers.R
@@ -261,12 +261,25 @@ dataview_columns <- function(state) {
   }, list(state$headers, state$types, seq_along(state$headers), state$columns), NULL)
 }
 
-dataview_register <- function(data) {
+dataview_new_id <- function() {
+  repeat {
+    ts <- gsub("[^0-9]", "", format(Sys.time(), "%Y%m%d%H%M%OS6"), perl = TRUE)
+    view_id <- sprintf("dv_%s_%06d", ts, sample.int(999999L, 1L))
+    if (is.null(.sess_env$dataviews) || is.null(.sess_env$dataviews[[view_id]])) {
+      return(view_id)
+    }
+  }
+}
+
+dataview_register <- function(data, view_id = NULL) {
   if (is.null(.sess_env$dataviews)) {
     .sess_env$dataviews <- list()
   }
-  ts <- gsub("[^0-9]", "", format(Sys.time(), "%Y%m%d%H%M%OS6"), perl = TRUE)
-  view_id <- sprintf("dv_%s_%06d", ts, sample.int(999999L, 1L))
+
+  if (is.null(view_id)) {
+    view_id <- dataview_new_id()
+  }
+
   state <- dataview_to_state(data)
   .sess_env$dataviews[[view_id]] <- state
   list(

--- a/sess/R/hooks.R
+++ b/sess/R/hooks.R
@@ -5,6 +5,10 @@
 #' @export
 register_hooks <- function(use_rstudioapi = TRUE, use_httpgd = TRUE) {
   # 1. Override View() to serve table data via paged RPC.
+  if (is.null(.sess_env$dataview_registry)) {
+    .sess_env$dataview_registry <- new.env(parent = emptyenv())
+  }
+
   show_dataview <- function(x, title = deparse(substitute(x))) {
     # make sure title is computed.
     force(title)
@@ -14,7 +18,21 @@ register_hooks <- function(use_rstudioapi = TRUE, use_httpgd = TRUE) {
     }
 
     if (is.data.frame(x) || is.matrix(x)) {
-      registration <- dataview_register(x)
+      title_key <- paste(as.character(title), collapse = "\n")
+      dataview_registry <- .sess_env$dataview_registry
+      has_view_id <- nzchar(title_key) &&
+        exists(title_key, envir = dataview_registry, inherits = FALSE)
+      view_id <- if (has_view_id) {
+        get(title_key, envir = dataview_registry, inherits = FALSE)
+      } else {
+        id <- dataview_new_id()
+        if (nzchar(title_key)) {
+          assign(title_key, id, envir = dataview_registry)
+        }
+        id
+      }
+
+      registration <- dataview_register(x, view_id = view_id)
 
       notify_client("dataview", list(
         title = title,

--- a/sess/R/hooks.R
+++ b/sess/R/hooks.R
@@ -38,8 +38,7 @@ register_hooks <- function(use_rstudioapi = TRUE, use_httpgd = TRUE) {
         title = title,
         source = "table",
         type = "json",
-        view_id = registration$view_id,
-        total_rows = registration$total_rows
+        view_id = registration$view_id
       ))
     } else if (is.list(x)) {
       file_path <- tempfile(tmpdir = .sess_env$tempdir, fileext = ".json")

--- a/sess/R/server.R
+++ b/sess/R/server.R
@@ -11,6 +11,9 @@ connect <- function(pipe_path = NULL, use_rstudioapi = TRUE, use_httpgd = TRUE) 
   .sess_env$pending_responses <- list()
   .sess_env$read_buffer <- ""
   .sess_env$dataviews <- list()
+  if (is.null(.sess_env$dataview_registry)) {
+    .sess_env$dataview_registry <- new.env(parent = emptyenv())
+  }
 
   .sess_env$tempdir <- file.path(tempdir(), "sess")
   dir.create(.sess_env$tempdir, showWarnings = FALSE, recursive = TRUE)

--- a/src/session.ts
+++ b/src/session.ts
@@ -128,10 +128,6 @@ function escapeHtml(text: string): string {
     return text.replace(/[&<>"']/g, c => map[c]);
 }
 
-function formatDataViewPanelTitle(baseTitle: string, totalRows: number): string {
-    return `${baseTitle} (rows: ${totalRows.toLocaleString()})`;
-}
-
 function attachDynamicDataViewBridge(panel: vscode.WebviewPanel, viewId: string, baseTitle: string): void {
     const postResponse = (requestId: number, ok: boolean, result?: unknown, error?: string) => {
         void panel.webview.postMessage({
@@ -158,9 +154,7 @@ function attachDynamicDataViewBridge(panel: vscode.WebviewPanel, viewId: string,
                 if (!result || typeof result.totalRows !== 'number') {
                     throw new Error('Invalid dataview_init response: missing or invalid totalRows');
                 }
-                if (Number.isFinite(result.totalRows)) {
-                    panel.title = formatDataViewPanelTitle(baseTitle, result.totalRows);
-                }
+                panel.title = baseTitle;
                 postResponse(msg.requestId, true, result);
                 return;
             }
@@ -179,9 +173,7 @@ function attachDynamicDataViewBridge(panel: vscode.WebviewPanel, viewId: string,
                 if (!result || typeof result.totalRows !== 'number') {
                     throw new Error('Invalid dataview_page response: missing or invalid totalRows');
                 }
-                if (Number.isFinite(result.totalRows)) {
-                    panel.title = formatDataViewPanelTitle(baseTitle, result.totalRows);
-                }
+                panel.title = baseTitle;
                 postResponse(msg.requestId, true, result);
                 return;
             }
@@ -637,17 +629,14 @@ export function openExternalBrowser(): void {
     }
 }
 
-export async function showDataView(source: string, type: string, title: string, file: string, viewer: string, viewId?: string, totalRows?: number): Promise<void> {
+export async function showDataView(source: string, type: string, title: string, file: string, viewer: string, viewId?: string): Promise<void> {
     console.info(`[showDataView] source: ${source}, type: ${type}, title: ${title}, file: ${file}, viewer: ${viewer}, viewId: ${String(viewId ?? '')}`);
-    const panelTitle = totalRows !== undefined && Number.isFinite(totalRows)
-        ? formatDataViewPanelTitle(title, totalRows)
-        : title;
 
     if (source === 'table') {
         if (viewId) {
             const existing = dynamicDataViewPanels.get(viewId);
             if (existing) {
-                existing.title = panelTitle;
+                existing.title = title;
                 existing.reveal(ViewColumn[viewer as keyof typeof ViewColumn], true);
                 const content = await getTableHtml(existing.webview, undefined, title);
                 existing.webview.html = `${content}\n<!-- dataview-reload:${++dynamicDataViewReloadRevision} -->`;
@@ -655,7 +644,7 @@ export async function showDataView(source: string, type: string, title: string, 
             }
         }
 
-        const panel = window.createWebviewPanel('dataview', panelTitle,
+        const panel = window.createWebviewPanel('dataview', title,
             {
                 preserveFocus: true,
                 viewColumn: ViewColumn[viewer as keyof typeof ViewColumn],
@@ -1574,7 +1563,6 @@ async function handleNotification(message: Record<string, unknown>, socket: IpcS
                         String(params.file ?? ''),
                         viewer,
                         params.view_id ? String(params.view_id) : undefined,
-                        typeof params.total_rows === 'number' ? params.total_rows : undefined,
                     );
                 }
             }

--- a/src/session.ts
+++ b/src/session.ts
@@ -114,7 +114,8 @@ interface DataViewRequestMessage {
     filterModel?: Record<string, unknown>;
 }
 
-const dynamicDataViewPanels = new WeakSet<vscode.WebviewPanel>();
+const dynamicDataViewPanels = new Map<string, vscode.WebviewPanel>();
+let dynamicDataViewReloadRevision = 0;
 
 function escapeHtml(text: string): string {
     const map: Record<string, string> = {
@@ -132,8 +133,6 @@ function formatDataViewPanelTitle(baseTitle: string, totalRows: number): string 
 }
 
 function attachDynamicDataViewBridge(panel: vscode.WebviewPanel, viewId: string, baseTitle: string): void {
-    dynamicDataViewPanels.add(panel);
-
     const postResponse = (requestId: number, ok: boolean, result?: unknown, error?: string) => {
         void panel.webview.postMessage({
             message: 'dataview/response',
@@ -192,8 +191,9 @@ function attachDynamicDataViewBridge(panel: vscode.WebviewPanel, viewId: string,
                     method: 'dataview_dispose',
                     params: { view_id: viewId },
                 });
-                // Remove from panels set to prevent duplicate disposal on panel close
-                dynamicDataViewPanels.delete(panel);
+                if (dynamicDataViewPanels.get(viewId) === panel) {
+                    dynamicDataViewPanels.delete(viewId);
+                }
                 postResponse(msg.requestId, true, true);
                 return;
             }
@@ -205,10 +205,10 @@ function attachDynamicDataViewBridge(panel: vscode.WebviewPanel, viewId: string,
     });
 
     panel.onDidDispose(() => {
-        if (!dynamicDataViewPanels.has(panel)) {
+        if (dynamicDataViewPanels.get(viewId) !== panel) {
             return;
         }
-        dynamicDataViewPanels.delete(panel);
+        dynamicDataViewPanels.delete(viewId);
         void sessionRequest({
             method: 'dataview_dispose',
             params: { view_id: viewId },
@@ -637,11 +637,25 @@ export function openExternalBrowser(): void {
     }
 }
 
-export async function showDataView(source: string, type: string, title: string, file: string, viewer: string, viewId?: string): Promise<void> {
+export async function showDataView(source: string, type: string, title: string, file: string, viewer: string, viewId?: string, totalRows?: number): Promise<void> {
     console.info(`[showDataView] source: ${source}, type: ${type}, title: ${title}, file: ${file}, viewer: ${viewer}, viewId: ${String(viewId ?? '')}`);
+    const panelTitle = totalRows !== undefined && Number.isFinite(totalRows)
+        ? formatDataViewPanelTitle(title, totalRows)
+        : title;
 
     if (source === 'table') {
-        const panel = window.createWebviewPanel('dataview', title,
+        if (viewId) {
+            const existing = dynamicDataViewPanels.get(viewId);
+            if (existing) {
+                existing.title = panelTitle;
+                existing.reveal(ViewColumn[viewer as keyof typeof ViewColumn], true);
+                const content = await getTableHtml(existing.webview, undefined, title);
+                existing.webview.html = `${content}\n<!-- dataview-reload:${++dynamicDataViewReloadRevision} -->`;
+                return;
+            }
+        }
+
+        const panel = window.createWebviewPanel('dataview', panelTitle,
             {
                 preserveFocus: true,
                 viewColumn: ViewColumn[viewer as keyof typeof ViewColumn],
@@ -652,12 +666,13 @@ export async function showDataView(source: string, type: string, title: string, 
                 retainContextWhenHidden: true,
                 localResourceRoots: [Uri.file(resDir)],
             });
-        const content = await getTableHtml(panel.webview, file || undefined, title);
         panel.iconPath = new UriIcon('open-preview');
-        panel.webview.html = content;
         if (viewId) {
+            dynamicDataViewPanels.set(viewId, panel);
             attachDynamicDataViewBridge(panel, viewId, title);
         }
+        const content = await getTableHtml(panel.webview, file || undefined, title);
+        panel.webview.html = content;
     } else if (source === 'list') {
         const panel = window.createWebviewPanel('dataview', title,
             {
@@ -1559,6 +1574,7 @@ async function handleNotification(message: Record<string, unknown>, socket: IpcS
                         String(params.file ?? ''),
                         viewer,
                         params.view_id ? String(params.view_id) : undefined,
+                        typeof params.total_rows === 'number' ? params.total_rows : undefined,
                     );
                 }
             }


### PR DESCRIPTION
This PR makes the data viewer to reused the viewer panels by view_id so repeated View() calls for the same data name refresh the existing viewer instead of opening a new one.

The `sess` side now reuses the same generated view_id for the same title while replacing the stored data state. The vscode side tracks open viewers by view_id, reveals the existing panel, restores the (rows: n) title, and reloads the webview so updated data is fetched.
