### PR TITLE
Start R language server only when needed and stop after 30s.

### DIFF
--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -12,22 +12,30 @@ import { extensionContext } from './extension';
 import { CommonOptions } from 'child_process';
 
 export class LanguageService implements Disposable {
+    private static readonly globalClientKey = 'global';
+    private static readonly idleStopDelayMs = 30_000;
     private readonly clients: Map<string, LanguageClient> = new Map();
     private readonly initSet: Set<string> = new Set();
+    private readonly idleStopTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+    private readonly trackedDocuments: Map<string, Set<string>> = new Map();
+    private readonly disposables: Disposable[] = [];
     private readonly config: WorkspaceConfiguration;
     private readonly outputChannel: OutputChannel;
+    private disposed = false;
 
     constructor() {
         this.outputChannel = window.createOutputChannel('R Language Server');
         this.config = workspace.getConfiguration('r');
-        void this.startLanguageService();
+        this.startLanguageService();
     }
 
     dispose(): Thenable<void> {
+        this.disposed = true;
         return this.stopLanguageService();
     }
 
-    private spawnServer(client: LanguageClient, rPath: string, args: readonly string[], options: CommonOptions & { cwd: string }): DisposableProcess {
+    private spawnServer(client: LanguageClient, rPath: string, args: readonly string[], options: CommonOptions & { cwd: string },
+        onExit?: (client: LanguageClient) => void): DisposableProcess {
         const childProcess = spawn(rPath, args, options);
         const pid = childProcess.pid || -1;
         client.outputChannel.appendLine(`R Language Server (${pid}) started`);
@@ -49,15 +57,14 @@ export class LanguageService implements Disposable {
                     client.outputChannel.show();
                 }
             }
-            if (client.needsStop()) {
-                void client.stop();
-            }
+            onExit?.(client);
         });
         return childProcess;
     }
 
     private async createClient(selector: DocumentFilter[],
-        cwd: string, workspaceFolder: WorkspaceFolder | undefined, outputChannel: OutputChannel): Promise<LanguageClient> {
+        cwd: string, workspaceFolder: WorkspaceFolder | undefined, outputChannel: OutputChannel,
+        onExit?: (client: LanguageClient) => void): Promise<LanguageClient> {
 
         let client: LanguageClient;
 
@@ -117,7 +124,7 @@ export class LanguageService implements Disposable {
             server.listen(0, '127.0.0.1', () => {
                 const port = (server.address() as net.AddressInfo).port;
                 env.VSCR_LSP_PORT = String(port);
-                return this.spawnServer(client, rPath, args, options);
+                return this.spawnServer(client, rPath, args, options, onExit);
             });
         });
 
@@ -183,154 +190,430 @@ export class LanguageService implements Disposable {
     }
 
 
-    private checkClient(name: string): boolean {
-        if (this.initSet.has(name)) {
+    private isSupportedDocumentScheme(document: TextDocument): boolean {
+        return document.uri.scheme === 'file' ||
+            document.uri.scheme === 'untitled' ||
+            document.uri.scheme === 'vscode-notebook-cell';
+    }
+
+    private isRLanguageDocument(document: TextDocument): boolean {
+        return document.languageId === 'r' || document.languageId === 'rmd';
+    }
+
+    private isTrackedRDocument(document: TextDocument): boolean {
+        return this.isSupportedDocumentScheme(document) &&
+            this.isRLanguageDocument(document) &&
+            !this.isTemporaryRSource(document);
+    }
+
+    private isTemporaryRSource(document: TextDocument): boolean {
+        if (document.uri.scheme !== 'file') {
+            return false;
+        }
+
+        const fsPath = document.uri.fsPath.toLowerCase();
+        return fsPath.includes('rtmp') &&
+            fsPath.endsWith('.r') &&
+            !fsPath.includes('.vdoc.');
+    }
+
+    private hasOpenRLanguageDocuments(): boolean {
+        return workspace.textDocuments.some((document) => this.isTrackedRDocument(document));
+    }
+
+    private isQuartoDocument(document: TextDocument): boolean {
+        return document.uri.fsPath.toLowerCase().endsWith('.qmd') ||
+            this.isUntitledQuartoDocument(document);
+    }
+
+    private isUntitledQuartoDocument(document: TextDocument): boolean {
+        return document.uri.scheme === 'untitled' &&
+            (document.languageId === 'quarto' ||
+                document.languageId === 'r' ||
+                document.languageId === 'rmd');
+    }
+
+    private isQuartoChunkUri(uriString: string): boolean {
+        try {
+            const uri = Uri.parse(uriString);
+            return uri.scheme === 'file' &&
+                uri.fsPath.includes('.vdoc.') &&
+                uri.fsPath.toLowerCase().endsWith('.r');
+        } catch {
+            return false;
+        }
+    }
+
+    private getServerKey(document: TextDocument): string | undefined {
+        const folder = workspace.getWorkspaceFolder(document.uri);
+        if (folder) {
+            return folder.uri.toString(true);
+        }
+
+        if (document.uri.scheme === 'vscode-notebook-cell') {
+            return `vscode-notebook:${document.uri.fsPath}`;
+        }
+
+        if (document.uri.scheme === 'untitled') {
+            return 'untitled';
+        }
+
+        if (document.uri.scheme === 'file') {
+            return dirname(document.uri.fsPath);
+        }
+
+        return undefined;
+    }
+
+    private trackDocument(serverKey: string, document: TextDocument): void {
+        let documentSet = this.trackedDocuments.get(serverKey);
+        if (!documentSet) {
+            documentSet = new Set<string>();
+            this.trackedDocuments.set(serverKey, documentSet);
+        }
+        documentSet.add(document.uri.toString(true));
+    }
+
+    private untrackDocument(serverKey: string, document: TextDocument): boolean {
+        const documentSet = this.trackedDocuments.get(serverKey);
+        if (!documentSet) {
+            return false;
+        }
+
+        documentSet.delete(document.uri.toString(true));
+        if (documentSet.size === 0) {
+            this.trackedDocuments.delete(serverKey);
             return true;
         }
-        const client = this.clients.get(name);
-        if (client && client.needsStop()) {
-            return true;
-        }
-        this.initSet.add(name);
+
         return false;
     }
 
-    private getKey(uri: Uri): string {
-        switch (uri.scheme) {
-            case 'untitled':
-                return uri.scheme;
-            case 'vscode-notebook-cell':
-                return `vscode-notebook:${uri.fsPath}`;
-            default:
-                return uri.toString(true);
+    private getOpenTrackedDocuments(serverKey: string): TextDocument[] {
+        const documentSet = this.trackedDocuments.get(serverKey);
+        if (!documentSet) {
+            return [];
+        }
+
+        const openDocuments: TextDocument[] = [];
+        for (const uri of Array.from(documentSet)) {
+            const document = workspace.textDocuments.find((doc) => doc.uri.toString(true) === uri);
+            if (document && this.isTrackedRDocument(document) && this.getServerKey(document) === serverKey) {
+                openDocuments.push(document);
+            } else {
+                documentSet.delete(uri);
+            }
+        }
+
+        if (documentSet.size === 0) {
+            this.trackedDocuments.delete(serverKey);
+        }
+
+        return openDocuments;
+    }
+
+    private hasOpenTrackedDocuments(serverKey: string): boolean {
+        return this.getOpenTrackedDocuments(serverKey).length > 0;
+    }
+
+    private forgetStoppedClient(serverKey: string): void {
+        const client = this.clients.get(serverKey);
+        if (client && !client.needsStop()) {
+            this.clients.delete(serverKey);
+            this.initSet.delete(serverKey);
+            void client.dispose();
+        }
+    }
+
+    private cancelIdleStop(serverKey: string): void {
+        const timer = this.idleStopTimers.get(serverKey);
+        if (timer) {
+            clearTimeout(timer);
+            this.idleStopTimers.delete(serverKey);
+        }
+    }
+
+    private scheduleIdleStop(serverKey: string, shouldStop: () => boolean): void {
+        if (this.disposed || this.idleStopTimers.has(serverKey)) {
+            return;
+        }
+
+        const timer = setTimeout(() => {
+            this.idleStopTimers.delete(serverKey);
+            if (shouldStop()) {
+                void this.stopClient(serverKey);
+            }
+        }, LanguageService.idleStopDelayMs);
+        this.idleStopTimers.set(serverKey, timer);
+    }
+
+    private scheduleMultiIdleStop(serverKey: string): void {
+        this.scheduleIdleStop(serverKey, () => !this.hasOpenTrackedDocuments(serverKey));
+    }
+
+    private scheduleSingleIdleStop(): void {
+        this.scheduleIdleStop(
+            LanguageService.globalClientKey,
+            () => !this.hasOpenRLanguageDocuments()
+        );
+    }
+
+    private clearIdleStops(): void {
+        for (const timer of this.idleStopTimers.values()) {
+            clearTimeout(timer);
+        }
+        this.idleStopTimers.clear();
+    }
+
+    private stopStartedClient(client: LanguageClient): Thenable<void> {
+        if (!client.needsStop()) {
+            void client.dispose();
+            return Promise.resolve();
+        }
+
+        return client.stop().then(() => {
+            void client.dispose();
+        });
+    }
+
+    private stopClient(serverKey: string): Thenable<void> | undefined {
+        this.cancelIdleStop(serverKey);
+        const client = this.clients.get(serverKey);
+        this.trackedDocuments.delete(serverKey);
+
+        if (!client) {
+            return undefined;
+        }
+
+        this.clients.delete(serverKey);
+        this.initSet.delete(serverKey);
+        return this.stopStartedClient(client);
+    }
+
+    private handleClientExit(serverKey: string, client: LanguageClient): void {
+        if (this.clients.get(serverKey) !== client) {
+            return;
+        }
+
+        this.clients.delete(serverKey);
+        this.initSet.delete(serverKey);
+        this.cancelIdleStop(serverKey);
+    }
+
+    private getMultiServerOptions(document: TextDocument): {
+        documentSelector: DocumentFilter[];
+        cwd: string;
+        workspaceFolder: WorkspaceFolder | undefined;
+    } | undefined {
+        const folder = workspace.getWorkspaceFolder(document.uri);
+
+        if (document.uri.scheme === 'vscode-notebook-cell') {
+            return {
+                documentSelector: [
+                    { scheme: 'vscode-notebook-cell', language: 'r', pattern: `${document.uri.fsPath}` },
+                ],
+                cwd: dirname(document.uri.fsPath),
+                workspaceFolder: folder
+            };
+        }
+
+        if (folder) {
+            const pattern = `${folder.uri.fsPath}/**/*`;
+            return {
+                documentSelector: [
+                    { scheme: 'file', language: 'r', pattern: pattern },
+                    { scheme: 'file', language: 'rmd', pattern: pattern },
+                ],
+                cwd: folder.uri.fsPath,
+                workspaceFolder: folder
+            };
+        }
+
+        if (document.uri.scheme === 'untitled') {
+            return {
+                documentSelector: [
+                    { scheme: 'untitled', language: 'r' },
+                    { scheme: 'untitled', language: 'rmd' },
+                ],
+                cwd: os.homedir(),
+                workspaceFolder: undefined
+            };
+        }
+
+        if (document.uri.scheme === 'file') {
+            const dir = dirname(document.uri.fsPath);
+            return {
+                documentSelector: [
+                    { scheme: 'file', pattern: `${dir}/**/*.{R,r,Rmd,rmd}` },
+                ],
+                cwd: dir,
+                workspaceFolder: undefined
+            };
+        }
+
+        return undefined;
+    }
+
+    private async startMultiClient(document: TextDocument): Promise<void> {
+        if (this.disposed || !this.isTrackedRDocument(document)) {
+            return;
+        }
+
+        const serverKey = this.getServerKey(document);
+        if (!serverKey) {
+            return;
+        }
+
+        this.trackDocument(serverKey, document);
+        this.cancelIdleStop(serverKey);
+
+        this.forgetStoppedClient(serverKey);
+
+        const client = this.clients.get(serverKey);
+        if ((client && client.needsStop()) || this.initSet.has(serverKey)) {
+            return;
+        }
+
+        const options = this.getMultiServerOptions(document);
+        if (!options) {
+            return;
+        }
+
+        this.initSet.add(serverKey);
+        try {
+            console.log(`Start language server for ${document.uri.toString(true)}`);
+            const client = await this.createClient(
+                options.documentSelector,
+                options.cwd,
+                options.workspaceFolder,
+                this.outputChannel,
+                (client) => this.handleClientExit(serverKey, client)
+            );
+
+            if (this.disposed) {
+                await this.stopStartedClient(client);
+                return;
+            }
+
+            this.clients.set(serverKey, client);
+            if (!this.trackedDocuments.has(serverKey)) {
+                this.scheduleMultiIdleStop(serverKey);
+            }
+        } finally {
+            this.initSet.delete(serverKey);
+        }
+    }
+
+    private closeMultiClient(document: TextDocument): void {
+        if (this.isRLanguageDocument(document)) {
+            const serverKey = this.getServerKey(document);
+            if (serverKey) {
+                this.untrackDocument(serverKey, document);
+                if (!this.hasOpenTrackedDocuments(serverKey)) {
+                    this.scheduleMultiIdleStop(serverKey);
+                }
+            }
+            return;
+        }
+
+        if (this.isQuartoDocument(document)) {
+            for (const [serverKey, documentSet] of this.trackedDocuments.entries()) {
+                if (documentSet.size > 0 && Array.from(documentSet).every((uri) => this.isQuartoChunkUri(uri))) {
+                    this.trackedDocuments.delete(serverKey);
+                    this.scheduleMultiIdleStop(serverKey);
+                }
+            }
         }
     }
 
     private startMultiLanguageService(): void {
-        const didOpenTextDocument = async (document: TextDocument) => {
-            if (document.uri.scheme !== 'file' && document.uri.scheme !== 'untitled' && document.uri.scheme !== 'vscode-notebook-cell') {
-                return;
-            }
-
-            if (document.languageId !== 'r' && document.languageId !== 'rmd') {
-                return;
-            }
-
-            const folder = workspace.getWorkspaceFolder(document.uri);
-
-            // Each notebook uses a server started from parent folder
-            if (document.uri.scheme === 'vscode-notebook-cell') {
-                const key = this.getKey(document.uri);
-                if (!this.checkClient(key)) {
-                    console.log(`Start language server for ${document.uri.toString(true)}`);
-                    const documentSelector: DocumentFilter[] = [
-                        { scheme: 'vscode-notebook-cell', language: 'r', pattern: `${document.uri.fsPath}` },
-                    ];
-                    const client = await this.createClient(documentSelector,
-                        dirname(document.uri.fsPath), folder, this.outputChannel);
-                    this.clients.set(key, client);
-                    this.initSet.delete(key);
-                }
-                return;
-            }
-
-            if (folder) {
-
-                // Each workspace uses a server started from the workspace folder
-                const key = this.getKey(folder.uri);
-                if (!this.checkClient(key)) {
-                    console.log(`Start language server for ${document.uri.toString(true)}`);
-                    const pattern = `${folder.uri.fsPath}/**/*`;
-                    const documentSelector: DocumentFilter[] = [
-                        { scheme: 'file', language: 'r', pattern: pattern },
-                        { scheme: 'file', language: 'rmd', pattern: pattern },
-                    ];
-                    const client = await this.createClient(documentSelector, folder.uri.fsPath, folder, this.outputChannel);
-                    this.clients.set(key, client);
-                    this.initSet.delete(key);
-                }
-
-            } else {
-
-                // All untitled documents share a server started from home folder
-                if (document.uri.scheme === 'untitled') {
-                    const key = this.getKey(document.uri);
-                    if (!this.checkClient(key)) {
-                        console.log(`Start language server for ${document.uri.toString(true)}`);
-                        const documentSelector: DocumentFilter[] = [
-                            { scheme: 'untitled', language: 'r' },
-                            { scheme: 'untitled', language: 'rmd' },
-                        ];
-                        const client = await this.createClient(documentSelector, os.homedir(), undefined, this.outputChannel);
-                        this.clients.set(key, client);
-                        this.initSet.delete(key);
-                    }
-                    return;
-                }
-
-                // Each file outside workspace uses a server started from parent folder
-                if (document.uri.scheme === 'file') {
-                    const key = this.getKey(document.uri);
-                    if (!this.checkClient(key)) {
-                        console.log(`Start language server for ${document.uri.toString(true)}`);
-                        const documentSelector: DocumentFilter[] = [
-                            { scheme: 'file', pattern: document.uri.fsPath },
-                        ];
-                        const client = await this.createClient(documentSelector,
-                            dirname(document.uri.fsPath), undefined, this.outputChannel);
-                        this.clients.set(key, client);
-                        this.initSet.delete(key);
-                    }
-                    return;
-                }
-            }
-        };
-
-        const didCloseTextDocument = (document: TextDocument): void => {
-            if (document.uri.scheme === 'untitled') {
-                const result = workspace.textDocuments.find((doc) => doc.uri.scheme === 'untitled');
-                if (result) {
-                    // Stop the language server when all untitled documents are closed.
-                    return;
-                }
-            }
-
-            if (document.uri.scheme === 'vscode-notebook-cell') {
-                const result = workspace.textDocuments.find((doc) =>
-                    doc.uri.scheme === document.uri.scheme && doc.uri.fsPath === document.uri.fsPath);
-                if (result) {
-                    // Stop the language server when all cell documents are closed (notebook closed).
-                    return;
-                }
-            }
-
-            // Stop the language server when single file outside workspace is closed, or the above cases.
-            const key = this.getKey(document.uri);
-            const client = this.clients.get(key);
-            if (client) {
-                this.clients.delete(key);
-                this.initSet.delete(key);
-                void client.stop();
-            }
-        };
-
-        workspace.onDidOpenTextDocument(didOpenTextDocument);
-        workspace.onDidCloseTextDocument(didCloseTextDocument);
-        workspace.textDocuments.forEach((doc) => void didOpenTextDocument(doc));
-        workspace.onDidChangeWorkspaceFolders((event) => {
+        const openDisposable = workspace.onDidOpenTextDocument((document) => {
+            void this.startMultiClient(document);
+        });
+        const closeDisposable = workspace.onDidCloseTextDocument((document) => {
+            this.closeMultiClient(document);
+        });
+        const workspaceDisposable = workspace.onDidChangeWorkspaceFolders((event) => {
             for (const folder of event.removed) {
-                const key = this.getKey(folder.uri);
-                const client = this.clients.get(key);
-                if (client) {
-                    this.clients.delete(key);
-                    this.initSet.delete(key);
-                    void client.stop();
-                }
+                void this.stopClient(folder.uri.toString(true));
             }
+        });
+
+        this.disposables.push(openDisposable, closeDisposable, workspaceDisposable);
+        workspace.textDocuments.forEach((document) => {
+            void this.startMultiClient(document);
         });
     }
 
-    private async startLanguageService(): Promise<void> {
+    private singleServerDocumentSelector(): DocumentFilter[] {
+        return [
+            { language: 'r' },
+            { language: 'rmd' },
+        ];
+    }
+
+    private async startSingleClient(): Promise<void> {
+        const serverKey = LanguageService.globalClientKey;
+        this.forgetStoppedClient(serverKey);
+        if (this.disposed || !this.hasOpenRLanguageDocuments() || this.clients.has(serverKey) || this.initSet.has(serverKey)) {
+            if (!this.disposed && this.hasOpenRLanguageDocuments()) {
+                this.cancelIdleStop(serverKey);
+            }
+            return;
+        }
+
+        this.cancelIdleStop(serverKey);
+        this.initSet.add(serverKey);
+        try {
+            const workspaceFolder = workspace.workspaceFolders?.[0];
+            const cwd = workspaceFolder ? workspaceFolder.uri.fsPath : os.homedir();
+            const client = await this.createClient(
+                this.singleServerDocumentSelector(),
+                cwd,
+                undefined,
+                this.outputChannel,
+                (client) => this.handleClientExit(serverKey, client)
+            );
+
+            if (this.disposed) {
+                await this.stopStartedClient(client);
+                return;
+            }
+
+            this.clients.set(serverKey, client);
+
+            if (!this.hasOpenRLanguageDocuments()) {
+                this.scheduleSingleIdleStop();
+            }
+        } finally {
+            this.initSet.delete(serverKey);
+        }
+    }
+
+    private stopSingleClientIfIdle(): void {
+        if (!this.hasOpenRLanguageDocuments()) {
+            this.scheduleSingleIdleStop();
+        }
+    }
+
+    private startSingleLanguageService(): void {
+        const openDisposable = workspace.onDidOpenTextDocument((document) => {
+            if (this.isRLanguageDocument(document)) {
+                void this.startSingleClient();
+            }
+        });
+        const closeDisposable = workspace.onDidCloseTextDocument(() => {
+            this.stopSingleClientIfIdle();
+        });
+
+        this.disposables.push(openDisposable, closeDisposable);
+
+        if (this.hasOpenRLanguageDocuments()) {
+            void this.startSingleClient();
+        }
+    }
+
+    private startLanguageService(): void {
         let useMultiServer = false;
         const multiServerConfig = this.config.get<boolean>('lsp.multiServer');
 
@@ -341,26 +624,24 @@ export class LanguageService implements Disposable {
         if (useMultiServer) {
             this.startMultiLanguageService();
         } else {
-            const documentSelector: DocumentFilter[] = [
-                { scheme: 'file', language: 'r' },
-                { scheme: 'file', language: 'rmd' },
-                { scheme: 'untitled', language: 'r' },
-                { scheme: 'untitled', language: 'rmd' },
-                { scheme: 'vscode-notebook-cell', language: 'r' },
-            ];
-
-            const workspaceFolder = workspace.workspaceFolders?.[0];
-            const cwd = workspaceFolder ? workspaceFolder.uri.fsPath : os.homedir();
-            const client = await this.createClient(documentSelector, cwd, undefined, this.outputChannel);
-            this.clients.set('global', client);
+            this.startSingleLanguageService();
         }
     }
 
     private stopLanguageService(): Thenable<void> {
         const promises: Thenable<void>[] = [];
-        for (const client of this.clients.values()) {
-            promises.push(client.stop());
+        this.clearIdleStops();
+        for (const disposable of this.disposables.splice(0)) {
+            disposable.dispose();
         }
+        for (const serverKey of Array.from(this.clients.keys())) {
+            const promise = this.stopClient(serverKey);
+            if (promise) {
+                promises.push(promise);
+            }
+        }
+        this.initSet.clear();
+        this.trackedDocuments.clear();
         return Promise.all(promises).then(() => undefined);
     }
 }

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -652,8 +652,11 @@ export class LanguageService implements Disposable {
 
     private singleServerDocumentSelector(): DocumentFilter[] {
         return [
-            { language: 'r' },
-            { language: 'rmd' },
+            { scheme: 'file', language: 'r' },
+            { scheme: 'file', language: 'rmd' },
+            { scheme: 'untitled', language: 'r' },
+            { scheme: 'untitled', language: 'rmd' },
+            { scheme: 'vscode-notebook-cell', language: 'r' },
         ];
     }
 

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -5,7 +5,7 @@ import { dirname } from 'path';
 import * as net from 'net';
 import { URL } from 'url';
 import * as fs from 'fs';
-import { LanguageClient, LanguageClientOptions, StreamInfo, DocumentFilter, ErrorAction, CloseAction, RevealOutputChannelOn } from 'vscode-languageclient/node';
+import { LanguageClient, LanguageClientOptions, StreamInfo, DocumentFilter, ErrorAction, CloseAction, RevealOutputChannelOn, Middleware } from 'vscode-languageclient/node';
 import { Disposable, workspace, Uri, TextDocument, WorkspaceConfiguration, OutputChannel, window, WorkspaceFolder } from 'vscode';
 import { DisposableProcess, getRLibPaths, getRpath, promptToInstallRPackage, spawn, substituteVariables } from './util';
 import { extensionContext } from './extension';
@@ -16,8 +16,11 @@ export class LanguageService implements Disposable {
     private static readonly idleStopDelayMs = 30_000;
     private readonly clients: Map<string, LanguageClient> = new Map();
     private readonly initSet: Set<string> = new Set();
+    private readonly stoppingClients: Map<string, Promise<void>> = new Map();
+    private readonly restartAfterStop: Map<string, () => void> = new Map();
     private readonly idleStopTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
     private readonly trackedDocuments: Map<string, Set<string>> = new Map();
+    private readonly quartoVirtualDocumentServerKeys: Map<string, string> = new Map();
     private readonly disposables: Disposable[] = [];
     private readonly config: WorkspaceConfiguration;
     private readonly outputChannel: OutputChannel;
@@ -64,6 +67,7 @@ export class LanguageService implements Disposable {
 
     private async createClient(selector: DocumentFilter[],
         cwd: string, workspaceFolder: WorkspaceFolder | undefined, outputChannel: OutputChannel,
+        serverKey: string,
         onExit?: (client: LanguageClient) => void): Promise<LanguageClient> {
 
         let client: LanguageClient;
@@ -129,6 +133,36 @@ export class LanguageService implements Disposable {
         });
 
         // Options to control the language client
+        const middleware: Middleware = {
+            handleDiagnostics: (uri, diagnostics, next) => {
+                const supportedSchemes = ['file', 'untitled', 'vscode-notebook-cell'];
+
+                // Drop diagnostics for unsupported schemes (like git://)
+                if (!supportedSchemes.includes(uri.scheme)) {
+                    return next(uri, []);
+                }
+
+                // Drop diagnostics for files that no longer exist on disk
+                if (uri.scheme === 'file' && !fs.existsSync(uri.fsPath)) {
+                    return next(uri, []);
+                }
+
+                return next(uri, diagnostics);
+            },
+            sendRequest: async (type, param, token, next) => {
+                if (!this.shouldRouteToClient(serverKey, param)) {
+                    return undefined as never;
+                }
+                return next(type, param, token);
+            },
+            sendNotification: async (type, next, params) => {
+                if (!this.shouldRouteToClient(serverKey, params)) {
+                    return;
+                }
+                return next(type, params);
+            }
+        };
+
         const clientOptions: LanguageClientOptions = {
             // Register the server for selected R documents
             documentSelector: selector,
@@ -145,23 +179,7 @@ export class LanguageService implements Disposable {
                 configurationSection: 'r.lsp',
                 fileEvents: workspace.createFileSystemWatcher('**/*.{R,r}'),
             },
-            middleware: {
-                handleDiagnostics: (uri, diagnostics, next) => {
-                    const supportedSchemes = ['file', 'untitled', 'vscode-notebook-cell'];
-                    
-                    // Drop diagnostics for unsupported schemes (like git://)
-                    if (!supportedSchemes.includes(uri.scheme)) {
-                        return next(uri, []); 
-                    }
-                    
-                    // Drop diagnostics for files that no longer exist on disk
-                    if (uri.scheme === 'file' && !fs.existsSync(uri.fsPath)) {
-                        return next(uri, []);
-                    }
-                    
-                    return next(uri, diagnostics);
-                }
-            },
+            middleware,
             revealOutputChannelOn: RevealOutputChannelOn.Never,
             errorHandler: {
                 error: () =>    {
@@ -206,6 +224,19 @@ export class LanguageService implements Disposable {
             !this.isTemporaryRSource(document);
     }
 
+    private isQuartoDocument(document: TextDocument): boolean {
+        return document.languageId === 'quarto' ||
+            document.uri.fsPath.toLowerCase().endsWith('.qmd');
+    }
+
+    private isQuartoVirtualDocument(document: TextDocument): boolean {
+        const fsPath = document.uri.fsPath.toLowerCase();
+        return document.uri.scheme === 'file' &&
+            document.languageId === 'r' &&
+            fsPath.includes('.vdoc.') &&
+            fsPath.endsWith('.r');
+    }
+
     private isTemporaryRSource(document: TextDocument): boolean {
         if (document.uri.scheme !== 'file') {
             return false;
@@ -218,30 +249,9 @@ export class LanguageService implements Disposable {
     }
 
     private hasOpenRLanguageDocuments(): boolean {
-        return workspace.textDocuments.some((document) => this.isTrackedRDocument(document));
-    }
-
-    private isQuartoDocument(document: TextDocument): boolean {
-        return document.uri.fsPath.toLowerCase().endsWith('.qmd') ||
-            this.isUntitledQuartoDocument(document);
-    }
-
-    private isUntitledQuartoDocument(document: TextDocument): boolean {
-        return document.uri.scheme === 'untitled' &&
-            (document.languageId === 'quarto' ||
-                document.languageId === 'r' ||
-                document.languageId === 'rmd');
-    }
-
-    private isQuartoChunkUri(uriString: string): boolean {
-        try {
-            const uri = Uri.parse(uriString);
-            return uri.scheme === 'file' &&
-                uri.fsPath.includes('.vdoc.') &&
-                uri.fsPath.toLowerCase().endsWith('.r');
-        } catch {
-            return false;
-        }
+        return workspace.textDocuments.some((document) =>
+            this.isTrackedRDocument(document) && !this.isQuartoVirtualDocument(document)
+        ) || this.hasOpenTrackedDocuments(LanguageService.globalClientKey);
     }
 
     private getServerKey(document: TextDocument): string | undefined {
@@ -274,6 +284,43 @@ export class LanguageService implements Disposable {
         documentSet.add(document.uri.toString(true));
     }
 
+    private shouldRouteToClient(serverKey: string, params: unknown): boolean {
+        if (!params || typeof params !== 'object') {
+            return true;
+        }
+
+        const textDocument = (params as { textDocument?: { uri?: unknown } }).textDocument;
+        if (typeof textDocument?.uri !== 'string') {
+            return true;
+        }
+
+        const documentKey = Uri.parse(textDocument.uri).toString();
+        const mappedServerKey = this.quartoVirtualDocumentServerKeys.get(documentKey);
+        return !mappedServerKey || mappedServerKey === serverKey;
+    }
+
+    private getParentQuartoDocument(document: TextDocument): TextDocument | undefined {
+        const sourceFolder = workspace.getWorkspaceFolder(document.uri);
+        const isInSourceWorkspace = (candidate: TextDocument): boolean =>
+            this.isQuartoDocument(candidate) &&
+            (!sourceFolder || workspace.getWorkspaceFolder(candidate.uri)?.uri.toString(true) === sourceFolder.uri.toString(true));
+
+        const activeDocument = window.activeTextEditor?.document;
+        if (activeDocument && isInSourceWorkspace(activeDocument)) {
+            return activeDocument;
+        }
+
+        const visibleDocuments = window.visibleTextEditors
+            .map((editor) => editor.document)
+            .filter(isInSourceWorkspace);
+        if (visibleDocuments.length === 1) {
+            return visibleDocuments[0];
+        }
+
+        const openDocuments = workspace.textDocuments.filter(isInSourceWorkspace);
+        return openDocuments.length === 1 ? openDocuments[0] : undefined;
+    }
+
     private untrackDocument(serverKey: string, document: TextDocument): boolean {
         const documentSet = this.trackedDocuments.get(serverKey);
         if (!documentSet) {
@@ -298,7 +345,11 @@ export class LanguageService implements Disposable {
         const openDocuments: TextDocument[] = [];
         for (const uri of Array.from(documentSet)) {
             const document = workspace.textDocuments.find((doc) => doc.uri.toString(true) === uri);
-            if (document && this.isTrackedRDocument(document) && this.getServerKey(document) === serverKey) {
+            const isTrackedDocument = document &&
+                (this.isTrackedRDocument(document) || this.isQuartoDocument(document));
+            const belongsToServer = document &&
+                (serverKey === LanguageService.globalClientKey || this.getServerKey(document) === serverKey);
+            if (document && isTrackedDocument && belongsToServer) {
                 openDocuments.push(document);
             } else {
                 documentSet.delete(uri);
@@ -376,8 +427,22 @@ export class LanguageService implements Disposable {
         });
     }
 
-    private stopClient(serverKey: string): Thenable<void> | undefined {
+    private queueRestartAfterStop(serverKey: string, restart: () => void): boolean {
+        if (!this.stoppingClients.has(serverKey)) {
+            return false;
+        }
+
+        this.restartAfterStop.set(serverKey, restart);
+        return true;
+    }
+
+    private stopClient(serverKey: string): Promise<void> | undefined {
         this.cancelIdleStop(serverKey);
+        const existingStop = this.stoppingClients.get(serverKey);
+        if (existingStop) {
+            return existingStop;
+        }
+
         const client = this.clients.get(serverKey);
         this.trackedDocuments.delete(serverKey);
 
@@ -387,7 +452,20 @@ export class LanguageService implements Disposable {
 
         this.clients.delete(serverKey);
         this.initSet.delete(serverKey);
-        return this.stopStartedClient(client);
+        const stopPromise = Promise.resolve(this.stopStartedClient(client)).finally(() => {
+            if (this.stoppingClients.get(serverKey) !== stopPromise) {
+                return;
+            }
+
+            this.stoppingClients.delete(serverKey);
+            const restart = this.restartAfterStop.get(serverKey);
+            this.restartAfterStop.delete(serverKey);
+            if (!this.disposed) {
+                restart?.();
+            }
+        });
+        this.stoppingClients.set(serverKey, stopPromise);
+        return stopPromise;
     }
 
     private handleClientExit(serverKey: string, client: LanguageClient): void {
@@ -459,13 +537,28 @@ export class LanguageService implements Disposable {
             return;
         }
 
-        const serverKey = this.getServerKey(document);
+        const quartoParent = this.isQuartoVirtualDocument(document) ?
+            this.getParentQuartoDocument(document) :
+            undefined;
+        const serverDocument = quartoParent ?? document;
+        const serverKey = this.getServerKey(serverDocument);
         if (!serverKey) {
             return;
         }
 
-        this.trackDocument(serverKey, document);
+        if (this.isQuartoVirtualDocument(document)) {
+            this.quartoVirtualDocumentServerKeys.set(document.uri.toString(), serverKey);
+        }
+        this.trackDocument(serverKey, quartoParent ?? document);
         this.cancelIdleStop(serverKey);
+
+        if (this.queueRestartAfterStop(serverKey, () => {
+            if (this.hasOpenTrackedDocuments(serverKey)) {
+                void this.startMultiClient(document);
+            }
+        })) {
+            return;
+        }
 
         this.forgetStoppedClient(serverKey);
 
@@ -474,10 +567,15 @@ export class LanguageService implements Disposable {
             return;
         }
 
-        const options = this.getMultiServerOptions(document);
+        const options = this.getMultiServerOptions(serverDocument);
         if (!options) {
             return;
         }
+        options.documentSelector.push({
+            scheme: 'file',
+            language: 'r',
+            pattern: '**/.vdoc.*.r'
+        });
 
         this.initSet.add(serverKey);
         try {
@@ -487,6 +585,7 @@ export class LanguageService implements Disposable {
                 options.cwd,
                 options.workspaceFolder,
                 this.outputChannel,
+                serverKey,
                 (client) => this.handleClientExit(serverKey, client)
             );
 
@@ -496,7 +595,7 @@ export class LanguageService implements Disposable {
             }
 
             this.clients.set(serverKey, client);
-            if (!this.trackedDocuments.has(serverKey)) {
+            if (!this.hasOpenTrackedDocuments(serverKey)) {
                 this.scheduleMultiIdleStop(serverKey);
             }
         } finally {
@@ -505,7 +604,7 @@ export class LanguageService implements Disposable {
     }
 
     private closeMultiClient(document: TextDocument): void {
-        if (this.isRLanguageDocument(document)) {
+        if (this.isQuartoDocument(document)) {
             const serverKey = this.getServerKey(document);
             if (serverKey) {
                 this.untrackDocument(serverKey, document);
@@ -516,12 +615,15 @@ export class LanguageService implements Disposable {
             return;
         }
 
-        if (this.isQuartoDocument(document)) {
-            for (const [serverKey, documentSet] of this.trackedDocuments.entries()) {
-                if (documentSet.size > 0 && Array.from(documentSet).every((uri) => this.isQuartoChunkUri(uri))) {
-                    this.trackedDocuments.delete(serverKey);
-                    this.scheduleMultiIdleStop(serverKey);
-                }
+        if (!this.isRLanguageDocument(document)) {
+            return;
+        }
+
+        const serverKey = this.getServerKey(document);
+        if (serverKey) {
+            this.untrackDocument(serverKey, document);
+            if (!this.hasOpenTrackedDocuments(serverKey)) {
+                this.scheduleMultiIdleStop(serverKey);
             }
         }
     }
@@ -532,6 +634,9 @@ export class LanguageService implements Disposable {
         });
         const closeDisposable = workspace.onDidCloseTextDocument((document) => {
             this.closeMultiClient(document);
+            if (this.isQuartoVirtualDocument(document)) {
+                setTimeout(() => this.quartoVirtualDocumentServerKeys.delete(document.uri.toString()), 0);
+            }
         });
         const workspaceDisposable = workspace.onDidChangeWorkspaceFolders((event) => {
             for (const folder of event.removed) {
@@ -552,17 +657,34 @@ export class LanguageService implements Disposable {
         ];
     }
 
-    private async startSingleClient(): Promise<void> {
+    private async startSingleClient(document?: TextDocument): Promise<void> {
         const serverKey = LanguageService.globalClientKey;
-        this.forgetStoppedClient(serverKey);
-        if (this.disposed || !this.hasOpenRLanguageDocuments() || this.clients.has(serverKey) || this.initSet.has(serverKey)) {
-            if (!this.disposed && this.hasOpenRLanguageDocuments()) {
-                this.cancelIdleStop(serverKey);
+        const isQuartoVirtualDocument = document && this.isQuartoVirtualDocument(document);
+        if (isQuartoVirtualDocument) {
+            const parent = this.getParentQuartoDocument(document);
+            if (parent) {
+                this.trackDocument(serverKey, parent);
             }
+        }
+
+        if (this.disposed || (!isQuartoVirtualDocument && !this.hasOpenRLanguageDocuments())) {
             return;
         }
 
         this.cancelIdleStop(serverKey);
+        if (this.queueRestartAfterStop(serverKey, () => {
+            if (this.hasOpenRLanguageDocuments()) {
+                void this.startSingleClient();
+            }
+        })) {
+            return;
+        }
+
+        this.forgetStoppedClient(serverKey);
+        if (this.clients.has(serverKey) || this.initSet.has(serverKey)) {
+            return;
+        }
+
         this.initSet.add(serverKey);
         try {
             const workspaceFolder = workspace.workspaceFolders?.[0];
@@ -572,6 +694,7 @@ export class LanguageService implements Disposable {
                 cwd,
                 undefined,
                 this.outputChannel,
+                serverKey,
                 (client) => this.handleClientExit(serverKey, client)
             );
 
@@ -599,17 +722,29 @@ export class LanguageService implements Disposable {
     private startSingleLanguageService(): void {
         const openDisposable = workspace.onDidOpenTextDocument((document) => {
             if (this.isRLanguageDocument(document)) {
-                void this.startSingleClient();
+                void this.startSingleClient(document);
             }
         });
-        const closeDisposable = workspace.onDidCloseTextDocument(() => {
+        const closeDisposable = workspace.onDidCloseTextDocument((document) => {
+            if (this.isQuartoDocument(document)) {
+                this.untrackDocument(LanguageService.globalClientKey, document);
+            }
             this.stopSingleClientIfIdle();
         });
 
         this.disposables.push(openDisposable, closeDisposable);
 
-        if (this.hasOpenRLanguageDocuments()) {
-            void this.startSingleClient();
+        for (const document of workspace.textDocuments) {
+            if (this.isQuartoVirtualDocument(document)) {
+                const parent = this.getParentQuartoDocument(document);
+                if (parent) {
+                    this.trackDocument(LanguageService.globalClientKey, parent);
+                }
+            }
+        }
+        const openRDocument = workspace.textDocuments.find((document) => this.isTrackedRDocument(document));
+        if (openRDocument) {
+            void this.startSingleClient(openRDocument);
         }
     }
 
@@ -629,19 +764,18 @@ export class LanguageService implements Disposable {
     }
 
     private stopLanguageService(): Thenable<void> {
-        const promises: Thenable<void>[] = [];
         this.clearIdleStops();
+        this.restartAfterStop.clear();
         for (const disposable of this.disposables.splice(0)) {
             disposable.dispose();
         }
         for (const serverKey of Array.from(this.clients.keys())) {
-            const promise = this.stopClient(serverKey);
-            if (promise) {
-                promises.push(promise);
-            }
+            void this.stopClient(serverKey);
         }
         this.initSet.clear();
         this.trackedDocuments.clear();
+        this.quartoVirtualDocumentServerKeys.clear();
+        const promises = Array.from(new Set(this.stoppingClients.values()));
         return Promise.all(promises).then(() => undefined);
     }
 }

--- a/src/languageService.ts
+++ b/src/languageService.ts
@@ -202,9 +202,17 @@ export class LanguageService implements Disposable {
             client = new LanguageClient('r', 'R Language Server', tcpServerOptions, clientOptions);
         }
 
-        extensionContext.subscriptions.push(client);
-        await client.start();
-        return client;
+        try {
+            await client.start();
+            return client;
+        } catch (error) {
+            try {
+                await client.dispose();
+            } catch {
+                // A failed start may leave no active connection to stop.
+            }
+            throw error;
+        }
     }
 
 


### PR DESCRIPTION
## Summary

This PR updates the R language server lifecycle so that the server starts only when an R-related document is opened, and shuts down after all R-related documents are closed.

This avoids keeping the language server running unnecessarily while still preserving the existing session if another R-related file is opened shortly after the last one is closed.

## Main Changes

* The language server no longer starts eagerly. It now starts only when an R-related file is opened.
* When the last R-related file is closed, a 30-second shutdown timer is started.
* If another R-related file is opened before the timer finishes, the shutdown is cancelled and the existing language server session is kept alive.
* Before shutting down, the timer performs a final check of the currently open editors. If any R-related file is still open, shutdown is aborted.
* This lifecycle behaviour works for both single-server mode and multi-workspace-server mode.
