### PR TITLE
Follow-up #1713: restore active terminal's workspace data when switching R terminals

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -1481,6 +1481,7 @@ export async function activateSession(session: Session): Promise<void> {
     info = session.info;
     sessionDir = session.sessionDir;
     workingDir = session.workingDir;
+    workspaceData = session.workspaceData;
 
     if (sessionStatusBarItem) {
         sessionStatusBarItem.text = `R ${rVer}: ${pid}`;
@@ -1489,6 +1490,7 @@ export async function activateSession(session: Session): Promise<void> {
     }
     await setContext('rSessionActive', true);
     rWorkspace?.refresh();
+    scheduleWorkspaceRefresh();
 }
 
 export function resetStatusBar(): void {


### PR DESCRIPTION
This fixes a regression caused by #1713 where the workspace viewer does not switch automatically when focusing a different R terminal if multiple ones are launched.

#1713 delayed workspace inspection to prevent submission lag. After that change, switching between R terminals no longer refreshes the workspace viewer automatically due to the stricter refresh condition being limited to the current active terminal.

The fix would now display active terminal’s workspace data immediately, and schedule a fresh using introduced delayed refresh mechanism.